### PR TITLE
fix(redis): attach connection handlers to stream events

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -309,8 +309,8 @@ Redis.prototype.connect = function (callback) {
         _this.removeListener(CONNECT_EVENT, connectionConnectHandler);
         reject(new Error(utils.CONNECTION_CLOSED_ERROR_MSG));
       };
-      stream.once(CONNECT_EVENT, connectionConnectHandler);
-      stream.once('close', connectionCloseHandler);
+      _this.once('connect', connectionConnectHandler);
+      _this.once('close', connectionCloseHandler);
     }, function (type, err) {
       _this.silentEmit(type, err);
     });

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -309,8 +309,8 @@ Redis.prototype.connect = function (callback) {
         _this.removeListener(CONNECT_EVENT, connectionConnectHandler);
         reject(new Error(utils.CONNECTION_CLOSED_ERROR_MSG));
       };
-      _this.once(CONNECT_EVENT, connectionConnectHandler);
-      _this.once('close', connectionCloseHandler);
+      stream.once(CONNECT_EVENT, connectionConnectHandler);
+      stream.once('close', connectionCloseHandler);
     }, function (type, err) {
       _this.silentEmit(type, err);
     });

--- a/test/unit/redis.js
+++ b/test/unit/redis.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Socket = require('net').Socket;
+var Connector = require('../../lib/connectors/connector');
 var Promise = require('bluebird');
 
 describe('Redis', function () {
@@ -145,6 +147,34 @@ describe('Redis', function () {
       flushQueue.call(redis, new Error(), { commandQueue: false });
       offline.verify();
       command.verify();
+    });
+  });
+
+  describe('#connect', function () {
+    it('should resolve the connect promise on plain connections', function (done) {
+      var mockedStream = new Socket();
+      var connectStub = stub(Connector.prototype, 'connect');
+
+      new Redis({ lazyConnect: true })
+        .connect()
+        .then(done)
+        .finally(connectStub.restore);
+
+      connectStub.callArgWith(0, null, mockedStream);
+      mockedStream.emit('connect');
+    });
+
+    it('should resolve the connect promise on TLS connections', function (done) {
+      var mockedStream = new Socket();
+      var connectStub = stub(Connector.prototype, 'connect');
+
+      new Redis({ lazyConnect: true, tls: true })
+        .connect()
+        .then(done)
+        .finally(connectStub.restore);
+
+      connectStub.callArgWith(0, null, mockedStream);
+      mockedStream.emit('secureConnect');
     });
   });
 });


### PR DESCRIPTION
Hi,

Currently the connect() promise doesn't resolves after the connect event. Attaching the event handlers to the socket will solves this issue.

All the best,
Istvan