### PR TITLE
Use connector as class not value

### DIFF
--- a/examples/custom_connector.js
+++ b/examples/custom_connector.js
@@ -23,7 +23,7 @@ class AsyncSentinelConnector extends Redis.SentinelConnector {
 }
 
 const redis = new Redis({
-  connector: new AsyncSentinelConnector()
+  Connector: AsyncSentinelConnector
 });
 
 // ioredis supports all Redis commands:

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -6,7 +6,7 @@ import {ICommanderOptions} from '../commander';
 export type ReconnectOnError = (err: Error) => boolean | 1 | 2;
 
 export interface IRedisOptions extends Partial<ISentinelConnectionOptions>, Partial<ICommanderOptions>, Partial<IClusterOptions> {
-    connector?: AbstractConnector,
+    Connector?: typeof AbstractConnector,
     retryStrategy?: (times: number) => number | void | null,
     keepAlive?: number,
     noDelay?: boolean,

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -54,7 +54,7 @@ export function connectHandler(self) {
           }
         } else {
           self.serverInfo = info;
-          if (self.options.connector.check(info)) {
+          if (self.connector.check(info)) {
             exports.readyHandler(self)();
           } else {
             self.disconnect(true);

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -132,12 +132,12 @@ function Redis() {
   this.resetCommandQueue();
   this.resetOfflineQueue();
 
-  if (!this.options.connector) {
-    if (this.options.sentinels) {
-      this.options.connector = new SentinelConnector(this.options);
-    } else {
-      this.options.connector = new StandaloneConnector(this.options);
-    }
+  if (this.options.Connector) {
+    this.connector = new this.options.Connector(this.options);
+  } else if (this.options.sentinels) {
+    this.connector = new SentinelConnector(this.options);
+  } else {
+    this.connector = new StandaloneConnector(this.options);
   }
 
   this.retryAttempts = 0;
@@ -251,7 +251,7 @@ Redis.prototype.connect = function (callback) {
     };
 
     var _this = this;
-    asCallback(options.connector.connect(function (type, err) {
+    asCallback(this.connector.connect(function (type, err) {
       _this.silentEmit(type, err);
     }), function (err, stream) {
       if (err) {
@@ -345,7 +345,7 @@ Redis.prototype.disconnect = function (reconnect) {
   if (this.status === 'wait') {
     eventHandler.closeHandler(this)();
   } else {
-    this.options.connector.disconnect();
+    this.connector.disconnect();
   }
 };
 


### PR DESCRIPTION
Fixes https://github.com/luin/ioredis/pull/907#issuecomment-505545220

Realized that options was being passed through from an internal object, not the one I passed in, hence internal instantiation is needed.