### PR TITLE
command: handle errors to avoid `Unhandled rejection Errors`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -79,6 +79,12 @@ Command.prototype.initPromise = function () {
       _this.reject = reject;
     }
   }).nodeify(this.callback);
+
+  this.promise.catch(function (err) {
+    if (typeof _this.callback === 'function') {
+      _this.callback(err);
+    }
+  });
 };
 
 Command.prototype.getSlot = function () {


### PR DESCRIPTION
I added the commit to get rid of `Unhandled rejection Errors` which can occur when issuing a `quit` call to the client, for instance.

I don't normally use promises, hence I cannot vouch for correctness here.

PS: I am currently using v2.5.0 of ioredis