### PR TITLE
 fix(Cluster): issues when setting enableOfflineQueue to false

### DIFF
--- a/lib/cluster/connection_pool.js
+++ b/lib/cluster/connection_pool.js
@@ -46,7 +46,7 @@ ConnectionPool.prototype.findOrCreate = function (node, readOnly) {
     redis = this.nodes.all[node.key];
     if (redis.options.readOnly !== readOnly) {
       redis.options.readOnly = readOnly;
-      debug('Change role of %s to %s', node.key, readOnly ? 'slave' : 'master')
+      debug('Change role of %s to %s', node.key, readOnly ? 'slave' : 'master');
       redis[readOnly ? 'readonly' : 'readwrite']().catch(_.noop);
       if (readOnly) {
         delete this.nodes.master[node.key];
@@ -59,7 +59,14 @@ ConnectionPool.prototype.findOrCreate = function (node, readOnly) {
   } else {
     debug('Connecting to %s as %s', node.key, readOnly ? 'slave' : 'master');
     redis = new Redis(_.defaults({
+      // Never try to reconnect when a node is lose,
+      // instead, waiting for a `MOVED` error and
+      // fetch the slots again.
       retryStrategy: null,
+      // Offline queue should be enabled so that
+      // we don't need to wait for the `ready` event
+      // before sending commands to the node.
+      enableOfflineQueue: true,
       readOnly: readOnly
     }, node, this.redisOptions, { lazyConnect: true }));
     this.nodes.all[node.key] = redis;


### PR DESCRIPTION
Offline queue should be enabled on the internal cluster nodes so that we don't need to wait for the `ready` event before sending commands to the node.

That doesn't cause issue when the node is lost, since the `retryStrategy` is null, so when a node is lost, the status become `end` and the further commands will be rejected.