### PR TITLE
Update connection_pool.js

### DIFF
--- a/lib/cluster/connection_pool.js
+++ b/lib/cluster/connection_pool.js
@@ -59,10 +59,6 @@ ConnectionPool.prototype.findOrCreate = function (node, readOnly) {
   } else {
     debug('Connecting to %s as %s', node.key, readOnly ? 'slave' : 'master');
     redis = new Redis(_.defaults({
-      // Never try to reconnect when a node is lose,
-      // instead, waiting for a `MOVED` error and
-      // fetch the slots again.
-      retryStrategy: null,
       // Offline queue should be enabled so that
       // we don't need to wait for the `ready` event
       // before sending commands to the node.


### PR DESCRIPTION
Do not force `retryStrategy` to be `null`.  If the node had simply restarted, then ioredis may never reconnect to this node.  Waiting for a `MOVED` error to appear to trigger a reconnect is a false assumption as a `MOVED` error may never appear - especially in simple node restart scenarios.