### PR TITLE
Add support for non-clustered replication without Sentinel

### DIFF
--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -439,7 +439,10 @@ Cluster.prototype.sendCommand = function (command, stream, node) {
     }
   }
 
-  var targetSlot = node ? node.slot : command.getSlot();
+  var targetSlot = false;
+  if (!this.options.replication) {
+    targetSlot = node ? node.slot : command.getSlot();
+  }
   var ttl = {};
   var _this = this;
   if (!node && !command.__is_reject_overwritten) {

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -168,12 +168,16 @@ Cluster.prototype.connect = function () {
     this.once('close', closeListener);
     this.once('close', this._handleCloseEvent.bind(this));
 
-    this.refreshSlotsCache(function (err) {
-      if (err && err.message === 'Failed to refresh slots cache.') {
-        Redis.prototype.silentEmit.call(this, 'error', err);
-        this.connectionPool.reset([]);
-      }
-    }.bind(this));
+    if (!this.options.replication) {
+      this.refreshSlotsCache(function (err) {
+        if (err && err.message === 'Failed to refresh slots cache.') {
+          Redis.prototype.silentEmit.call(this, 'error', err);
+          this.connectionPool.reset([]);
+        }
+      }.bind(this));
+    } else {
+      this.emit('refresh');
+    }
     this.selectSubscriber();
   }.bind(this));
 };

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -490,7 +490,7 @@ Cluster.prototype.sendCommand = function (command, stream, node) {
       return;
     }
     var redis;
-    if (_this.status === 'ready' || (command.name === 'cluster')) {
+    if (_this.status === 'ready' || (command.name === 'cluster') || _this.options.replication) {
       if (node && node.redis) {
         redis = node.redis;
       } else if (Command.checkFlag('ENTER_SUBSCRIBER_MODE', command.name) ||

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -624,31 +624,41 @@ Cluster.prototype.getInfoFromNode = function (redis, callback) {
  * @private
  */
 Cluster.prototype._readyCheck = function (callback) {
-  this.cluster('info', function (err, res) {
-    if (err) {
-      return callback(err);
-    }
-    if (typeof res !== 'string') {
-      return callback();
-    }
-
-    var state;
-    var lines = res.split('\r\n');
-    for (var i = 0; i < lines.length; ++i) {
-      var parts = lines[i].split(':');
-      if (parts[0] === 'cluster_state') {
-        state = parts[1];
-        break;
+  if (this.options.replication) {
+    Redis.prototype._readyCheck.call(this, function (err, info) {
+      if (err) {
+        return callback(err);
+      } else {
+        return callback();
       }
-    }
+    });
+  } else {
+    this.cluster('info', function (err, res) {
+      if (err) {
+        return callback(err);
+      }
+      if (typeof res !== 'string') {
+        return callback();
+      }
 
-    if (state === 'fail') {
-      debug('cluster state not ok (%s)', state);
-      callback(null, state);
-    } else {
-      callback();
-    }
-  });
+      var state;
+      var lines = res.split('\r\n');
+      for (var i = 0; i < lines.length; ++i) {
+        var parts = lines[i].split(':');
+        if (parts[0] === 'cluster_state') {
+          state = parts[1];
+          break;
+        }
+      }
+
+      if (state === 'fail') {
+        debug('cluster state not ok (%s)', state);
+        callback(null, state);
+      } else {
+        callback();
+      }
+    });
+  }
 };
 
 ['sscan', 'hscan', 'zscan', 'sscanBuffer', 'hscanBuffer', 'zscanBuffer']

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -478,7 +478,8 @@ Cluster.prototype.sendCommand = function (command, stream, node) {
       });
     };
   }
-  tryConnection();
+  // always select random instance if replication is enabled
+  this.options.replication ? tryConnection(true) : tryConnection();
 
   function tryConnection(random, asking) {
     if (_this.status === 'end') {

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -101,6 +101,7 @@ Cluster.defaultOptions = {
   enableReadyCheck: true,
   scaleReads: 'master',
   maxRedirections: 16,
+  replication: false,
   retryDelayOnFailover: 100,
   retryDelayOnClusterDown: 100,
   retryDelayOnTryAgain: 100

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -574,12 +574,12 @@ Cluster.prototype.handleError = function (error, ttl, handlers) {
   } else if (errv[0] === 'CLUSTERDOWN' && this.options.retryDelayOnClusterDown > 0) {
     this.delayQueue.push('clusterdown', handlers.connectionClosed, {
       timeout: this.options.retryDelayOnClusterDown,
-      callback: this.refreshSlotsCache.bind(this)
+      callback: this.options.replication ? function () { this.emit('refresh'); }.bind(this) : this.refreshSlotsCache.bind(this)
     });
   } else if (error.message === utils.CONNECTION_CLOSED_ERROR_MSG && this.options.retryDelayOnFailover > 0) {
     this.delayQueue.push('failover', handlers.connectionClosed, {
       timeout: this.options.retryDelayOnFailover,
-      callback: this.refreshSlotsCache.bind(this)
+      callback: this.options.replication ? function () { this.emit('refresh'); }.bind(this) : this.refreshSlotsCache.bind(this)
     });
   } else {
     handlers.defaults();

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -211,7 +211,7 @@ Pipeline.prototype.exec = function (callback) {
     this.resolve([]);
   }
   var pipelineSlot, i;
-  if (this.isCluster) {
+  if (this.isCluster && !this.options.replication) {
     // List of the first key for each command
     var sampleKeys = [];
     for (i = 0; i < this._queue.length; i++) {


### PR DESCRIPTION
Hi!

I have made a few modifications to Cluster class to enable the support for replication cluster (which is intended to solve: https://github.com/luin/ioredis/issues/387).
I tried it in a project which I have a Redis cluster setup which doesn't use sharding but replication (master-slave full replicas) and it seems to work properly.

I would very much appreciate feedback about this feature and my resolution and I hope this branch gets merged some day so that we can all benefit from it and gets maintained.