### PR TITLE
Quit immediately when reconnecting

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -579,6 +579,12 @@ Redis.prototype.sendCommand = function (command, stream) {
     return command.promise;
   }
 
+  if (!writable && command.name === 'quit' && this.offlineQueue.length === 0) {
+    this.disconnect();
+    command.resolve(new Buffer('OK'));
+    return command.promise;
+  }
+
   if (writable) {
     debug('write command[%d] -> %s(%s)', this.condition.select, command.name, command.args);
     (stream || this.stream).write(command.toWritable());

--- a/test/functional/connection.js
+++ b/test/functional/connection.js
@@ -146,6 +146,38 @@ describe('connection', function () {
         }
       });
     });
+
+    it('should skip reconnecting if quitting before connecting', function (done) {
+      var count = 0;
+      var redis = new Redis({
+        port: 8999,
+        retryStrategy: function () {
+          count++;
+        }
+      });
+
+      redis.quit().then(function (result) {
+        expect(result).to.eql('OK');
+        expect(count).to.eql(0);
+        done();
+      });
+    });
+
+    it('should skip reconnecting if quitting before connecting (buffer)', function (done) {
+      var count = 0;
+      var redis = new Redis({
+        port: 8999,
+        retryStrategy: function () {
+          count++;
+        }
+      });
+
+      redis.quitBuffer().then(function (result) {
+        expect(result).to.be.instanceof(Buffer);
+        expect(result.toString()).to.eql('OK');
+        done();
+      });
+    });
   });
 
   describe('connectionName', function () {


### PR DESCRIPTION
I'm not sure if this is the right approach but the idea is to be able to quit immediately when `redis.quit()` is called and the client is in the reconnecting state. In this case, `quit()` should not have to wait for the connection to be ready.

What do you think?