### PR TITLE
Remove io.js from description in readme and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![Join the chat at https://gitter.im/luin/ioredis](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/luin/ioredis?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-A robust, performance-focused and full-featured [Redis](http://redis.io) client for [Node](https://nodejs.org) and [io.js](https://iojs.org).
+A robust, performance-focused and full-featured [Redis](http://redis.io) client for [Node.js](https://nodejs.org).
 
 Supports Redis >= 2.6.12 and (Node.js >= 6).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ioredis",
   "version": "4.0.0-2",
-  "description": "A delightful, performance-focused Redis client for Node and io.js",
+  "description": "A robust, performance-focused and full-featured Redis client for Node.js.",
   "main": "built/index.js",
   "files": [
     "index.js",


### PR DESCRIPTION
This change makes the description in the readme and on npm line up with the repo description.

io.js isn't even supported any more, and references to it make the project sound dated or unmaintained.