### PR TITLE
fix: report error on Sentinel connection refused (#445)

### DIFF
--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -74,7 +74,6 @@ SentinelConnector.prototype.connect = function (callback) {
     _this.resolve(endpoint, function (err, resolved) {
       if (!_this.connecting) {
         callback(new Error(utils.CONNECTION_CLOSED_ERROR_MSG));
-        callback(new Error(utils.CONNECTION_CLOSED_ERROR_MSG));
         return;
       }
       if (resolved) {

--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -28,7 +28,7 @@ SentinelConnector.prototype.check = function (info) {
   return true;
 };
 
-SentinelConnector.prototype.connect = function (callback, errorEmitter) {
+SentinelConnector.prototype.connect = function (callback, eventEmitter) {
   this.connecting = true;
   this.retryAttempts = 0;
 
@@ -65,7 +65,7 @@ SentinelConnector.prototype.connect = function (callback, errorEmitter) {
       debug('All sentinels are unreachable. Retrying from scratch after %d', retryDelay);
       error = 'All sentinels are unreachable, retrying...';
       setTimeout(connectToNext, retryDelay);
-      errorEmitter(new Error(error));
+      eventEmitter('error', new Error(error));
       return;
     }
 
@@ -80,13 +80,13 @@ SentinelConnector.prototype.connect = function (callback, errorEmitter) {
         callback(null, _this.stream);
       } else if (err) {
         debug('failed to connect to sentinel %s:%s because %s', endpoint.host, endpoint.port, err);
-        errorEmitter(new Error('failed to connect to sentinel '+endpoint.host+':'+endpoint.port+' because '+err));
+        eventEmitter('sentinelError', new Error('failed to connect to sentinel '+endpoint.host+':'+endpoint.port+' because '+err));
         lastError = err;
         connectToNext();
       } else {
         debug('connected to sentinel %s:%s successfully, but got a invalid reply: %s',
           endpoint.host, endpoint.port, resolved);
-        errorEmitter(new Error('connected to sentinel '+endpoint.host+':'+endpoint.port+' successfully, but got a invalid reply: '+resolved));
+        eventEmitter('sentinelError', new Error('connected to sentinel '+endpoint.host+':'+endpoint.port+' successfully, but got a invalid reply: '+resolved));
         connectToNext();
       }
     });

--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -48,26 +48,32 @@ SentinelConnector.prototype.connect = function (callback) {
     if (_this.currentPoint === _this.sentinels.length) {
       _this.currentPoint = -1;
 
+      var error;
       var retryDelay;
       if (typeof _this.options.sentinelRetryStrategy === 'function') {
         retryDelay = _this.options.sentinelRetryStrategy(++_this.retryAttempts);
       }
+
       if (typeof retryDelay !== 'number') {
         debug('All sentinels are unreachable and retry is disabled, emitting error...');
-        var error = 'All sentinels are unreachable.';
-        if (lastError) {
-          error += ' Last error: ' + lastError.message;
-        }
-        return callback(new Error(error));
+        error = 'All sentinels are unreachable.';
+      } else {
+        debug('All sentinels are unreachable. Retrying from scratch after %d', retryDelay);
+        error = 'All sentinels are unreachable, retrying...';
+        setTimeout(connectToNext, retryDelay);
       }
-      debug('All sentinels are unreachable. Retrying from scratch after %d', retryDelay);
-      setTimeout(connectToNext, retryDelay);
-      return;
+
+      if (lastError) {
+        error += ' Last error: ' + lastError.message;
+      }
+      return callback(new Error(error));
+
     }
 
     var endpoint = _this.sentinels[_this.currentPoint];
     _this.resolve(endpoint, function (err, resolved) {
       if (!_this.connecting) {
+        callback(new Error(utils.CONNECTION_CLOSED_ERROR_MSG));
         callback(new Error(utils.CONNECTION_CLOSED_ERROR_MSG));
         return;
       }

--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -28,7 +28,7 @@ SentinelConnector.prototype.check = function (info) {
   return true;
 };
 
-SentinelConnector.prototype.connect = function (callback) {
+SentinelConnector.prototype.connect = function (callback, errorEmitter) {
   this.connecting = true;
   this.retryAttempts = 0;
 
@@ -57,17 +57,16 @@ SentinelConnector.prototype.connect = function (callback) {
       if (typeof retryDelay !== 'number') {
         debug('All sentinels are unreachable and retry is disabled, emitting error...');
         error = 'All sentinels are unreachable.';
-      } else {
-        debug('All sentinels are unreachable. Retrying from scratch after %d', retryDelay);
-        error = 'All sentinels are unreachable, retrying...';
-        setTimeout(connectToNext, retryDelay);
+        if (lastError) {
+            error += ' Last error: ' + lastError.message;
+        }
+        return callback(new Error(error));
       }
-
-      if (lastError) {
-        error += ' Last error: ' + lastError.message;
-      }
-      return callback(new Error(error));
-
+      debug('All sentinels are unreachable. Retrying from scratch after %d', retryDelay);
+      error = 'All sentinels are unreachable, retrying...';
+      setTimeout(connectToNext, retryDelay);
+      errorEmitter(new Error(error));
+      return;
     }
 
     var endpoint = _this.sentinels[_this.currentPoint];
@@ -77,15 +76,19 @@ SentinelConnector.prototype.connect = function (callback) {
         return;
       }
       if (resolved) {
+
+
         _this.stream = net.createConnection(resolved);
         callback(null, _this.stream);
       } else if (err) {
         debug('failed to connect to sentinel %s:%s because %s', endpoint.host, endpoint.port, err);
+        errorEmitter(new Error('failed to connect to sentinel '+endpoint.host+':'+endpoint.port+' because '+err));
         lastError = err;
         connectToNext();
       } else {
         debug('connected to sentinel %s:%s successfully, but got a invalid reply: %s',
           endpoint.host, endpoint.port, resolved);
+        errorEmitter(new Error('connected to sentinel '+endpoint.host+':'+endpoint.port+' successfully, but got a invalid reply: '+resolved));
         connectToNext();
       }
     });

--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -58,7 +58,7 @@ SentinelConnector.prototype.connect = function (callback, errorEmitter) {
         debug('All sentinels are unreachable and retry is disabled, emitting error...');
         error = 'All sentinels are unreachable.';
         if (lastError) {
-            error += ' Last error: ' + lastError.message;
+          error += ' Last error: ' + lastError.message;
         }
         return callback(new Error(error));
       }
@@ -76,8 +76,6 @@ SentinelConnector.prototype.connect = function (callback, errorEmitter) {
         return;
       }
       if (resolved) {
-
-
         _this.stream = net.createConnection(resolved);
         callback(null, _this.stream);
       } else if (err) {

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -311,8 +311,8 @@ Redis.prototype.connect = function (callback) {
       };
       _this.once(CONNECT_EVENT, connectionConnectHandler);
       _this.once('close', connectionCloseHandler);
-    }, function(err) {
-      _this.silentEmit('error', err);
+    }, function(type, err) {
+      _this.silentEmit(type, err);
     });
   }.bind(this)).nodeify(callback);
 };

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -311,6 +311,8 @@ Redis.prototype.connect = function (callback) {
       };
       _this.once(CONNECT_EVENT, connectionConnectHandler);
       _this.once('close', connectionCloseHandler);
+    }, function(err) {
+      _this.silentEmit('error', err);
     });
   }.bind(this)).nodeify(callback);
 };


### PR DESCRIPTION
This is a quick fix to report on a sentinel cluster not being able to connect. 
This will also report retries in `redis.on('end', ...` for subsequent retries of the Sentinel cluster, this behavior is similar to what happens on a failed connection with a single redis instance.
This is the quickest fix I could think of.