### PR TITLE
WIP: Upgrade redis parser to 2.0.x

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,11 @@
 *.cpuprofile
-/test.js
+API.md
+Changelog.md
+README.md
+benchmarks/
+bin/
+examples/
 logo.svg
 medis.png
+test/
+test_sentinel.js

--- a/README.md
+++ b/README.md
@@ -840,10 +840,6 @@ var cluster = new Redis.Cluster([
 });
 ```
 
-## Improve Performance
-ioredis supports two parsers, "hiredis" and "javascript". Refer to https://github.com/luin/ioredis/wiki/Improve-Performance
-for details about the differences between them in terms of performance.
-
 <hr>
 
 # Error Handling

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -179,6 +179,8 @@ Cluster.prototype.connect = function () {
 
 /**
  * Called when closed to check whether a reconnection should be made
+ *
+ * @private
  */
 Cluster.prototype._handleCloseEvent = function () {
   var retryDelay;

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -37,11 +37,7 @@ var commands = require('redis-commands');
  * @param {number} [options.db=0] - Database index to use.
  * @param {string} [options.password=null] - If set, client will send AUTH command
  * with the value of this option when connected.
- * @param {string} [options.parser=null] - Either "hiredis" or "javascript". If not set, "hiredis" parser
- * will be used if it's installed (`npm install hiredis`), otherwise "javascript" parser will be used.
  * @param {boolean} [options.dropBufferSupport=false] - Drop the buffer support for better performance.
- * This option is recommanded to be enabled when "hiredis" parser is used.
- * Refer to https://github.com/luin/ioredis/wiki/Improve-Performance for more details.
  * @param {boolean} [options.enableReadyCheck=true] - When a connection is established to
  * the Redis server, the server might still be loading the database from disk.
  * While loading, the server not respond to any commands.
@@ -82,8 +78,6 @@ var commands = require('redis-commands');
  * Only available for cluster mode.
  * @param {boolean} [options.stringNumbers=false] - Force numbers to be always returned as JavaScript
  * strings. This option is necessary when dealing with big numbers (exceed the [-2^53, +2^53] range).
- * Notice that when this option is enabled, the JavaScript parser will be used even "hiredis" is specified
- * because only JavaScript parser supports this feature for the time being.
  * @extends [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)
  * @extends Commander
  * @example
@@ -171,7 +165,6 @@ Redis.defaultOptions = {
   password: null,
   db: 0,
   // Others
-  parser: null,
   dropBufferSupport: false,
   enableOfflineQueue: true,
   enableReadyCheck: true,

--- a/lib/redis/parser.js
+++ b/lib/redis/parser.js
@@ -18,7 +18,6 @@ exports.initParser = function () {
   var _this = this;
 
   this.replyParser = new Parser({
-    name: this.options.parser,
     stringNumbers: this.options.stringNumbers,
     returnBuffers: !this.options.dropBufferSupport,
     returnError: function (err) {
@@ -33,12 +32,6 @@ exports.initParser = function () {
       _this.disconnect(true);
     }
   });
-
-  if (this.replyParser.name === 'hiredis' && !this.options.dropBufferSupport) {
-    console.warn('[WARN] ioredis is using hiredis parser, however "dropBufferSupport" is disabled. ' +
-     'It\'s highly recommanded to enable this option. ' +
-     'Refer to https://github.com/luin/ioredis/wiki/Improve-Performance for more details.');
-  }
 };
 
 exports.returnError = function (err) {

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "codeclimate-test-reporter": "0.3.1",
+    "codeclimate-test-reporter": "0.4.0",
     "cz-conventional-changelog": "^1.1.5",
     "istanbul": "^0.4.2",
     "jsdoc": "^3.4.0",
-    "jsdoc-to-markdown": "^1.3.3",
+    "jsdoc-to-markdown": "^2.0.0",
     "matcha": "^0.7.0",
-    "mocha": "^2.4.5",
+    "mocha": "^3.1.1",
     "redis": "^2.4.2",
     "server-destroy": "^1.0.1",
     "sinon": "^1.17.3"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "flexbuffer": "0.0.6",
     "lodash": "^4.8.2",
     "redis-commands": "^1.2.0",
-    "redis-parser": "^1.3.0"
+    "redis-parser": "^2.0.4"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/helpers/mock_server.js
+++ b/test/helpers/mock_server.js
@@ -29,7 +29,6 @@ MockServer.prototype.connect = function () {
     });
 
     var parser = new Parser({
-      name: 'javascript',
       returnBuffers: true,
       returnReply: function (reply) {
         reply = utils.convertBufferToString(reply);


### PR DESCRIPTION
there is no many differences between redis-parser 1.3.0 with 2.0.x(on the API level)

but since it's a huge fundamental change, it's better to be careful.

ref #342 
