### PR TITLE
Add documentation for slotsRefreshTimeout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,7 @@ but a few so that if one is unreachable the client will try the next one, and th
     * `retryDelayOnTryAgain`: If this option is a number (by default, it is `100`), the client
     will resend the commands rejected with `TRYAGAIN` error after the specified time (in ms).
     * `redisOptions`: Default options passed to the constructor of `Redis` when connecting to a node.
+    * `slotsRefreshTimeout`: Milliseconds before a timeout occurs while refreshing slots from the cluster (default `1000`)
 
 ### Read-write splitting
 

--- a/README.md
+++ b/README.md
@@ -702,7 +702,8 @@ but a few so that if one is unreachable the client will try the next one, and th
           return delay;
         }
         ```
-    It' possible to modify the `startupNodes` property in order to switch to another set of nodes here:
+
+        It's possible to modify the `startupNodes` property in order to switch to another set of nodes here:
 
         ```javascript
         function (times) {


### PR DESCRIPTION
This P/R offers some minor changes to the README. Most importantly (to me, anyway) to add missing documentation for a helpful setting when connecting to a cluster.

* Adds README doc for `slotsRefreshTimeout`, added in https://github.com/luin/ioredis/pull/475
* And a minor formatting tweak / typo fix in the `startupNodes` example, also in the Cluster section of the README

Let me know if you have any feedback.  Thanks!

-Ben