### PR TITLE
Disconnect error when connecting to a db > 0

### DIFF
--- a/test/functional/connection.js
+++ b/test/functional/connection.js
@@ -74,6 +74,24 @@ describe('connection', function () {
     });
   });
 
+  it.only('can handle next tick disconnects on non db:0', function (done) {
+    var redis = new Redis({ db: 1 });
+    process.on('unhandledRejection', function (err, promise) {
+      console.log('found unhandled error')
+      done(err);
+    })
+
+    redis.on('error', function (err)  { // never emitted
+      console.log('error event', err)
+      done(err)
+    })
+
+    process.nextTick(function () {
+      redis.disconnect();
+      done();
+    })
+  })
+
   describe('#connect', function () {
     it('should return a promise', function (done) {
       var pending = 2;


### PR DESCRIPTION
This test only fails when using a db other than 0

This is the stack from the error
```
Unhandled rejection Error: Connection is closed.
    at close (/Users/wizard/src/ioredis/lib/redis/event_handler.js:101:21)
    at Socket.<anonymous> (/Users/wizard/src/ioredis/lib/redis/event_handler.js:76:14)
    at Socket.g (events.js:292:16)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at TCP._handle.close [as _onclose] (net.js:497:12)
```

I get this debug output
```
  ioredis:redis status[127.0.0.1:6379]: connect -> close +0ms
  ioredis:connection skip reconnecting since the connection is manually closed. +1ms
  ioredis:redis status[127.0.0.1:6379]: close -> end +0ms
```

The `select` command is the obvious culprit but I can't follow the connection logic well enough to know how to have it detect the disconnecting/disconnected state.