### PR TITLE
Updated package.json to require node >=6

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "^2.9.2"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
The changelog for 4.0.0 states that node <6 isn't supported so this updates package.json to reflect that.