### PR TITLE
Add clarification about commands arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ redis.get('foo').then(function (result) {
   console.log(result);
 });
 
-// Arguments to commands are flattened, so the following are the same:
+// Arguments to commands are flattened, so the following are the same.
+// When the number of arguments is big the latter is slightly faster.
 redis.sadd('set', 1, 3, 5, 7);
 redis.sadd('set', [1, 3, 5, 7]);
 ```


### PR DESCRIPTION
This tweaks a comment to make clear that when the number of arguments is big, using an array results in better performances.

Correct me if I'm wrong.