### PR TITLE
fix(CLUSTER): fix cluster not disconnected when called disconnect method

### DIFF
--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -57,7 +57,7 @@ function Cluster(startupNodes, options) {
 
   var _this = this;
   this.connectionPool.on('-node', function (redis) {
-    if (_this.subscriber === redis) {
+    if (_this.status === 'ready' && _this.subscriber === redis) {
       _this.selectSubscriber();
     }
     _this.emit('-node', redis);
@@ -193,6 +193,8 @@ Cluster.prototype.connect = function () {
  * @public
  */
 Cluster.prototype.disconnect = function (reconnect) {
+  this.setStatus('disconnecting');
+
   if (!reconnect) {
     this.manuallyClosing = true;
   }

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -57,7 +57,7 @@ function Cluster(startupNodes, options) {
 
   var _this = this;
   this.connectionPool.on('-node', function (redis) {
-    if (_this.status === 'ready' && _this.subscriber === redis) {
+    if (_this.status !== 'disconnecting' && _this.subscriber === redis) {
       _this.selectSubscriber();
     }
     _this.emit('-node', redis);

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -300,6 +300,8 @@ Redis.prototype.connect = function (callback) {
  * @public
  */
 Redis.prototype.disconnect = function (reconnect) {
+  this.setStatus('disconnecting');
+
   if (!reconnect) {
     this.manuallyClosing = true;
   }
@@ -307,7 +309,11 @@ Redis.prototype.disconnect = function (reconnect) {
     clearTimeout(this.reconnectTimeout);
     this.reconnectTimeout = null;
   }
-  this.connector.disconnect();
+  if (this.status === 'wait') {
+    eventHandler.closeHandler(this)();
+  } else {
+    this.connector.disconnect();
+  }
 };
 
 /**

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -300,9 +300,6 @@ Redis.prototype.connect = function (callback) {
  * @public
  */
 Redis.prototype.disconnect = function (reconnect) {
-  var previousStatus = this.status;
-  this.setStatus('disconnecting');
-
   if (!reconnect) {
     this.manuallyClosing = true;
   }
@@ -310,7 +307,7 @@ Redis.prototype.disconnect = function (reconnect) {
     clearTimeout(this.reconnectTimeout);
     this.reconnectTimeout = null;
   }
-  if (previousStatus === 'wait') {
+  if (this.status === 'wait') {
     eventHandler.closeHandler(this)();
   } else {
     this.connector.disconnect();

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -300,6 +300,7 @@ Redis.prototype.connect = function (callback) {
  * @public
  */
 Redis.prototype.disconnect = function (reconnect) {
+  var previousStatus = this.status;
   this.setStatus('disconnecting');
 
   if (!reconnect) {
@@ -309,7 +310,7 @@ Redis.prototype.disconnect = function (reconnect) {
     clearTimeout(this.reconnectTimeout);
     this.reconnectTimeout = null;
   }
-  if (this.status === 'wait') {
+  if (previousStatus === 'wait') {
     eventHandler.closeHandler(this)();
   } else {
     this.connector.disconnect();

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "NODE_ENV=test mocha",
-    "test:cov": "NODE_ENV=test DEBUG=ioredis:* node ./node_modules/istanbul/lib/cli.js cover --preserve-comments ./node_modules/mocha/bin/_mocha -- -R spec",
+    "test:cov": "NODE_ENV=test node ./node_modules/istanbul/lib/cli.js cover --preserve-comments ./node_modules/mocha/bin/_mocha -- -R spec",
     "generate-docs": "jsdoc2md lib/redis.js lib/cluster/index.js lib/commander.js > API.md",
     "build": "node tools/build > commands.js",
     "bench": "matcha benchmarks/*.js"

--- a/test/functional/cluster.js
+++ b/test/functional/cluster.js
@@ -1219,7 +1219,7 @@ describe('cluster', function () {
         expect(cluster.nodes('master')).to.have.lengthOf(2);
         expect(cluster.nodes('slave')).to.have.lengthOf(1);
 
-        cluster.on('-node', function () {
+        cluster.once('-node', function () {
           expect(cluster.nodes()).to.have.lengthOf(2);
           expect(cluster.nodes('all')).to.have.lengthOf(2);
           expect(cluster.nodes('master')).to.have.lengthOf(1);

--- a/test/functional/lazy_connect.js
+++ b/test/functional/lazy_connect.js
@@ -26,4 +26,12 @@ describe('lazy connect', function () {
       });
     });
   });
+
+  it('should be able to disconnect', function (done) {
+    var redis = new Redis({ lazyConnect: true });
+    redis.on('end', function () {
+      done();
+    });
+    redis.disconnect();
+  });
 });


### PR DESCRIPTION
Before this change, when disconnecting from a cluster, the nodes will be disconnected one by one. However, when the subscriber is disconnected, a new subscriber will be connected to in `-node` event, leading the cluster keeping connected.

Related issue: #277 