### PR TITLE
stop mutating the arguments when calling multi

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -180,10 +180,12 @@ Pipeline.prototype.sendCommand = function (command) {
 };
 
 Pipeline.prototype.addBatch = function (commands) {
+  var command, commandName, args;
   for (var i = 0; i < commands.length; ++i) {
-    var command = commands[i];
-    var commandName = command.shift();
-    this[commandName].apply(this, command);
+    command = commands[i];
+    commandName = command[0];
+    args = command.slice(1);
+    this[commandName].apply(this, args);
   }
 
   return this;


### PR DESCRIPTION
This copies the arguments for a multi command instead of mutating the passed in arrays. This allows users to log the commands that gave an error if the multi command errors.