### PR TITLE
fix: use flexbuffer from GH with License

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1033,9 +1033,8 @@
       }
     },
     "flexbuffer": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/flexbuffer/-/flexbuffer-0.0.6.tgz",
-      "integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA="
+      "version": "github:mercadolibre/flexbuffer-node#1487df393a30872e3e81b246711a4cf6b0b23314",
+      "from": "github:mercadolibre/flexbuffer-node#1487df393a30872e3e81b246711a4cf6b0b23314"
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cluster-key-slot": "^1.0.6",
     "debug": "^3.1.0",
     "denque": "^1.1.0",
-    "flexbuffer": "0.0.6",
+    "flexbuffer": "github:mercadolibre/flexbuffer-node#1487df393a30872e3e81b246711a4cf6b0b23314",
     "lodash.defaults": "^4.2.0",
     "lodash.flatten": "^4.4.0",
     "redis-commands": "1.4.0",


### PR DESCRIPTION
Due to the distributed npm package not having `License` file embedded, the package contents shouldn't be used.

But one can install directly from the GH repository... and everything is 🎉 and ☀️ back again.