### PR TITLE
feat: emit authentication related errors with "error" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,6 @@ Besides the above connection events, there are several other custom events:
 
 Event    | Description
 :------------- | :-------------
-authError | emits when the password specified in the options is wrong or the server doesn't require a password.
 select   | emits when the database changed. The argument is the new db number.
 
 ## Offline Queue

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -337,7 +337,7 @@ Cluster.prototype.refreshSlotsCache = function (callback) {
 };
 
 /**
- * Flush offline queue and command queue with error.
+ * Flush offline queue with error.
  *
  * @param {Error} error - The error object to send to the commands
  * @private

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -315,9 +315,6 @@ Redis.prototype.disconnect = function (reconnect) {
   if (this.status === 'wait') {
     eventHandler.closeHandler(this)();
   } else {
-    if (this.stream) {
-      this.stream.removeAllListeners('data');
-    }
     this.connector.disconnect();
   }
 };
@@ -359,9 +356,14 @@ Redis.prototype.flushQueue = function (error) {
     item.command.reject(error);
   }
 
-  while (this.commandQueue.length > 0) {
-    item = this.commandQueue.shift();
-    item.command.reject(error);
+  if (this.commandQueue.length > 0) {
+    if (this.stream) {
+      this.stream.removeAllListeners('data');
+    }
+    while (this.commandQueue.length > 0) {
+      item = this.commandQueue.shift();
+      item.command.reject(error);
+    }
   }
 };
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -315,6 +315,9 @@ Redis.prototype.disconnect = function (reconnect) {
   if (this.status === 'wait') {
     eventHandler.closeHandler(this)();
   } else {
+    if (this.stream) {
+      this.stream.removeAllListeners('data');
+    }
     this.connector.disconnect();
   }
 };

--- a/lib/redis/event_handler.js
+++ b/lib/redis/event_handler.js
@@ -14,7 +14,13 @@ exports.connectHandler = function (self) {
     if (self.condition.auth) {
       self.auth(self.condition.auth, function (err) {
         if (err) {
-          self.silentEmit('error', err);
+          if (err.message.indexOf('no password is set') === -1) {
+            self.flushQueue(err);
+            self.silentEmit('error', err);
+            self.disconnect(true);
+          } else {
+            console.warn('[WARN] Redis server does not require a password, but a password was supplied.');
+          }
         }
       });
     }
@@ -35,6 +41,7 @@ exports.connectHandler = function (self) {
           self.flushQueue(new Error('Ready check failed: ' + err.message));
           if (!self.condition.auth && err.message.split(' ')[0] === 'NOAUTH') {
             self.silentEmit('error', err);
+            self.disconnect(true);
           }
         } else {
           self.serverInfo = info;

--- a/lib/redis/event_handler.js
+++ b/lib/redis/event_handler.js
@@ -11,10 +11,12 @@ exports.connectHandler = function (self) {
     self.resetCommandQueue();
 
     // AUTH command should be processed before any other commands
+    var flushed = false;
     if (self.condition.auth) {
       self.auth(self.condition.auth, function (err) {
         if (err) {
           if (err.message.indexOf('no password is set') === -1) {
+            flushed = true;
             self.flushQueue(err);
             self.silentEmit('error', err);
             self.disconnect(true);
@@ -38,9 +40,11 @@ exports.connectHandler = function (self) {
     if (self.options.enableReadyCheck) {
       self._readyCheck(function (err, info) {
         if (err) {
-          self.flushQueue(new Error('Ready check failed: ' + err.message));
-          self.silentEmit('error', err);
-          self.disconnect(true);
+          if (!flushed) {
+            self.flushQueue(new Error('Ready check failed: ' + err.message));
+            self.silentEmit('error', err);
+            self.disconnect(true);
+          }
         } else {
           self.serverInfo = info;
           if (self.connector.check(info)) {

--- a/lib/redis/event_handler.js
+++ b/lib/redis/event_handler.js
@@ -14,7 +14,7 @@ exports.connectHandler = function (self) {
     if (self.condition.auth) {
       self.auth(self.condition.auth, function (err) {
         if (err) {
-          self.emit('authError', err);
+          self.silentEmit('error', err);
         }
       });
     }
@@ -34,7 +34,7 @@ exports.connectHandler = function (self) {
         if (err) {
           self.flushQueue(new Error('Ready check failed: ' + err.message));
           if (!self.condition.auth && err.message.split(' ')[0] === 'NOAUTH') {
-            self.emit('authError', err);
+            self.silentEmit('error', err);
           }
         } else {
           self.serverInfo = info;

--- a/lib/redis/event_handler.js
+++ b/lib/redis/event_handler.js
@@ -39,10 +39,8 @@ exports.connectHandler = function (self) {
       self._readyCheck(function (err, info) {
         if (err) {
           self.flushQueue(new Error('Ready check failed: ' + err.message));
-          if (!self.condition.auth && err.message.split(' ')[0] === 'NOAUTH') {
-            self.silentEmit('error', err);
-            self.disconnect(true);
-          }
+          self.silentEmit('error', err);
+          self.disconnect(true);
         } else {
           self.serverInfo = info;
           if (self.connector.check(info)) {

--- a/test/functional/auth.js
+++ b/test/functional/auth.js
@@ -71,11 +71,21 @@ describe('auth', function () {
       }
     });
     var redis = new Redis({ port: 17379, password: 'pass' });
+    var pending = 2;
+    function check() {
+      if (!--pending) {
+        redis.disconnect();
+        server.disconnect();
+        done();
+      }
+    }
     redis.on('error', function (error) {
       expect(error).to.have.property('message', 'ERR invalid password');
-      redis.disconnect();
-      server.disconnect();
-      done();
+      check();
+    });
+    redis.get('foo', function (err, res) {
+      expect(err.message).to.eql('ERR invalid password');
+      check();
     });
   });
 

--- a/test/functional/auth.js
+++ b/test/functional/auth.js
@@ -41,14 +41,14 @@ describe('auth', function () {
     });
   });
 
-  it('should emit "authError" when the server doesn\'t need auth', function (done) {
+  it('should emit "error" when the server doesn\'t need auth', function (done) {
     var server = new MockServer(17379, function (argv) {
       if (argv[0] === 'auth' && argv[1] === 'pass') {
         return new Error('ERR Client sent AUTH, but no password is set');
       }
     });
     var redis = new Redis({ port: 17379, password: 'pass' });
-    redis.on('authError', function (error) {
+    redis.on('error', function (error) {
       expect(error).to.have.property('message', 'ERR Client sent AUTH, but no password is set');
       redis.disconnect();
       server.disconnect();
@@ -56,14 +56,14 @@ describe('auth', function () {
     });
   });
 
-  it('should emit "authError" when the password is wrong', function (done) {
+  it('should emit "error" when the password is wrong', function (done) {
     var server = new MockServer(17379, function (argv) {
       if (argv[0] === 'auth' && argv[1] === 'pass') {
         return new Error('ERR invalid password');
       }
     });
     var redis = new Redis({ port: 17379, password: 'pass' });
-    redis.on('authError', function (error) {
+    redis.on('error', function (error) {
       expect(error).to.have.property('message', 'ERR invalid password');
       redis.disconnect();
       server.disconnect();
@@ -71,14 +71,14 @@ describe('auth', function () {
     });
   });
 
-  it('should emit "authError" when password is not provided', function (done) {
+  it('should emit "error" when password is not provided', function (done) {
     var server = new MockServer(17379, function (argv) {
       if (argv[0] === 'info') {
         return new Error('NOAUTH Authentication required.');
       }
     });
     var redis = new Redis({ port: 17379 });
-    redis.on('authError', function (error) {
+    redis.on('error', function (error) {
       expect(error).to.have.property('message', 'NOAUTH Authentication required.');
       redis.disconnect();
       server.disconnect();

--- a/test/functional/ready_check.js
+++ b/test/functional/ready_check.js
@@ -16,4 +16,20 @@ describe('ready_check', function () {
     });
     redis.connect();
   });
+
+  it('should reconnect when info return a error', function (done) {
+    var redis = new Redis({
+      lazyConnect: true,
+      retryStrategy: function () {
+        done();
+        return;
+      }
+    });
+
+    stub(redis, 'info', function (callback) {
+      callback(new Error('info error'));
+    });
+
+    redis.connect();
+  });
 });


### PR DESCRIPTION
Use a unified error event will be more easier to deal with (Many people forget to listen to the `authError` event).

Note that we should disconnect from the Redis since many other libraries (e.g. connect-redis) suppose `error` event will be followed by a reconnection.

BREAKING CHANGE:

Authentication related errors are emited with "error" event,
instead of "authError" event