### PR TITLE
Fixes status debug message in case of Unix socket path

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -207,7 +207,7 @@ Redis.prototype.parseOptions = function () {
  * @private
  */
 Redis.prototype.setStatus = function (status, arg) {
-  debug('status[%s:%s]: %s -> %s', this.options.host, this.options.port, this.status || '[empty]', status);
+  debug('status[%s]: %s -> %s', (this.options.path ? this.options.path : (this.options.host + ':' + this.options.port)), this.status || '[empty]', status);
   this.status = status;
   process.nextTick(this.emit.bind(this, status, arg));
 };


### PR DESCRIPTION
When server uses Unix socket, the debug message of the status changes
still indicated [host:port] even though the connector was using the
socket's path correctly.