### PR TITLE
restrict files included in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-*.cpuprofile
-/test.js
-logo.svg
-medis.png

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.4.0",
   "description": "A delightful, performance-focused Redis client for Node and io.js",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "lib/"
+  ],
   "scripts": {
     "test": "NODE_ENV=test mocha",
     "test:cov": "NODE_ENV=test node ./node_modules/istanbul/lib/cli.js cover --preserve-comments ./node_modules/mocha/bin/_mocha -- -R spec",


### PR DESCRIPTION
Currently, the npm package contains the following:
```
benchmarks/
bin/
examples/
lib/
node_modules/
test/
.eslintrc
.npmignore
.travis.yml
API.md
Changelog.md
index.js
LICENSE
package.json
README.md
test_sentinel.js
```

Would it make sense to restrict it to the following?
```
lib/
Changelog.md
index.js
LICENSE
package.json
README.md
```

Edit: it should be easier than tracking each file :innocent: (https://github.com/luin/ioredis/pull/378/commits/1df3da92f72f252a0b0e70ba3983ead18027b985)