### PR TITLE
fix(cluster): handle connection errors by reconnection

### DIFF
--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -16,7 +16,7 @@ export interface IClusterOptions {
    *
    * @default (times) => Math.min(100 + times * 2, 2000)
    */
-  clusterRetryStrategy?: (times: number) => number | null
+  clusterRetryStrategy?: (times: number, reason?: Error) => number | null
 
   /**
    * See Redis class.


### PR DESCRIPTION
Closes #753.

Previously, exceptions caused by DNS resolving will not trigger any reconnections and fail silently. That makes errors much harder to be handled. This fix catches these exceptions and triggers a reconnection to keep the same behaviors as v3.