### PR TITLE
Previous Subscription State Error

### DIFF
--- a/lib/redis/event_handler.js
+++ b/lib/redis/event_handler.js
@@ -123,6 +123,23 @@ exports.readyHandler = function (self) {
     var finalSelect = self.prevCondition ? self.prevCondition.select : self.condition.select;
     self.condition.select = 0;
 
+    if (self.prevCondition) {
+      var condition = self.prevCondition;
+      self.prevCondition = null;
+      if (condition.subscriber && self.options.autoResubscribe) {
+        var subscribeChannels = condition.subscriber.channels('subscribe');
+        if (subscribeChannels.length) {
+          debug('subscribe %d channels', subscribeChannels.length);
+          self.subscribe(subscribeChannels);
+        }
+        var psubscribeChannels = condition.subscriber.channels('psubscribe');
+        if (psubscribeChannels.length) {
+          debug('psubscribe %d channels', psubscribeChannels.length);
+          self.psubscribe(psubscribeChannels);
+        }
+      }
+    }
+
     if (self.prevCommandQueue) {
       if (self.options.autoResendUnfulfilledCommands) {
         debug('resend %d unfulfilled commands', self.prevCommandQueue.length);
@@ -154,23 +171,6 @@ exports.readyHandler = function (self) {
     if (self.condition.select !== finalSelect) {
       debug('connect to db [%d]', finalSelect);
       self.selectBuffer(finalSelect);
-    }
-
-    if (self.prevCondition) {
-      var condition = self.prevCondition;
-      self.prevCondition = null;
-      if (condition.subscriber && self.options.autoResubscribe) {
-        var subscribeChannels = condition.subscriber.channels('subscribe');
-        if (subscribeChannels.length) {
-          debug('subscribe %d channels', subscribeChannels.length);
-          self.subscribe(subscribeChannels);
-        }
-        var psubscribeChannels = condition.subscriber.channels('psubscribe');
-        if (psubscribeChannels.length) {
-          debug('psubscribe %d channels', psubscribeChannels.length);
-          self.psubscribe(psubscribeChannels);
-        }
-      }
     }
   };
 };

--- a/test/functional/connection.js
+++ b/test/functional/connection.js
@@ -167,5 +167,20 @@ describe('connection', function () {
         pub.lpush('l', 1);
       });
     });
+    it('should resend previous subscribes before sending unfulfilled commands', function (done) {
+      var redis = new Redis({ db: 4 });
+      var pub = new Redis({ db: 4 });
+      redis.once('ready', function () {
+        redis.subscribe('l', function() {
+          redis.disconnect(true);
+          redis.unsubscribe('l', function() {
+            pub.pubsub('channels', function(err, channels){
+              expect(channels.length).to.eql(0);
+              done();
+            });
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This fixes an issue where we restored the previous state AFTER we ran the offline and previous command queue, which could cause us to miss unsubscribe requests. Unit test added for this scenario.