### PR TITLE
Handle stunnel options with sentinels

### DIFF
--- a/lib/connectors/sentinel_connector.js
+++ b/lib/connectors/sentinel_connector.js
@@ -80,6 +80,8 @@ SentinelConnector.prototype.connect = function (callback, eventEmitter) {
       }
       if (resolved) {
         debug('resolved: %s:%s', resolved.host, resolved.port);
+        resolved = _this.stunnel(resolved);
+        debug('resolved: %s:%s', resolved.host, resolved.port);
         _this.stream = net.createConnection(resolved);
         callback(null, _this.stream);
       } else {
@@ -241,6 +243,20 @@ SentinelConnector.prototype.resolve = function (endpoint, callback) {
   } else {
     this.resolveMaster(client, callback);
   }
+};
+
+SentinelConnector.prototype.stunnel = function (endpoint) {
+  if (this.options.stunnel) {
+    var resolved;
+    _.each(this.options.stunnel, function(stunnel) {
+      if (endpoint.host === stunnel.redisHost && endpoint.port === stunnel.redisPort) {
+        resolved =  { host: stunnel.stunnelHost, port: stunnel.stunnelPort };
+        return false;
+      }
+    });
+    return resolved;
+  }
+  else { return endpoint; }
 };
 
 function noop() {}


### PR DESCRIPTION
It would be great if ioredis could handle stunnel configuration when using sentinels.
If you pass in stunnel configuration data which is used on the resolve host/port after the sentinel has returned the Redis master IP address. You can not connect directly back to the Redis master as you need to go back through stunnel again. This allows you to pass your stunnel configuration and the correct stunnel port will be selected on your localhost. The example below assumes you are running three Redis servers.

new ioredis(
{
  sentinels: [{ host: 'localhost', port: 26379 }, { host: 'localhost', port: 26380 }],
  name: 'mymaster',
  stunnel: [ 
   { redisHost: 'ip-redis1', redisPort: 6379, stunnelHost: 'localhost', stunnelPort: 6381 },
   { redisHost: 'ip-redis2', redisPort: 6379, stunnelHost: 'localhost', stunnelPort: 6382 },
   { redisHost: 'ip-redis3', redisPort: 6379, stunnelHost: 'localhost', stunnelPort: 6383 },
  ]
});