### PR TITLE
refactor: remove unused Command#getKeyPart

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -124,18 +124,6 @@ Command.prototype._iterateKeys = function (transform) {
   return this._keys;
 };
 
-Command.prototype.getKeyPart = function (key) {
-  var starPos = key.indexOf('*');
-  if (starPos === -1) {
-    return key;
-  }
-  var hashPos = key.indexOf('->', starPos + 1);
-  if (hashPos === 1) {
-    return key;
-  }
-  return key.slice(0, hashPos);
-};
-
 /**
  * Convert command to writable buffer or string
  *


### PR DESCRIPTION
`getKeyPart` methods is not used anymore as the package redis-commands is used. Remove it won't break BC since it's not a public API (not listed on https://github.com/luin/ioredis/blob/master/API.md).