### PR TITLE
Allow Monitor clients to be named

### DIFF
--- a/lib/redis/event_handler.js
+++ b/lib/redis/event_handler.js
@@ -120,6 +120,11 @@ exports.readyHandler = function (self) {
     self.setStatus('ready');
     self.retryAttempts = 0;
 
+    if (self.options.connectionName) {
+      debug('set the connection name [%s]', self.options.connectionName);
+      self.client('setname', self.options.connectionName);
+    }
+
     if (self.options.monitor) {
       self.call('monitor');
       var sendCommand = self.sendCommand;
@@ -138,11 +143,6 @@ exports.readyHandler = function (self) {
     }
     var item;
     var finalSelect = self.prevCondition ? self.prevCondition.select : self.condition.select;
-
-    if (self.options.connectionName) {
-      debug('set the connection name [%s]', self.options.connectionName);
-      self.client('setname', self.options.connectionName);
-    }
 
     if (self.options.readOnly) {
       debug('set the connection to readonly mode');


### PR DESCRIPTION
We are setting up some tools to monitor the health and activity of Redis and could not name a Monitoring client. This fixes that issue and lets the monitoring client be named just like rest of the client threads.

There is still some awkwardness in the naming process but at least it can be done after this change.