### PR TITLE
Support cluster via NAT

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -621,6 +621,10 @@ class Cluster extends EventEmitter {
           this.slots[slot] = keys
         }
       }
+      
+      if (this.options && typeof this.options.processNodes === 'function') {
+        this.options.processNodes(nodes);
+      }
 
       this.connectionPool.reset(nodes)
       callback()


### PR DESCRIPTION
Allow user to update cluster nodes on the fly, e.g. applying a host map for NAT connections