### PR TITLE
feat: allow TLS when using Sentinel

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -84,6 +84,8 @@ var PromiseContainer = require('./promiseContainer');
  * Only available for cluster mode.
  * @param {boolean} [options.stringNumbers=false] - Force numbers to be always returned as JavaScript
  * strings. This option is necessary when dealing with big numbers (exceed the [-2^53, +2^53] range).
+ * @param {boolean} [options.enableTLSForSentinelMode=false] - Whether to support the `tls` option
+ * when connecting to Redis via sentinel mode.
  * @extends [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)
  * @extends Commander
  * @example
@@ -168,6 +170,7 @@ Redis.defaultOptions = {
   sentinelRetryStrategy: function (times) {
     return Math.min(times * 10, 1000);
   },
+  enableTLSForSentinelMode: false,
   // Status
   password: null,
   db: 0,
@@ -273,6 +276,9 @@ Redis.prototype.connect = function (callback) {
         return;
       }
       var CONNECT_EVENT = options.tls ? 'secureConnect' : 'connect';
+      if (options.sentinels && !options.enableTLSForSentinelMode) {
+        CONNECT_EVENT = 'connect';
+      }
 
       _this.stream = stream;
       if (typeof options.keepAlive === 'number') {

--- a/test/functional/tls.js
+++ b/test/functional/tls.js
@@ -1,0 +1,96 @@
+'use strict'
+import * as tls from 'tls'
+import * as net from 'net'
+
+describe('tls option', () => {
+  describe('Standalone', () => {
+    it('supports tls', (done) => {
+      let redis
+
+      stub(tls, 'connect', (op) => {
+        expect(op.ca).to.eql('123')
+        expect(op.port).to.eql(6379)
+        const stream = net.createConnection(op)
+        stream.on('connect', data => {
+          stream.emit('secureConnect', data)
+        })
+        return stream
+      })
+
+      redis = new Redis({tls: {ca: '123'}})
+      redis.on('ready', () => {
+        redis.disconnect()
+        tls.connect.restore()
+        redis.on('end', () => done())
+      })
+    })
+  })
+
+  describe('Sentinel', () => {
+    it('does not use tls option by default', (done) => {
+      new MockServer(27379, function (argv) {
+        if (argv[0] === 'sentinel' && argv[1] === 'get-master-addr-by-name') {
+          return ['127.0.0.1', '6379']
+        }
+      });
+
+      stub(tls, 'connect', () => {
+        throw new Error('called')
+      })
+
+      const redis = new Redis({sentinels: [{port: 27379}], name: 'my', tls: {ca: '123'}})
+      redis.on('ready', () => {
+        redis.disconnect()
+        tls.connect.restore()
+        done()
+      })
+    })
+
+    it('can be enabled by `enableTLSForSentinelMode`', (done) => {
+      new MockServer(27379, function (argv) {
+        if (argv[0] === 'sentinel' && argv[1] === 'get-master-addr-by-name') {
+          return ['127.0.0.1', '6379']
+        }
+      });
+
+      let redis
+
+      stub(tls, 'connect', (op) => {
+        expect(op.ca).to.eql('123')
+        redis.disconnect()
+        tls.connect.restore()
+        process.nextTick(done)
+        return tls.connect(op)
+      })
+
+      redis = new Redis({sentinels: [{port: 27379}], name: 'my', tls: {ca: '123'}, enableTLSForSentinelMode: true})
+    })
+
+    it('supports sentinelTLS', (done) => {
+      new MockServer(27379, function (argv) {
+        if (argv[0] === 'sentinel' && argv[1] === 'get-master-addr-by-name') {
+          return ['127.0.0.1', '6379']
+        }
+      });
+
+      let redis
+
+      stub(tls, 'connect', (op) => {
+        expect(op.ca).to.eql('123')
+        expect(op.port).to.eql(27379)
+        const stream = net.createConnection(op)
+        stream.on('connect', data => {
+          stream.emit('secureConnect', data)
+        })
+        return stream
+      })
+
+      redis = new Redis({sentinels: [{port: 27379}], name: 'my', sentinelTLS: {ca: '123'}})
+      redis.on('ready', () => {
+        redis.disconnect()
+        tls.connect.restore()
+        redis.on('end', () => done())
+      })
+    })
+  })
+})


### PR DESCRIPTION
Two options added: `enableTLSForSentinelMode` & `sentinelTLS`