### PR TITLE
support Sentinel instances with authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,7 @@ redis.set('foo', 'bar');
 The arguments passed to the constructor are different from the ones you use to connect to a single node, where:
 
 * `name` identifies a group of Redis instances composed of a master and one or more slaves (`mymaster` in the example);
+* `sentinelPassword` (optional) password for Sentinel instances.
 * `sentinels` are a list of sentinels to connect to. The list does not need to enumerate all your sentinel instances, but a few so that if one is down the client will try the next one.
 * `role` (optional) with a value of `slave` will return a random slave from the Sentinel group.
 * `preferredSlaves` (optional) can be used to prefer a particular slave or set of slaves based on priority. It accepts a function or array.

--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -25,6 +25,7 @@ type PreferredSlaves =
 interface ISentinelConnectionOptions extends ITcpConnectionOptions {
   role: 'master' | 'slave'
   name: 'string'
+  sentinelPasseword?: 'string'
   sentinels: Array<ISentinelAddress>
   sentinelRetryStrategy?: (retryAttempts: number) => number
   preferredSlaves?: PreferredSlaves
@@ -219,6 +220,7 @@ export default class SentinelConnector extends AbstractConnector {
     var client = new Redis({
       port: endpoint.port || 26379,
       host: endpoint.host,
+      password: this.options.sentinelPasseword || null,
       family: endpoint.family || (isIIpcConnectionOptions(this.options) ? undefined : this.options.family),
       tls: this.options.sentinelTLS,
       retryStrategy: null,

--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -25,7 +25,7 @@ type PreferredSlaves =
 interface ISentinelConnectionOptions extends ITcpConnectionOptions {
   role: 'master' | 'slave'
   name: 'string'
-  sentinelPasseword?: 'string'
+  sentinelPassword?: 'string'
   sentinels: Array<ISentinelAddress>
   sentinelRetryStrategy?: (retryAttempts: number) => number
   preferredSlaves?: PreferredSlaves

--- a/test/functional/sentinel.js
+++ b/test/functional/sentinel.js
@@ -124,7 +124,6 @@ describe('sentinel', function () {
         name: 'master'
       });
     });
-
     it('should add additionally discovered sentinels when resolving successfully', function (done) {
 
       var sentinels = [
@@ -186,7 +185,25 @@ describe('sentinel', function () {
         name: 'master'
       });
     });
+    it('should connect to sentinel with authentication successfully', function (done) {
+      var sentinel = new MockServer(27379, function (argv) {
+        if (argv[0] === 'auth' && argv[1] === 'pass') {
+          authed = true;
+        }
+      });
+      sentinel.once('connect', function () {
+        redis.disconnect();
+        sentinel.disconnect(done);
+      });
 
+      var redis = new Redis({
+        sentinelPassword: 'pass',
+        sentinels: [
+          { host: '127.0.0.1', port: '27379' }
+        ],
+        name: 'master'
+      });
+    });
   });
 
   describe('master', function () {


### PR DESCRIPTION
According to the [document](https://redis.io/topics/sentinel), Sentinel instances with authentication has been available since redis version 5.0.1.

I would like to support it.

Would you confirm this PR.