### PR TITLE
Supports rediss:// URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ new Redis({
 });
 ```
 
-You can also specify connection options as a [`redis://` URL](http://www.iana.org/assignments/uri-schemes/prov/redis):
+You can also specify connection options as a [`redis://` URL](http://www.iana.org/assignments/uri-schemes/prov/redis) or [`rediss://` URL](https://www.iana.org/assignments/uri-schemes/prov/rediss) when using [TLS encryption](#tls-options):
 
 ```javascript
 // Connect to 127.0.0.1:6380, db 4, using password "authpassword":
@@ -701,6 +701,12 @@ var redis = new Redis({
     ca: fs.readFileSync("cert.pem")
   }
 });
+```
+
+Alternatively, specify the connection through a [`rediss://` URL](https://www.iana.org/assignments/uri-schemes/prov/rediss).
+
+```javascript
+var redis = new Redis("rediss://redis.my-service.com");
 ```
 
 <hr>

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -110,6 +110,7 @@ var debug = Debug("redis");
  * var unixSocketRedis2 = new Redis('/tmp/echo.sock');
  * var urlRedis = new Redis('redis://user:password@redis-service.com:6379/');
  * var urlRedis2 = new Redis('//localhost:6379');
+ * var urlRedisTls = new Redis('rediss://user:password@redis-service.com:6379/');
  * var authedRedis = new Redis(6380, '192.168.100.1', { password: 'password' });
  * ```
  */

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -260,7 +260,7 @@ export function parseURL(url) {
     result.password = parsed.auth.split(":")[1];
   }
   if (parsed.pathname) {
-    if (parsed.protocol === "redis:") {
+    if (parsed.protocol === "redis:" || parsed.protocol === "rediss:") {
       if (parsed.pathname.length > 1) {
         result.db = parsed.pathname.slice(1);
       }
@@ -273,6 +273,9 @@ export function parseURL(url) {
   }
   if (parsed.port) {
     result.port = parsed.port;
+  }
+  if (parsed.protocol === "rediss:") {
+    result.tls = true;
   }
   defaults(result, parsed.query);
 

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -192,6 +192,16 @@ describe("utils", function() {
       expect(utils.parseURL("redis://127.0.0.1/")).to.eql({
         host: "127.0.0.1"
       });
+      expect(
+        utils.parseURL("rediss://user:pass@127.0.0.1:6380/4?key=value")
+      ).to.eql({
+        tls: true,
+        host: "127.0.0.1",
+        port: "6380",
+        db: "4",
+        password: "pass",
+        key: "value"
+      });
     });
   });
 


### PR DESCRIPTION
Support [`rediss://` URL](https://www.iana.org/assignments/uri-schemes/prov/rediss) (Redis over TLS) by defaulting option `tls: true` for those URLs.

Fixes #846