### PR TITLE
fix: switches from flexbuffer to flexbuffer2

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -1,4 +1,4 @@
-import * as fbuffer from 'flexbuffer'
+import * as fbuffer from 'flexbuffer2'
 import * as commands from 'redis-commands'
 import * as calculateSlot from 'cluster-key-slot'
 import asCallback from 'standard-as-callback'

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -278,7 +278,7 @@ Pipeline.prototype.exec = function (callback: CallbackFunction) {
   }).then(execPipeline)
 
   function execPipeline() {
-    let data: FlexBuffer | string = ''
+    let data: FlexBuffer | Buffer | string = ''
     let writePending: number = _this.replyPending = _this._queue.length
 
     let node
@@ -303,7 +303,7 @@ Pipeline.prototype.exec = function (callback: CallbackFunction) {
         }
         if (!--writePending) {
           if (bufferMode) {
-            data = data.getBuffer()
+            data = (data as FlexBuffer).getBuffer()
           }
           if (_this.isCluster) {
             node.redis.stream.write(data)

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -1,5 +1,5 @@
 import Command from './command'
-import {FlexBuffer} from 'flexbuffer'
+import {FlexBuffer} from 'flexbuffer2'
 import {deprecate} from 'util'
 import asCallback from 'standard-as-callback'
 import {exists, hasFlag} from 'redis-commands'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1033,9 +1033,9 @@
       }
     },
     "flexbuffer2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/flexbuffer2/-/flexbuffer2-1.0.1.tgz",
-      "integrity": "sha512-64afD5dAqicJz3neWxlnv35exoaARo5egC5mUy4L+PcWCIq7v30h1zEktMEie3cRCvuwcpJ7Cu3IEHk2gzEp6w=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flexbuffer2/-/flexbuffer2-1.0.2.tgz",
+      "integrity": "sha512-SgodDga2R2PWiR90kP21x9tYcfAEiSl9hTD+fAcd5TQxGHVHgh4HbGhmdDWBTCbZ76NzQRLPoGLIbHeU4wBPDQ=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1032,9 +1032,10 @@
         "test-value": "^3.0.0"
       }
     },
-    "flexbuffer": {
-      "version": "github:mercadolibre/flexbuffer-node#1487df393a30872e3e81b246711a4cf6b0b23314",
-      "from": "github:mercadolibre/flexbuffer-node#1487df393a30872e3e81b246711a4cf6b0b23314"
+    "flexbuffer2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/flexbuffer2/-/flexbuffer2-1.0.1.tgz",
+      "integrity": "sha512-64afD5dAqicJz3neWxlnv35exoaARo5egC5mUy4L+PcWCIq7v30h1zEktMEie3cRCvuwcpJ7Cu3IEHk2gzEp6w=="
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cluster-key-slot": "^1.0.6",
     "debug": "^3.1.0",
     "denque": "^1.1.0",
-    "flexbuffer2": "^1.0.1",
+    "flexbuffer2": "^1.0.2",
     "lodash.defaults": "^4.2.0",
     "lodash.flatten": "^4.4.0",
     "redis-commands": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cluster-key-slot": "^1.0.6",
     "debug": "^3.1.0",
     "denque": "^1.1.0",
-    "flexbuffer": "github:mercadolibre/flexbuffer-node#1487df393a30872e3e81b246711a4cf6b0b23314",
+    "flexbuffer2": "^1.0.1",
     "lodash.defaults": "^4.2.0",
     "lodash.flatten": "^4.4.0",
     "redis-commands": "1.4.0",


### PR DESCRIPTION
@kuba-kubula is correct in #821 that we shouldn't use the package without a license. However, linking directly to a git repo has added a new dependency on **git**.

As an alternate solution, I've forked **flexbuffer** and created a modernized drop-in replacement.
