### PR TITLE
Auto resend unfulfilled commands for cluster

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -295,6 +295,10 @@ Cluster.prototype.flushQueue = function (error) {
   }
 };
 
+Redis.prototype.resetCommandQueue = function () {
+  this.commandQueue = new Deque();
+};
+
 Cluster.prototype.executeOfflineCommands = function () {
   if (this.offlineQueue.length) {
     debug('send %d commands in offline queue', this.offlineQueue.length);

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -81,8 +81,10 @@ Cluster.prototype.connect = function () {
       this.retryAttempts = 0;
       this.manuallyClosing = false;
       this.setStatus('connect');
+      this.resetCommandQueue();
       this.setStatus('ready');
       this.executeOfflineCommands();
+      this.resendUnfulfilledCommands();
       resolve();
     };
 
@@ -108,6 +110,9 @@ Cluster.prototype.connect = function () {
         }.bind(this), retryDelay);
       } else {
         this.setStatus('end');
+        if (this.commandQueue.length) {
+          this.prevCommandQueue = this.commandQueue;
+        }
         this.flushQueue(new Error('None of startup nodes is available'));
       }
     });
@@ -283,6 +288,11 @@ Cluster.prototype.flushQueue = function (error) {
     item = this.offlineQueue.shift();
     item.command.reject(error);
   }
+  var cqItem;
+  while (this.commandQueue.length > 0) {
+    cqItem = this.commandQueue.shift();
+    cqItem.command.reject(error);
+  }
 };
 
 Cluster.prototype.executeOfflineCommands = function () {
@@ -293,6 +303,16 @@ Cluster.prototype.executeOfflineCommands = function () {
     while (offlineQueue.length > 0) {
       var item = offlineQueue.shift();
       this.sendCommand(item.command, item.stream, item.node);
+    }
+  }
+};
+
+Cluster.prototype.resendUnfulfilledCommands = function () {
+  if (this.prevCommandQueue.length) {
+    debug('resend %d unfulfilled commands', this.prevCommandQueue.length);
+    while (this.prevCommandQueue.length) {
+      var cqItem = self.prevCommandQueue.shift();
+      this.sendCommand(cqItem.command, cqItem.stream, cqItem.node);
     }
   }
 };
@@ -365,6 +385,9 @@ Cluster.prototype.sendCommand = function (command, stream, node) {
         node.redis = redis;
       }
       redis.sendCommand(command, stream);
+      if (_this.options.autoResendUnfulfilledCommands) {
+        _this.commandQueue.push({command: command, stream: stream, node: node});
+      }
     } else if (_this.options.enableOfflineQueue) {
       _this.offlineQueue.push({
         command: command,


### PR DESCRIPTION
I noticed that the autoResendUnfulfilledCommands functions were not implemented in Cluster mode.  I did it - please check my work, I was unable to exhaustively verify that it works.