### PR TITLE
Handle watch-exec rollback correctly

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -70,6 +70,9 @@ exports.convertBufferToString = function (value, encoding) {
  * @private
  */
 exports.wrapMultiResult = function (arr) {
+  // When using WATCH/EXEC transactions, the EXEC will return
+  // a null instead of an array
+  if (!arr) return null;
   var result = [];
   var length = arr.length;
   for (var i = 0; i < length; ++i) {

--- a/test/functional/watch-exec.js
+++ b/test/functional/watch-exec.js
@@ -1,0 +1,34 @@
+'use strict';
+
+describe('watch-exec', function () {
+
+  it('should support watch/exec transactions', function (done) {
+    var redis1 = new Redis();
+    redis1.watch('watchkey')
+      .then(function() {
+        return redis1.multi().set('watchkey', '1').exec();
+      })
+      .then(function(result) {
+        expect(result.length).to.eql(1);
+        expect(result[0]).to.eql([null, 'OK']);
+      })
+      .nodeify(done);
+  });
+
+  it('should support watch/exec transaction rollback', function (done) {
+    var redis1 = new Redis();
+    var redis2 = new Redis();
+    redis1.watch('watchkey')
+      .then(function() {
+        return redis2.set('watchkey', '2');
+      })
+      .then(function() {
+        return redis1.multi().set('watchkey', '1').exec();
+      })
+      .then(function(result) {
+        expect(result).to.be.null;
+      })
+      .nodeify(done);
+  });
+
+});


### PR DESCRIPTION
When using [WATCH/EXEC](http://redis.io/topics/transactions) transactions in Redis, if the transaction rolls back (due to one of the watched keys being modified), the EXEC command does not return a result (instead of returning an array).

Currently this leads to `utils/wrapMultiResult` failing with a `TypeError: Cannot read property 'length' of null`. 

This PR adds tests for WATCH/EXEC (normal and rollback) and fixes the problem by making `wrapMultiResult` a little more defensive.