### PR TITLE
Use given `connectTimeout` for sentinel connections

### DIFF
--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -117,7 +117,7 @@ SentinelConnector.prototype.resolve = function (endpoint, callback) {
     host: endpoint.host,
     retryStrategy: null,
     enableReadyCheck: false,
-    connectTimeout: 2000
+    connectTimeout: this.options.connectTimeout
   });
 
   if (this.options.role === 'slave') {


### PR DESCRIPTION
This change allows sentinel connections to use the user-specified connection timeout instead of the hard-coded value of 2000 milliseconds. In cases where a `connectTimeout` is not specified, the default value in `Redis.defaultOptions` will be used (currently 3000 millis).