### PR TITLE
Implement auto-pipelining for all connections [~100% op/s increase]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.cpuprofile
 /test.js
+.idea

--- a/lib/connectors/connector.js
+++ b/lib/connectors/connector.js
@@ -5,12 +5,59 @@ var net = require('net');
 var tls = require('tls');
 var utils = require('../utils');
 
+var MAX_BUFFER_SIZE = 4 * 1024 * 1024;  // 4 mb
+var MAX_QUEUED = 100;  // appears to be a good number after testing
+
 function Connector(options) {
   this.options = options;
+
+  if (options.path) {
+    this.connectionOptions = _.pick(options, ['path']);
+  } else {
+    this.connectionOptions = _.pick(options, ['port', 'host', 'family']);
+  }
+  if (options.tls) {
+    _.assign(this.connectionOptions, options.tls);
+  }
+
+  // auto pipeline props
+  this.pipelineBuffer = '';
+  this.pipelineQueued = 0;
+  this.pipelineImmediate = null;
 }
 
 Connector.prototype.check = function () {
   return true;
+};
+
+/**
+ * Proxy stream writer for auto-pipeline.
+ * @param str usual stream.write arg
+ * @param forceWrite set to true when calling write to force pipeline bypass
+ */
+Connector.prototype.write = function (str, forceWrite) {
+  this.pipelineBuffer += str;
+  this.pipelineQueued++;
+
+  // queue the write for the next event loop if this is the first write issued
+  if (this.pipelineQueued < 2) {
+    this.pipelineImmediate = setImmediate(this.writePipeline.bind(this));
+  }
+
+  // write pipeline if limits have been exceeded or this is a forced write
+  if (forceWrite || this.pipelineQueued > MAX_QUEUED || this.pipelineBuffer.length > MAX_BUFFER_SIZE) {
+    clearImmediate(this.pipelineImmediate);
+    this.writePipeline();
+  }
+};
+
+/**
+ * Writes the buffered pipelines and resets counts and buffer.
+ */
+Connector.prototype.writePipeline = function () {
+  this.stream._stream.write(this.pipelineBuffer);
+  this.pipelineBuffer = '';
+  this.pipelineQueued = 0;
 };
 
 Connector.prototype.disconnect = function () {
@@ -21,31 +68,45 @@ Connector.prototype.disconnect = function () {
 };
 
 Connector.prototype.connect = function (callback) {
-  this.connecting = true;
-  var connectionOptions;
-  if (this.options.path) {
-    connectionOptions = _.pick(this.options, ['path']);
-  } else {
-    connectionOptions = _.pick(this.options, ['port', 'host', 'family']);
-  }
-  if (this.options.tls) {
-    _.assign(connectionOptions, this.options.tls);
-  }
-
   var _this = this;
+  this.connecting = true;
+
   process.nextTick(function () {
     if (!_this.connecting) {
       callback(new Error(utils.CONNECTION_CLOSED_ERROR_MSG));
       return;
     }
+
     var stream;
+
     if (_this.options.tls) {
-      stream = tls.connect(connectionOptions);
+      stream = tls.connect(_this.connectionOptions);
     } else {
-      stream = net.createConnection(connectionOptions);
+      stream = net.createConnection(_this.connectionOptions);
     }
-    _this.stream = stream;
-    callback(null, stream);
+
+    // create a fake stream so we can intercept write without overriding it
+    // sometimes on tear-down 'stream' is undefined so added a check
+    if (stream) {
+      _this.stream = {
+        _stream: stream,
+        writable: stream.writable,
+        on: stream.on.bind(stream),
+        end: stream.end.bind(stream),
+        remotePort: stream.remotePort,
+        once: stream.once.bind(stream),
+        write: _this.write.bind(_this),
+        remoteAddress: stream.remoteAddress,
+        destroy: stream.destroy.bind(stream),
+        _writableState: stream._writableState,
+        setTimeout: stream.setTimeout.bind(stream),
+        setKeepAlive: stream.setKeepAlive.bind(stream),
+        removeListener: stream.removeListener.bind(stream),
+        removeAllListeners: stream.removeAllListeners.bind(stream)
+      };
+    }
+
+    callback(null, _this.stream);
   });
 };
 


### PR DESCRIPTION
### Description

This implements auto-pipelining.

Took the route of least change and implemented it directly in the Connector class for a per redis server basis, this is done by intercepting `stream.write()` with a bespoke function to handle auto-pipelining. 

This applies to all types of connections, including Sentinel and clusters.
### How it works

When stream write is called the proxy function starts a string buffer and keeps track of the number of writes currently buffered, if the number of writes buffered exceeds `MAX_QUEUED` or if the size of the buffered string exceeds `MAX_BUFFER_SIZE` then the pipeline buffer is written to the stream.

The above limits are on a **per event loop tick** basis - so at the start of every node event loop if there is anything buffered it will immediately get written to the stream.
### Benchmarks

These benchmarks were done against a local redis server. The benefits of this change are even more noticeable against remote redis servers as the network latency is greater - pipelining reduces round trips.

![image](https://cloud.githubusercontent.com/assets/5347038/16541754/0b831460-4084-11e6-97a2-aee842416683.png)
### Notes
- The limits are hard set at the moment, should we allow user land to change these? They're very hit and miss, took a lot of trying to get the best results.
- Should we allow turning this off? Can't see a reason why this should be off, ever - it's more efficient and a recommended redis practice? I have however added a second param to `.write()` that if set to `true` will force a write.
- Cleaned up the whole connector class and moved the connection options into the constructor - no need to re-create these on every `.connect()`?
- Probably worth mentioning in the readme that ioredis has this feature and does this by default?

**Obligatory gif.**
![pew pew](https://media.giphy.com/media/115NBvjY0rnLnW/giphy.gif)
