### PR TITLE
feat: revisit of .to(nodeGroup) command

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -401,7 +401,7 @@ Cluster.prototype.executeClusterDownCommands = function () {
 
 Cluster.prototype.to = function (name) {
   var fnName = '_select' + name[0].toUpperCase() + name.slice(1);
-  var fn = typeof this[fnName];
+  var fn = this[fnName];
   if (typeof fn !== 'function') {
     // programmatic error, can't happen in prod, so throw
     throw new Error('to ' + name + ' is not a valid group of nodes');

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -399,6 +399,59 @@ Cluster.prototype.executeClusterDownCommands = function () {
   }
 };
 
+Cluster.prototype.to = function (name) {
+  var fnName = '_select' + name[0].toUpperCase() + name.slice(1);
+  var fn = typeof this[fnName];
+  if (typeof fn !== 'function') {
+    // programmatic error, can't happen in prod, so throw
+    throw new Error('to ' + name + ' is not a valid group of nodes');
+  }
+
+  // could be 0 nodes just as well
+  var nodes = fn();
+  return {
+    nodes: nodes,
+    call: this._generateCallNodes(nodes, 'call'),
+    callBuffer: this._generateCallNodes(nodes, 'callBuffer')
+  };
+};
+
+Cluster.prototype._generateCallNodes = function (nodes, op, _opts) {
+  var opts = _opts || {};
+
+  return function callNode() {
+    var argLength = arguments.length;
+    var hasCb = typeof arguments[argLength - 1] === 'function';
+    var args = new Array(argLength);
+    for (var i = 0; i < argLength; ++i) {
+      args[i] = arguments[i];
+    }
+
+    var callback = hasCb ? args.pop() : null;
+    var promise = Promise.map(function (node) {
+      return node[op].apply(node, args);
+    }, opts);
+
+    if (callback) {
+      return promise.nodeify(callback);
+    }
+
+    return promise;
+  };
+};
+
+Cluster.prototype._selectAll = function () {
+  return _.values(this.nodes);
+};
+
+Cluster.prototype._selectMasters = function () {
+  return _.values(this.masterNodes);
+};
+
+Cluster.prototype._selectSlaves = function () {
+  return _.difference(this._selectAll(), this._selectMasters());
+};
+
 Cluster.prototype.sendCommand = function (command, stream, node) {
   if (this.status === 'end') {
     command.reject(new Error('Connection is closed.'));


### PR DESCRIPTION
Provides ability to send arbitrary commands too all nodes in a requested group or
just a handy helper to select nodes from such a group

Supports 'all', 'masters' and 'slaves' groups exposing `call` and `callBuffer` command
semantics similar to Commander