### PR TITLE
Use given 'dropBufferSupport' for sentinel connections

### DIFF
--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -124,7 +124,8 @@ SentinelConnector.prototype.resolve = function (endpoint, callback) {
     host: endpoint.host,
     retryStrategy: null,
     enableReadyCheck: false,
-    connectTimeout: this.options.connectTimeout
+    connectTimeout: this.options.connectTimeout,
+    dropBufferSupport: true
   });
 
   if (this.options.role === 'slave') {


### PR DESCRIPTION
Basically same as https://github.com/luin/ioredis/pull/155 , but this time passing the `dropBufferSupport` option also through the sentinel-connector.

Would it be better to just pass the whole `this.options`, and only override or exclude properties like `host`, `port` and `enableReadyCheck`?