### PR TITLE
pmessage now properly returns pattern, channel, message

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -211,9 +211,14 @@ Cluster.prototype.selectSubscriber = function () {
     this.subscriber.connect().catch(noop);
   }
   var _this = this;
-  ['message', 'messageBuffer', 'pmessage', 'pmessageBuffer'].forEach(function (event) {
+  ['message', 'messageBuffer'].forEach(function (event) {
     _this.subscriber.on(event, function (arg1, arg2) {
       _this.emit(event, arg1, arg2);
+    });
+  });
+  ['pmessage', 'pmessageBuffer'].forEach(function (event) {
+    _this.subscriber.on(event, function (arg1, arg2, arg3) {
+      _this.emit(event, arg1, arg2, arg3);
     });
   });
 };


### PR DESCRIPTION
In Redis Cluster mode, arg3 (message) was not getting passed to pmessage/pmessageBuffer.