### PR TITLE
Update debug to v2.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "bluebird": "^3.3.4",
     "cluster-key-slot": "^1.0.6",
-    "debug": "^2.2.0",
+    "debug": "^2.6.9",
     "denque": "^1.1.0",
     "flexbuffer": "0.0.6",
     "lodash.assign": "^4.2.0",


### PR DESCRIPTION
In order to close a low-severity ReDoS vulnerability, the debug
module should be updated to at least v2.6.9

See https://nodesecurity.io/advisories/534 for more information