### PR TITLE
fix(cluster): reorder defaults arguments to prioritize user options

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -68,6 +68,7 @@ class Cluster extends EventEmitter {
 
     this.startupNodes = startupNodes
     this.options = defaults(this.options, options, DEFAULT_CLUSTER_OPTIONS)
+    this.options = defaults({}, options, DEFAULT_CLUSTER_OPTIONS, this.options)
 
     // validate options
     if (typeof this.options.scaleReads !== 'function' &&

--- a/test/unit/cluster.js
+++ b/test/unit/cluster.js
@@ -15,10 +15,15 @@ describe('cluster', function () {
   it('should support frozen options', function () {
     var options = Object.freeze({ maxRedirections: 1000 });
     var cluster = new Cluster([{ port: 7777 }], options);
-    expect(cluster.options).to.have.property('showFriendlyErrorStack', false);
+    expect(cluster.options).to.have.property('maxRedirections', 1000);
     expect(cluster.options).to.have.property('showFriendlyErrorStack', false);
     expect(cluster.options).to.have.property('scaleReads', 'master');
   });
+
+  it('should allow overriding Commander options', function () {
+    const cluster = new Cluster([{ port: 7777 }], {showFriendlyErrorStack: true});
+    expect(cluster.options).to.have.property('showFriendlyErrorStack', true);
+  })
 
   it('throws when scaleReads is invalid', function () {
     expect(function () {


### PR DESCRIPTION
Addresses the issue noted in https://github.com/luin/ioredis/issues/883#issuecomment-499959143