### PR TITLE
fix critical typo in handleError

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -516,7 +516,7 @@ Cluster.prototype.handleError = function (error, ttl, handlers) {
     if (!this.failoverTimeout) {
       this.failoverTimeout = setTimeout(function () {
         _this.refreshSlotsCache(function () {
-          _this.failOverTimeout = null;
+          _this.failoverTimeout = null;
           _this.executeFailoverCommands();
         });
       }, this.options.retryDelayOnFailover);


### PR DESCRIPTION
this is a critical fix as the timeout never gets nulled so it will not work after a single failover