### PR TITLE
extends cluster with .mastersExec, which executes a given command on every already discovered master

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -496,6 +496,38 @@ Cluster.prototype.getInfoFromNode = function (redis, callback) {
   }, 1000));
 };
 
+Cluster.prototype.mastersExec = function () {
+  var masterNodes = _.values(this.masterNodes);
+
+  var argumentsLength = arguments.length;
+  var hasCallback = typeof arguments[argumentsLength - 1] === 'function';
+
+  var argsLength = hasCallback ? argumentsLength - 1 : argumentsLength;
+  var args = new Array(argsLength - 1);
+  for (var i = 1; i < argsLength; i++) {
+    args[i - 1] = arguments[i];
+  }
+
+  var command = arguments[0];
+  var promise = Promise.map(masterNodes, function sendCommandToRedis(redis) {
+    return redis[command].apply(redis, args);
+  });
+
+  if (hasCallback) {
+    return promise.nodeify(arguments[argsLength]);
+  }
+
+  return promise;
+}
+
+Cluster.prototype.flushCluster = function (callback) {
+  return this.mastersExec('flushall', callback);
+};
+
+Cluster.prototype.flushClusterDb = function (callback) {
+  return this.mastersExec('flushdb', callback);
+};
+
 require('./transaction').addTransactionSupport(Cluster.prototype);
 
 function noop() {}

--- a/test/functional/cluster.js
+++ b/test/functional/cluster.js
@@ -962,6 +962,140 @@ describe('cluster', function () {
 
     });
   });
+
+  describe("#mastersExec", function () {
+    it('should issue command on every master node', function (done) {
+      var slotTable = [
+        [0, 5460, ['127.0.0.1', 30001], ['127.0.0.1', 30003]],
+        [5461, 10922, ['127.0.0.1', 30002]]
+      ];
+      var node1 = new MockServer(30001, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+
+        if (argv[0] === 'flushdb') {
+          return '30001';
+        }
+      });
+      var node2 = new MockServer(30002, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+
+        if (argv[0] === 'flushdb') {
+          return '30002';
+        }
+      });
+
+      var node3 = new MockServer(30003, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+
+        if (argv[0] === 'flushdb') {
+          return '30003';
+        }
+      });
+
+      var cluster = new Redis.Cluster([{ host: '127.0.0.1', port: '30001'}]);
+      cluster.on('ready', function() {
+        cluster.mastersExec('flushdb', function (err, response) {
+          expect(err).to.eql(null);
+          expect(response).to.eql(['30001', '30002']);
+          disconnect([node1, node2, node3], done);
+        });
+      });
+
+    });
+  });
+
+  describe("#flushCluster", function () {
+    it('should issue flushall command on every master node', function (done) {
+      var slotTable = [
+        [0, 12181, ['127.0.0.1', 30001]],
+        [12182, 12183, ['127.0.0.1', 30002]],
+        [12184, 16383, ['127.0.0.1', 30003]],
+      ];
+      var node1 = new MockServer(30001, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+        if (argv[0] === 'flushall') {
+          return '30001';
+        }
+      });
+      var node2 = new MockServer(30002, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+        if (argv[0] === 'flushall') {
+          return '30002';
+        }
+      });
+      var node3 = new MockServer(30003, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+        if (argv[0] === 'flushall') {
+          return '30003';
+        }
+      });
+
+      var cluster = new Redis.Cluster([{ host: '127.0.0.1', port: '30001'}]);
+      cluster.on('ready', function() {
+        cluster.flushCluster(function (err, response) {
+          expect(err).to.eql(null);
+          expect(response).to.eql(['30001', '30002', '30003']);
+          disconnect([node1, node2, node3], done);
+        });
+      });
+    });
+  });
+
+  describe("#flushClusterDb", function () {
+    it('should issue flushdb command on every master node', function (done) {
+      var slotTable = [
+        [0, 12181, ['127.0.0.1', 30001]],
+        [12182, 12183, ['127.0.0.1', 30002]],
+        [12184, 16383, ['127.0.0.1', 30003]],
+      ];
+      var node1 = new MockServer(30001, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+        if (argv[0] === 'flushdb') {
+          return '30001';
+        }
+      });
+      var node2 = new MockServer(30002, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+        if (argv[0] === 'flushdb') {
+          return '30002';
+        }
+      });
+      var node3 = new MockServer(30003, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+        if (argv[0] === 'flushdb') {
+          return '30003';
+        }
+      });
+
+      var cluster = new Redis.Cluster([{ host: '127.0.0.1', port: '30001'}]);
+      cluster.on('ready', function() {
+        cluster.flushClusterDb(function (err, response) {
+          expect(err).to.eql(null);
+          expect(response).to.eql(['30001', '30002', '30003']);
+          disconnect([node1, node2, node3], done);
+        });
+      });
+    });
+  });
+
 });
 
 function disconnect (clients, callback) {


### PR DESCRIPTION
* `.mastersExec(command, [callback)` utility
* `.flushCluster([callback])`
* `.flushClusterDb([callback])`

It's often needed to do something like, so why not add a helper?