### PR TITLE
Add NAT support for redis cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,19 @@ var redis = new Redis({
 });
 ```
 
+```javascript
+var cluster = new Redis.Cluster(nodesList, {
+  redisOptions: {
+    tls: {
+      // Refer to `tls.connect()` section in
+      // https://nodejs.org/api/tls.html
+      // for all supported options
+      ca: fs.readFileSync('cert.pem')
+    }
+  }
+});
+```
+
 <hr>
 
 ## Sentinel
@@ -744,6 +757,7 @@ but a few so that if one is unreachable the client will try the next one, and th
     will resend the commands rejected with `TRYAGAIN` error after the specified time (in ms).
     * `redisOptions`: Default options passed to the constructor of `Redis` when connecting to a node.
     * `slotsRefreshTimeout`: Milliseconds before a timeout occurs while refreshing slots from the cluster (default `1000`)
+    * `natRemap`: Remap each node's `host:port` key to a NAT endpoint. See: [`CLUSTER NODES`](https://redis.io/commands/cluster-nodes). Example: `natRemap: { 'xxxx-cache-0001-001.xxxx-cache.xx.xxxx1.cache.amazonaws.com:6379': { host: '13.8.8.8', port: 6380 } }`
 
 ### Read-write splitting
 

--- a/lib/cluster/connection_pool.js
+++ b/lib/cluster/connection_pool.js
@@ -6,9 +6,10 @@ var EventEmitter = require('events').EventEmitter;
 var _ = require('../utils/lodash');
 var Redis = require('../redis');
 
-function ConnectionPool(redisOptions) {
+function ConnectionPool(redisOptions, natRemap) {
   EventEmitter.call(this);
   this.redisOptions = redisOptions;
+  this.natRemap = natRemap;
 
   // master + slave = all
   this.nodes = {
@@ -31,7 +32,7 @@ util.inherits(ConnectionPool, EventEmitter);
  * @public
  */
 ConnectionPool.prototype.findOrCreate = function (node, readOnly) {
-  setKey(node);
+  setKey(node, this.natRemap);
   readOnly = Boolean(readOnly);
 
   if (this.specifiedOptions[node.key]) {
@@ -108,7 +109,7 @@ ConnectionPool.prototype.reset = function (nodes) {
     }
     delete options.db;
 
-    setKey(options);
+    setKey(options, this.natRemap);
     newNodes[options.key] = options;
   }, this);
 
@@ -128,11 +129,20 @@ ConnectionPool.prototype.reset = function (nodes) {
  *
  * @private
  */
-function setKey(node) {
+function setKey(node, natRemap) {
+  natRemap = natRemap || {};
   node = node || {};
   node.port = node.port || 6379;
   node.host = node.host || '127.0.0.1';
   node.key = node.key || node.host + ':' + node.port;
+
+  // Remap node host & port from `cluster.nodes()` to NAT endpoints
+  if (node.key in natRemap) {
+    var mapping = natRemap[node.key];
+    node.port = mapping.port || 6379;
+    node.host = mapping.host || '127.0.0.1';
+  }
+
   return node;
 }
 

--- a/lib/cluster/index.js
+++ b/lib/cluster/index.js
@@ -54,7 +54,7 @@ function Cluster(startupNodes, options) {
       '". Expected "all", "master", "slave" or a custom function');
   }
 
-  this.connectionPool = new ConnectionPool(this.options.redisOptions);
+  this.connectionPool = new ConnectionPool(this.options.redisOptions, this.options.natRemap);
   this.startupNodes = startupNodes;
 
   var _this = this;


### PR DESCRIPTION
Add support for redis clusters than are behind Network Address Translation (NAT).
This is useful for scenarios like this: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/accessing-elasticache.html#access-from-outside-aws