### PR TITLE
feat: add cluster.duplicate() method

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -386,6 +386,29 @@ class Cluster extends EventEmitter {
   }
 
   /**
+   * Create a new instance with the same startup nodes and options as the current one.
+   *
+   * @example
+   * ```js
+   * var cluster = new Redis.Cluster([{ host: "127.0.0.1", port: "30001" }]);
+   * var anotherCluster = cluster.duplicate();
+   * ```
+   *
+   * @public
+   * @param {(Array<string | number | object>)} [overrideStartupNodes=[]]
+   * @param {IClusterOptions} [overrideOptions={}]
+   * @memberof Cluster
+   */
+  public duplicate(overrideStartupNodes = [], overrideOptions = {}) {
+    const startupNodes =
+      overrideStartupNodes.length > 0
+        ? overrideStartupNodes
+        : this.startupNodes.slice(0);
+    const options = Object.assign({}, this.options, overrideOptions);
+    return new Cluster(startupNodes, options);
+  }
+
+  /**
    * Get nodes with the specified role
    *
    * @param {NodeRole} [role='all']

--- a/test/functional/cluster/duplicate.ts
+++ b/test/functional/cluster/duplicate.ts
@@ -1,0 +1,21 @@
+import MockServer from "../../helpers/mock_server";
+import { Cluster } from "../../../lib";
+import { expect } from "chai";
+
+describe("cluster:duplicate", () => {
+  it("clone the options", done => {
+    var node = new MockServer(30001);
+    var cluster = new Cluster([]);
+    var duplicatedCluster = cluster.duplicate([
+      { host: "127.0.0.1", port: "30001" }
+    ]);
+
+    node.once("connect", function() {
+      expect(duplicatedCluster.nodes()).to.have.lengthOf(1);
+      expect(duplicatedCluster.nodes()[0].options.port).to.eql(30001);
+      cluster.disconnect();
+      duplicatedCluster.disconnect();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Hi,

See https://github.com/luin/ioredis/issues/921. This PR adds the missing `cluster.duplicate()` method.

Notes:
- I'm using `this.startupNodes.slice(0)` to ensure we pass a copy and not a reference. This matches the behavior of the options, which also get a copy thanks to `Object.assign()`.
- I'm not sure this new test I added is being executed when running `npm test`. I don't see it in the mocha output. It works as expected when I run ` npx mocha test/functional/cluster/duplicate.ts`, could someone please validate?