### PR TITLE
Update options host & port with resolved Redis server

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -213,7 +213,9 @@ Redis.prototype.parseOptions = function () {
  * @private
  */
 Redis.prototype.setStatus = function (status, arg) {
-  debug('status[%s]: %s -> %s', (this.options.path ? this.options.path : (this.options.host + ':' + this.options.port)), this.status || '[empty]', status);
+  var remoteHost = this.stream && this.stream.remoteAddress || this.options.host;
+  var remotePort = this.stream && this.stream.remotePort || this.options.port;
+  debug('status[%s:%s]: %s -> %s', remoteHost, remotePort, this.status || '[empty]', status);
   this.status = status;
   process.nextTick(this.emit.bind(this, status, arg));
 };


### PR DESCRIPTION
When `ioredis` connects to a sentinel, retrieves the host and port of the master server, it stills outputs `localhost:6379` in the debug output, which is usually incorrect/misleading.

Even with debug output disabled, it would be nice to be able to print the address of the connected redis server when the `#ready` event fires, e.g.:
```javascript
redis.on('ready', function () {
  console.log('Connected to Redis @ %s:%s', redis.options.host, redis.options.port);
});
```

Now, maybe `options` is not the best place to store this, but since this is what's used for the debug/status messages (e.g. `ioredis:redis status[192.168.33.10:26379]: connecting -> connect +1ms`), I felt this was the simplest place to put it.