### PR TITLE
Pass stream via sync callback

### DIFF
--- a/lib/connectors/connector.js
+++ b/lib/connectors/connector.js
@@ -26,9 +26,7 @@ Connector.prototype.connect = function (callback) {
   }
 
   var stream = this.stream = net.createConnection(connectionOptions);
-  process.nextTick(function () {
-    callback(null, stream);
-  });
+  callback(null, stream);
 };
 
 module.exports = Connector;


### PR DESCRIPTION
That way we avoid errors firing between error listener is defined. Fixes process crash during network device up/down. Fixes #80