### PR TITLE
Include all runtime errors in transaction result

### DIFF
--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -179,9 +179,9 @@ export default class SentinelConnector extends AbstractConnector {
       }
 
       result
-        .map<IAddressFromResponse>(packObject as (
-          value: any
-        ) => IAddressFromResponse)
+        .map<IAddressFromResponse>(
+          packObject as (value: any) => IAddressFromResponse
+        )
         .forEach(sentinel => {
           const flags = sentinel.flags ? sentinel.flags.split(",") : [];
           if (
@@ -248,9 +248,9 @@ export default class SentinelConnector extends AbstractConnector {
       }
 
       const availableSlaves = result
-        .map<IAddressFromResponse>(packObject as (
-          value: any
-        ) => IAddressFromResponse)
+        .map<IAddressFromResponse>(
+          packObject as (value: any) => IAddressFromResponse
+        )
         .filter(
           slave =>
             slave.flags && !slave.flags.match(/(disconnected|s_down|o_down)/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,9 +2680,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha1-aCPnxZAAF7S9Os9G/prEtNe9qeo=",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "pretty-quick": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "husky": "^2.5.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.0.0",
-    "prettier": "^1.18.2",
+    "prettier": "^1.19.1",
     "pretty-quick": "^1.11.1",
     "server-destroy": "^1.0.1",
     "sinon": "^7.3.2",

--- a/test/functional/cluster/connect.ts
+++ b/test/functional/cluster/connect.ts
@@ -224,7 +224,10 @@ describe("cluster:connect", function() {
   it("should send command to the correct node", function(done) {
     new MockServer(30001, function(argv) {
       if (argv[0] === "cluster" && argv[1] === "slots") {
-        return [[0, 1, ["127.0.0.1", 30001]], [2, 16383, ["127.0.0.1", 30002]]];
+        return [
+          [0, 1, ["127.0.0.1", 30001]],
+          [2, 16383, ["127.0.0.1", 30002]]
+        ];
       }
     });
     new MockServer(30002, function(argv) {

--- a/test/functional/cluster/index.ts
+++ b/test/functional/cluster/index.ts
@@ -29,7 +29,10 @@ describe("cluster", function() {
   it("should get value successfully", function(done) {
     new MockServer(30001, function(argv) {
       if (argv[0] === "cluster" && argv[1] === "slots") {
-        return [[0, 1, ["127.0.0.1", 30001]], [2, 16383, ["127.0.0.1", 30002]]];
+        return [
+          [0, 1, ["127.0.0.1", 30001]],
+          [2, 16383, ["127.0.0.1", 30002]]
+        ];
       }
     });
     new MockServer(30002, function(argv) {

--- a/test/functional/cluster/maxRedirections.ts
+++ b/test/functional/cluster/maxRedirections.ts
@@ -8,7 +8,10 @@ describe("cluster:maxRedirections", function() {
     var redirectTimes = 0;
     var argvHandler = function(argv) {
       if (argv[0] === "cluster" && argv[1] === "slots") {
-        return [[0, 1, ["127.0.0.1", 30001]], [2, 16383, ["127.0.0.1", 30002]]];
+        return [
+          [0, 1, ["127.0.0.1", 30001]],
+          [2, 16383, ["127.0.0.1", 30002]]
+        ];
       } else if (argv[0] === "get" && argv[1] === "foo") {
         redirectTimes += 1;
         return new Error("ASK " + calculateSlot("foo") + " 127.0.0.1:30001");

--- a/test/functional/cluster/pub_sub.ts
+++ b/test/functional/cluster/pub_sub.ts
@@ -8,7 +8,10 @@ describe("cluster:pub/sub", function() {
   it("should receive messages", function(done) {
     var handler = function(argv) {
       if (argv[0] === "cluster" && argv[1] === "slots") {
-        return [[0, 1, ["127.0.0.1", 30001]], [2, 16383, ["127.0.0.1", 30002]]];
+        return [
+          [0, 1, ["127.0.0.1", 30001]],
+          [2, 16383, ["127.0.0.1", 30002]]
+        ];
       }
     };
     var node1 = new MockServer(30001, handler);

--- a/test/functional/pipeline.ts
+++ b/test/functional/pipeline.ts
@@ -319,7 +319,10 @@ describe("pipeline", function() {
         .exec();
       expect(pipeline1.length).to.eql(4);
 
-      var pipeline2 = redis.pipeline([["set", "foo", "bar"], ["get", "foo"]]);
+      var pipeline2 = redis.pipeline([
+        ["set", "foo", "bar"],
+        ["get", "foo"]
+      ]);
       expect(pipeline2.length).to.eql(2);
       redis.disconnect();
     });

--- a/test/functional/reconnect_on_error.ts
+++ b/test/functional/reconnect_on_error.ts
@@ -105,7 +105,10 @@ describe("reconnectOnError", function() {
       .get("foo")
       .sadd("foo", "a")
       .exec(function(err, res) {
-        expect(res).to.eql([[null, "bar"], [null, 1]]);
+        expect(res).to.eql([
+          [null, "bar"],
+          [null, 1]
+        ]);
         done();
       });
   });

--- a/test/functional/scripting.ts
+++ b/test/functional/scripting.ts
@@ -96,7 +96,10 @@ describe("scripting", function() {
       .set("test", "pipeline")
       .test("test")
       .exec(function(err, results) {
-        expect(results).to.eql([[null, "OK"], [null, "pipeline"]]);
+        expect(results).to.eql([
+          [null, "OK"],
+          [null, "pipeline"]
+        ]);
         redis.disconnect();
         done();
       });

--- a/test/functional/transaction.ts
+++ b/test/functional/transaction.ts
@@ -37,7 +37,10 @@ describe("transaction", function() {
       .get("foo")
       .exec(function(err, result) {
         expect(err).to.eql(null);
-        expect(result).to.eql([[null, "OK"], [null, "transaction"]]);
+        expect(result).to.eql([
+          [null, "OK"],
+          [null, "transaction"]
+        ]);
         done();
       });
   });
@@ -116,7 +119,10 @@ describe("transaction", function() {
       })
       .exec(function(err, result) {
         expect(pending).to.eql(0);
-        expect(result).to.eql([[null, "OK"], [null, "bar"]]);
+        expect(result).to.eql([
+          [null, "OK"],
+          [null, "bar"]
+        ]);
         done();
       });
   });
@@ -146,7 +152,10 @@ describe("transaction", function() {
     redis.set("foo", "bar");
     redis.get("foo");
     redis.exec(function(err, results) {
-      expect(results).to.eql([[null, "OK"], [null, "bar"]]);
+      expect(results).to.eql([
+        [null, "OK"],
+        [null, "bar"]
+      ]);
       done();
     });
   });

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -60,7 +60,10 @@ describe("utils", function() {
   describe(".wrapMultiResult", function() {
     it("should return correctly", function() {
       expect(utils.wrapMultiResult(null)).to.eql(null);
-      expect(utils.wrapMultiResult([1, 2])).to.eql([[null, 1], [null, 2]]);
+      expect(utils.wrapMultiResult([1, 2])).to.eql([
+        [null, 1],
+        [null, 2]
+      ]);
 
       var error = new Error("2");
       expect(utils.wrapMultiResult([1, 2, error])).to.eql([
@@ -137,7 +140,10 @@ describe("utils", function() {
         expect(utils.convertMapToArray(new Map([[1, 2]]))).to.eql([1, 2]);
         expect(
           utils.convertMapToArray(
-            new Map<number | string, string>([[1, "2"], ["abc", "def"]])
+            new Map<number | string, string>([
+              [1, "2"],
+              ["abc", "def"]
+            ])
           )
         ).to.eql([1, "2", "abc", "def"]);
       }


### PR DESCRIPTION
READONLY errors are common with AWS Elasticache failovers, but there's a problem when it comes to ioredis transactions. Consider this contrived transaction:

```
const res = await multi()
  .set('foo', 42)
  .get('bar')
  .exec();
```

If you run it against an Elasticache endpoint which has just failed over under your feet, a READONLY error is reported, but your `res` contains an unexpected result:

```
[
  [null, 'barvalue']  
]
```

The transaction has partially failed, but I don't see the error in my exec result like I would if it was a WRONGTYPE error. On the wire, what I actually got back is this:

```
+OK
-READONLY You can't write against a read only replica.
+QUEUED
*1
$8
barvalue
```

Redis excluded the error from the exec result because it was rejected upfront rather than QUEUED. This PR will re-insert such errors back into the `exec()` result in the order they were sent so that we instead `res` looks this:

```
[
  [ReplyError: READONLY...]
  [null, 'barvalue']
]
```

I'm not sure if what I'm doing is kosher, e.g if `exec()` is meant to _exactly_ represent the last element sent on the wire. But I imagine there may be other redis runtime errors that behave like READONLY. I'm open to alternative ideas on how to clearly communicate to the caller which individual commands succeeded and which failed in a partially failed transaction.

Note: The readme proposes to handle such ElastiCache READONLY errors with `reconnectOnError`. This works most of the time however mixing this with transactions introduces a different problem which I think was first reported [here](https://github.com/luin/ioredis/issues/965). I'm hoping do address that in a further PR.