### PR TITLE
allow the connection to be named even if susbscribed and reconnected

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -153,6 +153,7 @@ Redis.defaultOptions = {
     return Math.min(times * 2, 2000);
   },
   keepAlive: 0,
+  connectionName: null,
   // Sentinel
   sentinels: null,
   name: null,

--- a/lib/redis/event_handler.js
+++ b/lib/redis/event_handler.js
@@ -123,6 +123,11 @@ exports.readyHandler = function (self) {
     var finalSelect = self.prevCondition ? self.prevCondition.select : self.condition.select;
     self.condition.select = 0;
 
+    if (self.options.connectionName) {
+      debug('set the connection mane [%s]', self.options.connectionName);
+      self.client('setname', self.options.connectionName);
+    }
+
     if (self.prevCondition) {
       var condition = self.prevCondition;
       self.prevCondition = null;

--- a/test/functional/connection.js
+++ b/test/functional/connection.js
@@ -139,6 +139,35 @@ describe('connection', function () {
     });
   });
 
+  describe('connectionName', function () {
+    it('shoud name the connection if options.connectionName is not null', function (done) {
+      var redis = new Redis({ connectionName: 'niceName' });
+      redis.once('ready', function() {
+        redis.client('getname', function(err, res) {
+          expect(res).to.eql('niceName');
+          done();
+        });
+      });
+      redis.set('foo', 1);
+    });
+
+    it('should set the name before any subscribe command if reconnected', function(done) {
+      var redis = new Redis({ connectionName: 'niceName' });
+      var pub = new Redis();
+      redis.once('ready', function () {
+        redis.subscribe('l', function() {
+          redis.disconnect(true);
+          redis.unsubscribe('l', function() {
+            redis.client('getname', function(err, res) {
+             expect(res).to.eql('niceName');
+             done();
+           });              
+          });
+        });
+      });
+    });
+  });
+
   describe('autoResendUnfulfilledCommands', function () {
     it('should resend unfulfilled commands to the correct db when reconnected', function (done) {
       var redis = new Redis({ db: 3 });


### PR DESCRIPTION
From the redis documentation: "setting names to connections is a good way to debug connection leaks due to bugs in the application using Redis.". The problem is on subscribed connection the name must be set before any subscribe, although the developer can take care of it on the initial connection, the name is lost if ioredis reconnects automatically and resubscribe. A new option "connectionName" can be sued to set the name and leave it to ioredis to set the name consistently across reconnections.