### PR TITLE
fix issue where options were not changed if passed freezed object

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -61,7 +61,7 @@ function Cluster(startupNodes, options) {
   this.slots = [];
 
   this.retryAttempts = 0;
-  this.options = _.defaults(options || {}, this.options || {}, Cluster.defaultOptions);
+  this.options = _.defaults({}, options || {}, Cluster.defaultOptions);
 
   this.resetOfflineQueue();
   this.resetFailoverQueue();


### PR DESCRIPTION
fixes #233 

The problem was that the `_.defaults()` function was using the `options` argument that was passed to it as the base object, and when that object was being freezed by `Object.freeze()`, the defaults weren't being used.