### PR TITLE
Ensure node exists before being redirected via an ASK

### DIFF
--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -401,6 +401,8 @@ Cluster.prototype.sendCommand = function (command, stream, node) {
         },
         ask: function (slot, key) {
           debug('command %s is required to ask %s:%s', command.name, key);
+          var splitKey = key.split(':');
+          _this.connectionPool.findOrCreate({ host: splitKey[0], port: Number(splitKey[1]) });
           tryConnection(false, key);
         },
         tryagain: partialTry,

--- a/test/functional/cluster.js
+++ b/test/functional/cluster.js
@@ -452,6 +452,38 @@ describe('cluster', function () {
         cluster.get('foo');
       });
     });
+
+    it('should be able to redirect a command to a unknown node', function (done) {
+      var asked = false;
+      var slotTable = [
+        [0, 16383, ['127.0.0.1', 30002]]
+      ];
+      var node1 = new MockServer(30001, function (argv) {
+        if (argv[0] === 'get' && argv[1] === 'foo') {
+          expect(asked).to.eql(true);
+          return "bar"
+        } else if (argv[0] === 'asking') {
+          asked = true;
+        }
+      });
+      var node2 = new MockServer(30002, function (argv) {
+        if (argv[0] === 'cluster' && argv[1] === 'slots') {
+          return slotTable;
+        }
+        if (argv[0] === 'get' && argv[1] === 'foo') {
+          return new Error('ASK ' + calculateSlot('foo') + ' 127.0.0.1:30001');
+        }
+      });
+
+      var cluster = new Redis.Cluster([
+        { host: '127.0.0.1', port: '30002' }
+      ]);
+      cluster.get('foo', function (err, res) {
+        expect(res).to.eql('bar');
+        cluster.disconnect();
+        disconnect([node1, node2], done);
+      });
+    });
   });
 
   describe('TRYAGAIN', function () {


### PR DESCRIPTION
If a master node in the Redis cluster does not have any slots, it is not returned by the `cluster slots` command, and so does not have a client in the connectionPool. If slots are migrated to this new master node, the old master node returns an `ASK` error with the new node details. At the moment ioredis looks up the node in the connectionPool but it doesn't exist, so the following error is returned:

```
TypeError: Cannot call method 'asking' of undefined
  at tryConnection (/var/www/document-updater/releases/5543/node_modules/ioredis/lib/cluster/index.js:464:19)
  at Object._this.handleError.ask (/var/www/document-updater/releases/5543/node_modules/ioredis/lib/cluster/index.js:404:11)
  at Cluster.handleError (/var/www/document-updater/releases/5543/node_modules/ioredis/lib/cluster/index.js:503:52)
  at Command.command.reject (/var/www/document-updater/releases/5543/node_modules/ioredis/lib/cluster/index.js:389:13)
  at Redis.exports.returnError (/var/www/document-updater/releases/5543/node_modules/ioredis/lib/redis/parser.js:75:18)
```

It looks like a similar issues with a `MOVED` reply was fixed in https://github.com/luin/ioredis/commit/0dcb768e2e418b9dd3fa7feaf01ad85cb01521ef. This patch applies the same fix to the `ASK` error. 