### PR TITLE
Update API doc and README regarding dnsLookup attribute

### DIFF
--- a/API.md
+++ b/API.md
@@ -230,6 +230,7 @@ Creates a Redis Cluster instance
 | startupNodes | <code>Array.&lt;Object&gt;</code> |  | An array of nodes in the cluster, [{ port: number, host: string }] |
 | options | <code>Object</code> |  |  |
 | [options.clusterRetryStrategy] | <code>function</code> |  | See "Quick Start" section |
+| [options.dnsLookup] | <code>function(hostname, function(err, addr, family))<code> | <code>[dns.lookup](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback)</code> | Function used to resolve DNS hostnames of Redis cluster members. |
 | [options.enableOfflineQueue] | <code>boolean</code> | <code>true</code> | See Redis class |
 | [options.enableReadyCheck] | <code>boolean</code> | <code>true</code> | When enabled, ioredis only emits "ready" event when `CLUSTER INFO` command reporting the cluster is ready for handling commands. |
 | [options.scaleReads] | <code>string</code> | <code>&quot;master&quot;</code> | Scale reads to the node with the specified role. Available values are "master", "slave" and "all". |

--- a/README.md
+++ b/README.md
@@ -774,6 +774,7 @@ but a few so that if one is unreachable the client will try the next one, and th
         }
         ```
 
+    * `dnsLookup`: Alternative DNS lookup function (`dns.lookup()` is used by default).  It may be useful to override this in special cases, such as when AWS ElastiCache used with TLS enabled.
     * `enableOfflineQueue`: Similar to the `enableOfflineQueue` option of `Redis` class.
     * `enableReadyCheck`: When enabled, "ready" event will only be emitted when `CLUSTER INFO` command
     reporting the cluster is ready for handling commands. Otherwise, it will be emitted immediately after "connect" is emitted.
@@ -929,6 +930,27 @@ var cluster = new Redis.Cluster([
     password: 'fallback-password'
   }
 });
+```
+
+### Special note: AWS ElastiCache Clusters with TLS
+
+AWS ElastiCache for Redis (Clustered Mode) supports TLS encryption.  If you use
+this, you may encounter errors with invalid certificates.  To resolve this
+issue, construct the `Cluster` with the `dnsLookup` option as follows:
+
+```javascript
+var cluster = new Redis.Cluster(
+  [{
+    host: 'clustercfg.myCluster.abcdefg.xyz.cache.amazonaws.com',
+    port: 6379
+  }],
+  {
+    dnsLookup: (address, callback) => callback(null, address),
+    redisOptions: {
+      tls: {}
+    },
+  }
+};
 ```
 
 <hr>


### PR DESCRIPTION
Document `dnsLookup` attribute to `Cluster` constructor.
Fixes #892.