### PR TITLE
Add print function

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,9 @@ exports.Promise = require('bluebird');
 exports.Cluster = require('./lib/cluster');
 
 exports.print = function (err, reply) {
-    if (err) {
-        console.log("Error: " + err);
-    } else {
-        console.log("Reply: " + reply);
-    }
+  if (err) {
+    console.log("Error: " + err);
+  } else {
+    console.log("Reply: " + reply);
+  }
 };

--- a/index.js
+++ b/index.js
@@ -3,3 +3,11 @@ exports = module.exports = require('./lib/redis');
 exports.ReplyError = require('./lib/reply_error');
 exports.Promise = require('bluebird');
 exports.Cluster = require('./lib/cluster');
+
+exports.print = function (err, reply) {
+    if (err) {
+        console.log("Error: " + err);
+    } else {
+        console.log("Reply: " + reply);
+    }
+};


### PR DESCRIPTION
Add a print function for convenience. The lack of ioredis.print can cause an error if it is used to replace node_redis.