### PR TITLE
fix: pipeline with transactions causes unhandled warnings

### DIFF
--- a/lib/transaction.ts
+++ b/lib/transaction.ts
@@ -31,6 +31,12 @@ export function addTransactionSupport (redis) {
       if (this._transactions > 0) {
         exec.call(pipeline)
       }
+
+      // Returns directly when the pipeline
+      // has been called multiple times (retries).
+      if (this.nodeifiedPromise) {
+        return exec.call(pipeline)
+      }
       const promise = exec.call(pipeline)
       return asCallback(promise.then(function (result) {
         const execResult = result[result.length - 1]


### PR DESCRIPTION
`Pipeline#exec()` is a little tricky: it has an init process when called first time (indicated by whether `Pipeline#nodeifiedPromise` is true). `Transaction#exec()` is similar to that, it also has an init process that parse the result from `Pipeline#exec()` before returning to users. However, `#nodeifiedPromise` is not checked here, so it may fail which causes the unhandled warnings when retries.

Closes: #883.

To be frank, it also take me a lot of time in order to understand the code, especially the complex relation between Pipeline & Transaction. We indeed need to do a refactor on this.