### PR TITLE
Fix for allNodes array containing nodes not serving the specified slot.

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -458,13 +458,13 @@ Cluster.prototype.getInfoFromNode = function (redis, callback) {
     }
     var i;
     var oldNodes = {};
-    var allNodes = [];
     var keys = Object.keys(_this.nodes);
     for (i = 0; i < keys.length; ++i) {
       oldNodes[keys[i]] = true;
     }
     _this.masterNodes = {};
     for (i = 0; i < result.length; ++i) {
+      var allNodes = [];
       var items = result[i];
       var slotRangeStart = items.shift();
       var slotRangeEnd = items.shift();


### PR DESCRIPTION
The allNodes array was accumulating the nodes for all previously processed entries in the `cluster slots` result. This meant read-only clients sometimes repeatedly targeting an incorrect node, especially in larger clusters.