### PR TITLE
Sentinel preferredSlaves option

### DIFF
--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -11,7 +11,7 @@ var Redis;
 function SentinelConnector(options) {
   Connector.call(this, options);
   if (this.options.sentinels.length === 0) {
-    throw new Error('Requires at least on sentinel to connect to.');
+    throw new Error('Requires at least one sentinel to connect to.');
   }
   if (!this.options.name) {
     throw new Error('Requires the name of master.');
@@ -99,7 +99,7 @@ SentinelConnector.prototype.updateSentinels = function (client, callback) {
         var sentinel = utils.packObject(result[i]);
         var flags = sentinel.flags ? sentinel.flags.split(',') : [];
         if (flags.indexOf('disconnected') === -1 && sentinel.ip && sentinel.port) {
-          var endpoint = { host: sentinel.ip, port: parseInt(sentinel.port) };
+          var endpoint = { host: sentinel.ip, port: parseInt(sentinel.port, 10) };
           var isDuplicate = _this.sentinels.some(function (o) {
             return o.host === endpoint.host && o.port === endpoint.port;
           });
@@ -133,6 +133,7 @@ SentinelConnector.prototype.resolveMaster = function (client, callback) {
 };
 
 SentinelConnector.prototype.resolveSlave = function (client, callback) {
+  var _this = this;
   client.sentinel('slaves', this.options.name, function (err, result) {
     client.disconnect();
     if (err) {
@@ -147,7 +148,60 @@ SentinelConnector.prototype.resolveSlave = function (client, callback) {
           availableSlaves.push(slave);
         }
       }
-      selectedSlave = _.sample(availableSlaves);
+      // allow the options to prefer particular slave(s)
+      if (_this.options.preferredSlaves) {
+        var preferredSlaves = _this.options.preferredSlaves;
+        switch (typeof preferredSlaves) {
+        case 'function':
+          // use function from options to filter preferred slave
+          selectedSlave = _this.options.preferredSlaves(availableSlaves);
+          break;
+        case 'object':
+          if (!Array.isArray(preferredSlaves)) {
+            preferredSlaves = [preferredSlaves];
+          } else {
+            // sort by priority
+            preferredSlaves.sort(function (a, b) {
+              // default the priority to 1
+              if (!a.prio) {
+                a.prio = 1;
+              }
+              if (!b.prio) {
+                b.prio = 1;
+              }
+
+              // lowest priority first
+              if (a.prio < b.prio) {
+                return -1;
+              }
+              if (a.prio > b.prio) {
+                return 1;
+              }
+              return 0;
+            });
+          }
+          // loop over preferred slaves and return the first match
+          for (var p = 0; p < preferredSlaves.length; p++) {
+            for (var a = 0; a < availableSlaves.length; a++) {
+              if (availableSlaves[a].ip === preferredSlaves[p].ip) {
+                if (availableSlaves[a].port === preferredSlaves[p].port) {
+                  selectedSlave = availableSlaves[a];
+                  break;
+                }
+              }
+            }
+            if (selectedSlave) {
+              break;
+            }
+          }
+          // if none of the preferred slaves are available, a random available slave is returned
+          break;
+        }
+      }
+      if (!selectedSlave) {
+        // get a random available slave
+        selectedSlave = _.sample(availableSlaves);
+      }
     }
     callback(null, selectedSlave ? { host: selectedSlave.ip, port: selectedSlave.port } : null);
   });


### PR DESCRIPTION
Option to specify a preferred slave (or slaves by priority) when connecting to a Sentinel group.

Fixes #38 .