### PR TITLE
Allow connection to IPv6-only sentinels

### DIFF
--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -226,6 +226,7 @@ SentinelConnector.prototype.resolve = function (endpoint, callback) {
   var client = new Redis({
     port: endpoint.port || 26379,
     host: endpoint.host,
+    family: endpoint.family || this.options.family,
     retryStrategy: null,
     enableReadyCheck: false,
     connectTimeout: this.options.connectTimeout,


### PR DESCRIPTION
Hey there. It seems that when sentinels are IPv6-only, there's currently no way to connect to them: the "family" option doesn't apply. This PR fixes the situation.