### PR TITLE
fix(Cluster): ignore connection errors for subscriber.

### DIFF
--- a/lib/cluster/ClusterSubscriber.ts
+++ b/lib/cluster/ClusterSubscriber.ts
@@ -74,6 +74,9 @@ export default class ClusterSubscriber {
       lazyConnect: true
     })
 
+    // Ignore the errors since they're handled in the connection pool.
+    this.subscriber.on('error', noop)
+
     // Re-subscribe previous channels
     var previousChannels = { subscribe: [], psubscribe: [] }
     if (lastActiveSubscriber) {


### PR DESCRIPTION
The errors will be caught by connection pool and a new election will be made when the current subscriber
is lost, so we can safely ignore these errors.

Fix #768