### PR TITLE
Switches from flexbuffer to flexbuffer2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1032,9 +1032,10 @@
         "test-value": "^3.0.0"
       }
     },
-    "flexbuffer": {
-      "version": "github:mercadolibre/flexbuffer-node#1487df393a30872e3e81b246711a4cf6b0b23314",
-      "from": "github:mercadolibre/flexbuffer-node#1487df393a30872e3e81b246711a4cf6b0b23314"
+    "flexbuffer2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flexbuffer2/-/flexbuffer2-1.0.0.tgz",
+      "integrity": "sha512-1G2gs7A2Ck+BpadZyg7R0XvWe0H3erR29DdDMsYF02OI9Wm6lyOOwGNf++bQ4pfKescZrbHZAvtXeng09Ofx6A=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cluster-key-slot": "^1.0.6",
     "debug": "^3.1.0",
     "denque": "^1.1.0",
-    "flexbuffer": "github:mercadolibre/flexbuffer-node#1487df393a30872e3e81b246711a4cf6b0b23314",
+    "flexbuffer2": "^1.0.0",
     "lodash.defaults": "^4.2.0",
     "lodash.flatten": "^4.4.0",
     "redis-commands": "1.4.0",


### PR DESCRIPTION
@kuba-kubula is correct in #821 that we shouldn't use the package without a license. However, linking directly to a git repo has added a new dependency on **git**.

As an alternate solution, I've forked **flexbuffer** and created a modernized drop-in replacement.