### PR TITLE
Use redis.get only in callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ $ npm install ioredis
 var Redis = require('ioredis');
 var redis = new Redis();
 
-redis.set('foo', 'bar');
-redis.get('foo', function (err, result) {
-  console.log(result);
+redis.set('foo', 'bar', function() {
+  redis.get('foo', function (err, result) {
+    console.log(result);
+  });
 });
 
 // Or using a promise if the last argument isn't a function


### PR DESCRIPTION
This is a toxic example that will only work on your local machine. Add network latency and clustering and you will not find ```foo``` all the time.