### PR TITLE
Resolves a bug with cluster where a subscribe is sent to a disconnected node

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -162,10 +162,11 @@ Cluster.prototype.createNode = function (port, host) {
 
     var _this = this;
     this.nodes[key].once('end', function () {
-      if (_this.subscriber === _this.nodes[key]) {
+      var deadNode = _this.nodes[key];
+      delete _this.nodes[key];
+      if (_this.subscriber === deadNode) {
         _this.selectSubscriber();
       }
-      delete _this.nodes[key];
       if (Object.keys(_this.nodes).length === 0) {
         _this.setStatus('close');
       }
@@ -179,6 +180,10 @@ Cluster.prototype.selectRandomNode = function () {
 };
 
 Cluster.prototype.selectSubscriber = function () {
+  if (Object.keys(this.nodes).length === 0) {
+    this.subscriber = null;
+    return;
+  }
   this.subscriber = this.selectRandomNode();
   if (this.subscriber.status === 'wait') {
     this.subscriber.connect().catch(function () {});
@@ -405,7 +410,6 @@ Cluster.prototype.getInfoFromNode = function (redis, callback) {
     }
     Object.keys(oldNodes).forEach(function (key) {
       _this.nodes[key].disconnect();
-      delete _this.nodes[key];
     });
     callback();
   }, 1000));


### PR DESCRIPTION
The issue came up when connecting to a load balancer, sitting in front of the redis cluster nodes, and attempting to subscribe as soon as the 'ready' event was fired.  The load balancer's IP:port is not in redis cluster's list of nodes so the connection was disconnected and removed, causing the subscribe to be sent to the disconnected node.