### PR TITLE
fix: "MOVED" err not crashing process when slot was not assigned

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -411,10 +411,17 @@ Cluster.prototype.sendCommand = function (command, stream, node) {
   var _this = this;
   if (!node) {
     command.reject = function (err) {
+      var partialTry = _.partial(tryConnection, true);
+
       _this.handleError(err, ttl, {
         moved: function (node, slot, hostPort) {
           debug('command %s is moved to %s:%s', command.name, hostPort[0], hostPort[1]);
-          _this.slots[slot].masterNode = node;
+          var coveredSlot = _this.slots[slot];
+          if (!coveredSlot) {
+            _this.slots[slot] = { masterNode: node, allNodes: [node] };
+          } else {
+            coveredSlot.masterNode = node;
+          }
           tryConnection();
           _this.refreshSlotsCache();
         },
@@ -422,8 +429,8 @@ Cluster.prototype.sendCommand = function (command, stream, node) {
           debug('command %s is required to ask %s:%s', command.name, hostPort[0], hostPort[1]);
           tryConnection(false, node);
         },
-        clusterDown: tryConnection.bind(null, true),
-        connectionClosed: tryConnection.bind(null, true),
+        clusterDown: partialTry,
+        connectionClosed: partialTry,
         maxRedirections: function (redirectionError) {
           reject.call(command, redirectionError);
         },


### PR DESCRIPTION
If slot was not previously discovered by ioredis - it would cause a crash as it
would try to rewrite a masterNode on a missing object

Should close #231 