### PR TITLE
feat(transaction): transform replies of transactions

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -200,23 +200,31 @@ Command.prototype.stringifyArguments = function () {
 Command.prototype._convertValue = function (resolve) {
   var _this = this;
   return function (value) {
-    // Convert buffer/buffer[] to string/string[]
-    var result = value;
-    var transformer;
     try {
-      if (_this.replyEncoding) {
-        result = utils.convertBufferToString(value, _this.replyEncoding);
-      }
-      transformer = Command._transformer.reply[_this.name];
-      if (transformer) {
-        result = transformer(result);
-      }
-      resolve(result);
+      resolve(_this.transformReply(value));
     } catch (err) {
       _this.reject(err);
     }
     return _this.promise;
   };
+};
+
+/**
+ * Convert buffer/buffer[] to string/string[],
+ * and apply reply transformer.
+ *
+ * @public
+ */
+Command.prototype.transformReply = function (result) {
+  if (this.replyEncoding) {
+    result = utils.convertBufferToString(result, this.replyEncoding);
+  }
+  var transformer = Command._transformer.reply[this.name];
+  if (transformer) {
+    result = transformer(result);
+  }
+
+  return result;
 };
 
 Command.FLAGS = {

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -5,6 +5,7 @@ var Command = require('./command');
 var fbuffer = require('flexbuffer');
 var Promise = require('bluebird');
 var utils = require('./utils');
+var util = require('util');
 var commands = require('redis-commands');
 
 function Pipeline(redis) {
@@ -35,13 +36,27 @@ function Pipeline(redis) {
 _.assign(Pipeline.prototype, Commander.prototype);
 
 Pipeline.prototype.fillResult = function (value, position) {
+  var i;
+  if (this._queue[position].name === 'exec' && Array.isArray(value[1])) {
+    var execLength = value[1].length;
+    for (i = 0; i < execLength; i++) {
+      if (value[1][i] instanceof Error) {
+        continue;
+      }
+      var cmd = this._queue[position - (execLength - i)];
+      try {
+        value[1][i] = cmd.transformReply(value[1][i]);
+      } catch (err) {
+        value[1][i] = err;
+      }
+    }
+  }
   this._result[position] = value;
 
   if (--this.replyPending) {
     return;
   }
 
-  var i;
   if (this.isCluster) {
     var retriable = true;
     var commonError;
@@ -175,18 +190,17 @@ Pipeline.prototype.multi = function () {
 };
 
 var execBuffer = Pipeline.prototype.execBuffer;
-Pipeline.prototype.execBuffer = function () {
+Pipeline.prototype.execBuffer = util.deprecate(function () {
   if (this._transactions > 0) {
     this._transactions -= 1;
   }
   return execBuffer.apply(this, arguments);
-};
+}, 'Pipeline#execBuffer: Use Pipeline#exec instead');
 
-var exec = Pipeline.prototype.exec;
 Pipeline.prototype.exec = function (callback) {
   if (this._transactions > 0) {
     this._transactions -= 1;
-    return exec.apply(this, arguments);
+    return execBuffer.apply(this, arguments);
   }
   if (!this.nodeifiedPromise) {
     this.nodeifiedPromise = true;


### PR DESCRIPTION
BREAKING CHANGE:

  1. Reply transformers is supported inside transactions.
  2. `Pipeline#execBuffer()` is deprecated. Use `Pipeline#exec()` instead.

Closes #158.