### PR TITLE
Reject with general error in Redis#connect

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -299,9 +299,9 @@ Redis.prototype.connect = function (callback) {
         _this.removeListener('close', connectionCloseHandler);
         resolve();
       };
-      var connectionCloseHandler = function (err) {
+      var connectionCloseHandler = function () {
         _this.removeListener(CONNECT_EVENT, connectionConnectHandler);
-        reject(err);
+        reject(new Error(utils.CONNECTION_CLISED_ERROR_MSG));
       };
       _this.once(CONNECT_EVENT, connectionConnectHandler);
       _this.once('close', connectionCloseHandler);


### PR DESCRIPTION
Now it rejects with an `undefined`, which will cause warnings.