### PR TITLE
fix typo in error handler

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -301,7 +301,7 @@ Redis.prototype.connect = function (callback) {
       };
       var connectionCloseHandler = function () {
         _this.removeListener(CONNECT_EVENT, connectionConnectHandler);
-        reject(new Error(utils.CONNECTION_CLISED_ERROR_MSG));
+        reject(new Error(utils.CONNECTION_CLOSED_ERROR_MSG));
       };
       _this.once(CONNECT_EVENT, connectionConnectHandler);
       _this.once('close', connectionCloseHandler);


### PR DESCRIPTION
`CONNECTION_CLISED_ERROR_MSG` -> `CONNECTION_CLOSED_ERROR_MSG`