### PR TITLE
fix: Don’t clobber passed-in tls options with rediss:/ URLs

### DIFF
--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -192,6 +192,7 @@ Redis.prototype.resetOfflineQueue = function() {
 
 Redis.prototype.parseOptions = function() {
   this.options = {};
+  let isTls = false;
   for (var i = 0; i < arguments.length; ++i) {
     var arg = arguments[i];
     if (arg === null || typeof arg === "undefined") {
@@ -201,11 +202,17 @@ Redis.prototype.parseOptions = function() {
       defaults(this.options, arg);
     } else if (typeof arg === "string") {
       defaults(this.options, parseURL(arg));
+      if (arg.startsWith("rediss://")) {
+        isTls = true;
+      }
     } else if (typeof arg === "number") {
       this.options.port = arg;
     } else {
       throw new Error("Invalid argument " + arg);
     }
+  }
+  if (isTls) {
+    defaults(this.options, { tls: true });
   }
   defaults(this.options, Redis.defaultOptions);
 

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -274,9 +274,6 @@ export function parseURL(url) {
   if (parsed.port) {
     result.port = parsed.port;
   }
-  if (parsed.protocol === "rediss:") {
-    result.tls = true;
-  }
   defaults(result, parsed.query);
 
   return result;

--- a/test/unit/redis.ts
+++ b/test/unit/redis.ts
@@ -80,6 +80,14 @@ describe("Redis", function() {
           host: "192.168.1.1"
         });
         expect(option).to.have.property("port", 6380);
+
+        option = getOption("rediss://host");
+        expect(option).to.have.property("tls", true);
+
+        option = getOption("rediss://example.test", {
+          tls: { hostname: "example.test" }
+        });
+        expect(option.tls).to.deep.equal({ hostname: "example.test" });
       } catch (err) {
         stub.restore();
         throw err;

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -195,7 +195,6 @@ describe("utils", function() {
       expect(
         utils.parseURL("rediss://user:pass@127.0.0.1:6380/4?key=value")
       ).to.eql({
-        tls: true,
         host: "127.0.0.1",
         port: "6380",
         db: "4",


### PR DESCRIPTION
Fix #940. Alternative to #942.