### PR TITLE
fix: generate declaration files d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ext .js,.ts .",
     "format": "prettier --write \"{,!(node_modules)/**/}*.{js,ts}\"",
     "format-check": "prettier --check \"{,!(node_modules)/**/}*.{js,ts}\"",
-    "build": "rm -rf built && tsc",
+    "build": "rm -rf built && tsc --declaration",
     "prepublishOnly": "npm run build && npm test",
     "bench": "matcha benchmarks/*.js",
     "semantic-release": "semantic-release"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./built",
-    "allowJs": true,
+    "allowJs": false,
     "target": "es6",
     "lib": ["es6"],
     "moduleResolution": "node",
@@ -9,8 +9,5 @@
     "typeRoots": ["node_modules/@types"],
     "module": "commonjs"
   },
-  "include": [
-    "./lib/**/*"
-    ]
+  "include": ["./lib/**/*"]
 }
-


### PR DESCRIPTION
Related #968 

Now that ioredis is in TypeScript, we can set `allowJs` to false, let `tsc` generates declaration files `d.ts` and publish it to npm.

after:

![image](https://user-images.githubusercontent.com/627278/65941974-8028f900-e456-11e9-94e1-59d02804b332.png)
