### PR TITLE
fix transaction with dropBufferSupport:true

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -197,10 +197,11 @@ Pipeline.prototype.execBuffer = util.deprecate(function () {
   return execBuffer.apply(this, arguments);
 }, 'Pipeline#execBuffer: Use Pipeline#exec instead');
 
+var exec = Pipeline.prototype.exec;
 Pipeline.prototype.exec = function (callback) {
   if (this._transactions > 0) {
     this._transactions -= 1;
-    return execBuffer.apply(this, arguments);
+    return exec.apply(this, arguments);
   }
   if (!this.nodeifiedPromise) {
     this.nodeifiedPromise = true;

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -190,6 +190,7 @@ Pipeline.prototype.multi = function () {
 };
 
 var execBuffer = Pipeline.prototype.execBuffer;
+var exec = Pipeline.prototype.exec;
 Pipeline.prototype.execBuffer = util.deprecate(function () {
   if (this._transactions > 0) {
     this._transactions -= 1;
@@ -197,11 +198,10 @@ Pipeline.prototype.execBuffer = util.deprecate(function () {
   return execBuffer.apply(this, arguments);
 }, 'Pipeline#execBuffer: Use Pipeline#exec instead');
 
-var exec = Pipeline.prototype.exec;
 Pipeline.prototype.exec = function (callback) {
   if (this._transactions > 0) {
     this._transactions -= 1;
-    return exec.apply(this, arguments);
+    return (this.options.dropBufferSupport ? exec : execBuffer).apply(this, arguments);
   }
   if (!this.nodeifiedPromise) {
     this.nodeifiedPromise = true;

--- a/test/functional/drop_buffer_support.js
+++ b/test/functional/drop_buffer_support.js
@@ -84,8 +84,23 @@ describe('dropBufferSupport', function () {
         expect(err).to.eql(null);
         expect(res[0][1]).to.eql('OK');
         expect(res[1][1]).to.eql('bar');
+        redis.disconnect();
         done();
       });
+    });
+
+    it('should work with transaction', function (done) {
+      var redis = new Redis({ dropBufferSupport: true });
+      redis.multi()
+        .set('foo', 'bar')
+        .get('foo')
+        .exec(function(err, res) {
+          expect(err).to.eql(null);
+          expect(res[0][1]).to.eql('OK');
+          expect(res[1][1]).to.eql('bar');
+          redis.disconnect();
+          done();
+        });
     });
 
     it('should work with internal select command', function (done) {
@@ -94,6 +109,8 @@ describe('dropBufferSupport', function () {
       redis.set('foo', 'bar', function () {
         check.get('foo', function (err, res) {
           expect(res).to.eql('bar');
+          redis.disconnect();
+          check.disconnect();
           done();
         });
       });

--- a/test/functional/drop_buffer_support.js
+++ b/test/functional/drop_buffer_support.js
@@ -103,6 +103,17 @@ describe('dropBufferSupport', function () {
         });
     });
 
+    it('should fail early with Buffer transaction', function (done) {
+      var redis = new Redis({ dropBufferSupport: true });
+      redis.multi()
+        .set('foo', 'bar')
+        .getBuffer(new Buffer('foo'), function(err) {
+          expect(err.message).to.match(/Buffer methods are not available/);
+          redis.disconnect();
+          done();
+        });
+    });
+
     it('should work with internal select command', function (done) {
       var redis = new Redis({ dropBufferSupport: true, db: 1 });
       var check = new Redis({ db: 1 });

--- a/test/functional/transaction.js
+++ b/test/functional/transaction.js
@@ -79,7 +79,7 @@ describe('transaction', function () {
         if (!--pending) {
           done();
         }
-      }).hgetallBuffer('foo').get('foo').getBuffer('foo').execBuffer(function (err, res) {
+      }).hgetallBuffer('foo').get('foo').getBuffer('foo').exec(function (err, res) {
         expect(res[0][1]).to.eql('OK');
         expect(res[1][1]).to.eql(data);
         expect(res[2][1]).to.eql({
@@ -101,7 +101,7 @@ describe('transaction', function () {
       var redis = new Redis();
       var data = { name: 'Bob', age: '17' };
       redis.pipeline().hmset('foo', data).multi().typeBuffer('foo')
-      .hgetall('foo').execBuffer().hgetall('foo').exec(function (err, res) {
+      .hgetall('foo').exec().hgetall('foo').exec(function (err, res) {
         expect(res[0][1]).to.eql('OK');
         expect(res[1][1]).to.eql('OK');
         expect(res[2][1]).to.eql(new Buffer('QUEUED'));

--- a/test/functional/transaction.js
+++ b/test/functional/transaction.js
@@ -79,7 +79,7 @@ describe('transaction', function () {
         if (!--pending) {
           done();
         }
-      }).hgetallBuffer('foo').get('foo').getBuffer('foo').exec(function (err, res) {
+      }).hgetallBuffer('foo').get('foo').getBuffer('foo').execBuffer(function (err, res) {
         expect(res[0][1]).to.eql('OK');
         expect(res[1][1]).to.eql(data);
         expect(res[2][1]).to.eql({
@@ -101,7 +101,7 @@ describe('transaction', function () {
       var redis = new Redis();
       var data = { name: 'Bob', age: '17' };
       redis.pipeline().hmset('foo', data).multi().typeBuffer('foo')
-      .hgetall('foo').exec().hgetall('foo').exec(function (err, res) {
+      .hgetall('foo').execBuffer().hgetall('foo').exec(function (err, res) {
         expect(res[0][1]).to.eql('OK');
         expect(res[1][1]).to.eql('OK');
         expect(res[2][1]).to.eql(new Buffer('QUEUED'));


### PR DESCRIPTION
fixes #313 + regression test.

@luin There is another issue now with `dropBufferSupport` regarding transactions that combine both Buffer & non-Buffer methods.
I'm not sure this is supported now and will cause an error.
