### PR TITLE
Adds ReadOnly mode for Standalone/Cluster mode

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -164,6 +164,12 @@ Cluster.prototype.createNode = function (port, host) {
     }));
 
     var _this = this;
+    if (this.options.readOnly) {
+      this.nodes[key].once('ready', function () {
+        debug('sending readonly to %s', key);
+        _this.nodes[key].readonly();
+      });
+    }
     this.nodes[key].once('end', function () {
       var deadNode = _this.nodes[key];
       delete _this.nodes[key];
@@ -425,12 +431,14 @@ Cluster.prototype.getInfoFromNode = function (redis, callback) {
       _this.masterNodes[masterNodeKey] = masterNode;
       allNodes.push(masterNode);
       delete oldNodes[masterNodeKey];
-      items.forEach(function(item) {
-        var host = item[0];
-        var port = item[1];
-        allNodes.push(_this.createNode(port, host));
-        delete oldNodes[host + ':' + port];
-      });
+      if (_this.options.readOnly) {
+        items.forEach(function(item) {
+          var host = item[0];
+          var port = item[1];
+          allNodes.push(_this.createNode(port, host));
+          delete oldNodes[host + ':' + port];
+        });
+      }
       for (var slot = slotRangeStart; slot <= slotRangeEnd; ++slot) {
         _this.slots[slot] = { masterNode : masterNode, allNodes: allNodes };
       };

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -18,6 +18,7 @@ var Command = require('./command');
  * @param {Object} options
  * @param {boolean} [options.enableOfflineQueue=true] - See Redis class
  * @param {boolean} [options.lazyConnect=false] - See Redis class
+ * @param {boolean} [options.readOnly=false] - Connect in READONLY mode
  * @param {number} [options.maxRedirections=16] - When a MOVED or ASK error is received, client will redirect the
  * command to another node. This option limits the max redirections allowed to send a command.
  * @param {function} [options.clusterRetryStrategy] - See "Quick Start" section
@@ -36,6 +37,7 @@ function Cluster (startupNodes, options) {
   this.startupNodes = startupNodes;
 
   this.nodes = {};
+  this.masterNodes = {};
   this.slots = [];
   this.connections = {};
   this.retryAttempts = 0;
@@ -57,6 +59,7 @@ Cluster.defaultOptions = _.assign({}, Redis.defaultOptions, {
   maxRedirections: 16,
   retryDelayOnFailover: 2000,
   retryDelayOnClusterDown: 1000,
+  readOnly: false,
   clusterRetryStrategy: function (times) {
     return Math.min(100 + times * 2, 2000);
   }
@@ -172,11 +175,20 @@ Cluster.prototype.createNode = function (port, host) {
       }
     });
   }
+
   return this.nodes[key];
+};
+
+Cluster.prototype.selectRandomMasterNode = function () {
+  return this.nodes[_.sample(Object.keys(this.masterNodes))];
 };
 
 Cluster.prototype.selectRandomNode = function () {
   return this.nodes[_.sample(Object.keys(this.nodes))];
+};
+
+Cluster.prototype.selectRandomNodeForSlot = function (targetSlot) {
+  return _.sample(this.slots[targetSlot].allNodes);
 };
 
 Cluster.prototype.selectSubscriber = function () {
@@ -284,7 +296,7 @@ Cluster.prototype.sendCommand = function (command, stream, node) {
       _this.handleError(err, ttl, {
         moved: function (node, slot, hostPort) {
           debug('command %s is moved to %s:%s', command.name, hostPort[0], hostPort[1]);
-          _this.slots[slot] = node;
+          _this.slots[slot].masterNode = node;
           tryConnection();
           _this.refreshSlotsCache();
         },
@@ -319,14 +331,18 @@ Cluster.prototype.sendCommand = function (command, stream, node) {
         redis = _this.subscriber;
       } else {
         if (typeof targetSlot === 'number') {
-          redis = _this.slots[targetSlot];
+          if (_this.options.readOnly) {
+            redis = _this.selectRandomNodeForSlot(targetSlot);
+          } else {
+            redis = _this.slots[targetSlot].masterNode;
+          }
         }
         if (asking && !random) {
           redis = asking;
           redis.asking();
         }
         if (random || !redis) {
-          redis = _this.selectRandomNode();
+          redis = _this.selectRandomMasterNode();
         }
       }
       if (node && !node.redis) {
@@ -394,20 +410,32 @@ Cluster.prototype.getInfoFromNode = function (redis, callback) {
     }
     var i;
     var oldNodes = {};
+    var allNodes = [];
     var keys = Object.keys(_this.nodes);
     for (i = 0; i < keys.length; ++i) {
       oldNodes[keys[i]] = true;
     }
     for (i = 0; i < result.length; ++i) {
-      var item = result[i];
-      var host = item[2][0];
-      var port = item[2][1];
-      var node = _this.createNode(port, host);
-      delete oldNodes[host + ':' + port];
-      for (var slot = item[0]; slot <= item[1]; ++slot) {
-        _this.slots[slot] = node;
-      }
+      var items = result[i];
+      var slotRangeStart = items.shift();
+      var slotRangeEnd = items.shift();
+      var master = items.shift();
+      var masterNodeKey = master[0] + ':' + master[1];
+      var masterNode = _this.createNode(master[1], master[0]);
+      _this.masterNodes[masterNodeKey] = masterNode;
+      allNodes.push(masterNode);
+      delete oldNodes[masterNodeKey];
+      items.forEach(function(item) {
+        var host = item[0];
+        var port = item[1];
+        allNodes.push(_this.createNode(port, host));
+        delete oldNodes[host + ':' + port];
+      });
+      for (var slot = slotRangeStart; slot <= slotRangeEnd; ++slot) {
+        _this.slots[slot] = { masterNode : masterNode, allNodes: allNodes };
+      };
     }
+
     Object.keys(oldNodes).forEach(function (key) {
       _this.nodes[key].disconnect();
     });

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -32,7 +32,6 @@ try {
  * @param {number} [options.port=6379] - Port of the Redis server.
  * @param {string} [options.host=localhost] - Host of the Redis server.
  * @param {string} [options.family=4] - Version of IP stack. Defaults to 4.
- * @param {boolean} [options.readOnly=false] - Connect in READONLY mode
  * @param {string} [options.path=null] - Local domain socket path. If set the `port`, `host`
  * and `family` will be ignored.
  * @param {string} [options.password=null] - If set, client will send AUTH command
@@ -164,8 +163,7 @@ Redis.defaultOptions = {
   enableReadyCheck: true,
   autoResubscribe: true,
   autoResendUnfulfilledCommands: true,
-  lazyConnect: false,
-  readOnly: false
+  lazyConnect: false
 };
 
 Redis.prototype.parseOptions = function () {
@@ -259,15 +257,6 @@ Redis.prototype.connect = function (callback) {
         _this.removeListener('connect', connectionConnectHandler);
         reject(err);
       };
-      var readOnlyHandler = function() {
-        debug('Sending readonly command');
-          _this.readonly();
-      };
-
-      if (_this.options.readOnly) {
-        _this.once('ready', readOnlyHandler);  
-      }
-      
       _this.once('connect', connectionConnectHandler);
       _this.once('close', connectionCloseHandler);
     });

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -32,6 +32,7 @@ try {
  * @param {number} [options.port=6379] - Port of the Redis server.
  * @param {string} [options.host=localhost] - Host of the Redis server.
  * @param {string} [options.family=4] - Version of IP stack. Defaults to 4.
+ * @param {boolean} [options.readOnly=false] - Connect in READONLY mode
  * @param {string} [options.path=null] - Local domain socket path. If set the `port`, `host`
  * and `family` will be ignored.
  * @param {string} [options.password=null] - If set, client will send AUTH command
@@ -163,7 +164,8 @@ Redis.defaultOptions = {
   enableReadyCheck: true,
   autoResubscribe: true,
   autoResendUnfulfilledCommands: true,
-  lazyConnect: false
+  lazyConnect: false,
+  readOnly: false
 };
 
 Redis.prototype.parseOptions = function () {
@@ -257,6 +259,15 @@ Redis.prototype.connect = function (callback) {
         _this.removeListener('connect', connectionConnectHandler);
         reject(err);
       };
+      var readOnlyHandler = function() {
+        debug('Sending readonly command');
+          _this.readonly();
+      };
+
+      if (_this.options.readOnly) {
+        _this.once('ready', readOnlyHandler);  
+      }
+      
       _this.once('connect', connectionConnectHandler);
       _this.once('close', connectionCloseHandler);
     });


### PR DESCRIPTION
 - Cluster slots are now served with both Master and Slave instances.

The purpose is to use the client in a `readonly` mode to scale reads.

Each client individual issues a `readonly` once `ready`.
Each node in the cluster is connected to, maintaining a pool of Master nodes and SlaveNodes.

