### PR TITLE
fix: add second arg to "node error" to know which node failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,7 +898,7 @@ reconnecting | emits after `close` when a reconnection will be made. The argumen
 end     | emits after `close` when no more reconnections will be made.
 +node   | emits when a new node is connected.
 -node   | emits when a node is disconnected.
-node error | emits when an error occurs when connecting to a node
+node error | emits when an error occurs when connecting to a node. The second argument indicates the address of the node.
 
 ### Password
 Setting the `password` option to access password-protected clusters:

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -374,7 +374,8 @@ class Cluster extends EventEmitter {
         return wrapper(error)
       }
       const node = nodes[index]
-      debug('getting slot cache from %s:%s', node.options.host, node.options.port)
+      const key = `${node.options.host}:${node.options.port}`
+      debug('getting slot cache from %s', key)
       _this.getInfoFromNode(node, function (err) {
         switch (_this.status) {
           case 'close':
@@ -384,7 +385,7 @@ class Cluster extends EventEmitter {
             return wrapper(new Error('Cluster is disconnecting.'))
         }
         if (err) {
-          _this.emit('node error', err, `${node.options.host}:${node.options.port}`)
+          _this.emit('node error', err, key)
           lastNodeError = err
           tryNode(index + 1)
         } else {

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -87,8 +87,8 @@ class Cluster extends EventEmitter {
     this.connectionPool.on('drain', () => {
       this.setStatus('close')
     })
-    this.connectionPool.on('nodeError', (error) => {
-      this.emit('node error', error)
+    this.connectionPool.on('nodeError', (error, key) => {
+      this.emit('node error', error, key)
     })
 
     this.subscriber = new ClusterSubscriber(this.connectionPool, this)
@@ -384,7 +384,7 @@ class Cluster extends EventEmitter {
             return wrapper(new Error('Cluster is disconnecting.'))
         }
         if (err) {
-          _this.emit('node error', err)
+          _this.emit('node error', err, `${node.options.host}:${node.options.port}`)
           lastNodeError = err
           tryNode(index + 1)
         } else {

--- a/test/functional/cluster/connect.js
+++ b/test/functional/cluster/connect.js
@@ -271,8 +271,9 @@ describe('cluster:connect', function () {
       }
     });
 
-    cluster.once('node error', function (err) {
+    cluster.once('node error', function (err, key) {
       expect(err.message).to.eql(errorMessage);
+      expect(['127.0.0.1:30001', '127.0.0.1:30002']).to.include(key)
       checkDone();
     });
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 --reporter spec
 --recursive
---growl


### PR DESCRIPTION
Fixes: #774