### PR TITLE
fix: handle non-utf8 command name

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -220,7 +220,7 @@ export default class Command {
     }
 
     let result
-    let commandStr = '*' + (this.args.length + 1) + '\r\n$' + this.name.length + '\r\n' + this.name + '\r\n'
+    let commandStr = '*' + (this.args.length + 1) + '\r\n$' + Buffer.byteLength(this.name) + '\r\n' + this.name + '\r\n'
     if (bufferMode) {
       const buffers = new MixedBuffers();
       buffers.push(commandStr);

--- a/test/functional/send_command.js
+++ b/test/functional/send_command.js
@@ -217,6 +217,7 @@ describe('send command', function () {
     } catch(e) {
       err = e.message
     }
-    expect(err).to.contain(`unknown command \`${invalidCommand}\``)
+    expect(err).to.contain('unknown command')
+    expect(err).to.contain(invalidCommand)
   })
 });

--- a/test/functional/send_command.js
+++ b/test/functional/send_command.js
@@ -207,4 +207,16 @@ describe('send command', function () {
       });
     });
   });
+
+  it('throws for invalid command', async () => {
+    const redis = new Redis()
+    const invalidCommand = 'áéűáű'
+    let err
+    try {
+      await redis.call(invalidCommand, [])
+    } catch(e) {
+      err = e.message
+    }
+    expect(err).to.contain(`unknown command \`${invalidCommand}\``)
+  })
 });


### PR DESCRIPTION
This commit uses Buffer.byteLength() insteand of String#length to handle non-utf8 command names.

Close #862