### PR TITLE
Bugfix for ssl handshake + socket hangup errors

### DIFF
--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -305,7 +305,7 @@ Redis.prototype.connect = function(callback) {
         }
 
         stream.once(CONNECT_EVENT, eventHandler.connectHandler(_this));
-        stream.once("error", eventHandler.errorHandler(_this));
+        stream.on("error", eventHandler.errorHandler(_this));
         stream.once("close", eventHandler.closeHandler(_this));
 
         if (options.connectTimeout) {


### PR DESCRIPTION
* changing the `once()` to `on()` to prevent the first error from removing the listener and causing the second event to be an unhandled error event.
* Added unit test for multiple errors emitting from socket
