### PR TITLE
Allow convertObjectToArray to handle objects with no prototype

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -170,10 +170,10 @@ exports.timeout = function (callback, timeout) {
  */
 exports.convertObjectToArray = function (obj) {
   var result = [];
-  for (var key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      result.push(key, obj[key]);
-    }
+  var keys = Object.keys(obj);
+
+  for (var i = 0, l = keys.length; i < l; i++) {
+    result.push(keys[i], obj[keys[i]]);
   }
   return result;
 };

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -82,6 +82,9 @@ describe('utils', function () {
 
   describe('.convertObjectToArray', function () {
     it('should return correctly', function () {
+      var nullObject = Object.create(null);
+      nullObject.abc = 'def';
+      expect(utils.convertObjectToArray(nullObject)).to.eql(['abc', 'def']);
       expect(utils.convertObjectToArray({ 1: 2 })).to.eql(['1', 2]);
       expect(utils.convertObjectToArray({ 1: '2' })).to.eql(['1', '2']);
       expect(utils.convertObjectToArray({ 1: '2', abc: 'def' })).to.eql(['1', '2', 'abc', 'def']);


### PR DESCRIPTION
Currently this method expects `hasOwnProperty` to exist on the passed object. By using the method on `Object.prototype` instead, objects created with `Object.create(null)` can also be properly handled.

Ran into this bug trying to pass graphQL input objects (heavily uses `Object.create(null)`) directly to hmset commands