### PR TITLE
Add a default port for sentinel connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ var redis = new Redis({
 
 ## Sentinel
 ioredis supports Sentinel out of the box. It works transparently as all features that work when
-you connect to a single node also work when you connect to a sentinel group. Make sure to run Redis >= 2.8.12 if you want to use this feature.
+you connect to a single node also work when you connect to a sentinel group. Make sure to run Redis >= 2.8.12 if you want to use this feature. Sentinels have a default port of 26379.
 
 To connect using Sentinel, use:
 

--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -210,7 +210,7 @@ SentinelConnector.prototype.resolve = function (endpoint, callback) {
     Redis = require('../redis');
   }
   var client = new Redis({
-    port: endpoint.port,
+    port: endpoint.port || 26379,
     host: endpoint.host,
     retryStrategy: null,
     enableReadyCheck: false,
@@ -232,7 +232,7 @@ function noop() {}
 
 function isSentinelEql(a, b) {
   return ((a.host || '127.0.0.1') === (b.host || '127.0.0.1')) &&
-    ((a.port || 6379) === (b.port || 6379));
+    ((a.port || 26379) === (b.port || 26379));
 }
 
 module.exports = SentinelConnector;

--- a/test/functional/sentinel.js
+++ b/test/functional/sentinel.js
@@ -18,6 +18,22 @@ describe('sentinel', function () {
 
     });
 
+    it('should default to the default sentinel port', function (done) {
+      var sentinel = new MockServer(26379);
+      sentinel.once('connect', function () {
+        redis.disconnect();
+        sentinel.disconnect(done);
+      });
+
+      var redis = new Redis({
+        sentinels: [
+          { host: '127.0.0.1' }
+        ],
+        name: 'master'
+      });
+
+    });
+
     it('should try to connect to all sentinel', function (done) {
       var sentinel = new MockServer(27380);
       sentinel.once('connect', function () {


### PR DESCRIPTION
Also add a few helpful notes to the README. This came from some frustrations I had the first time I setup a project to talk to sentinels.