### PR TITLE
Allow sentinelRetryStrategy to be disabled

### DIFF
--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -37,7 +37,7 @@ export interface ISentinelConnectionOptions extends ITcpConnectionOptions {
   name: string;
   sentinelPassword?: string;
   sentinels: Array<Partial<ISentinelAddress>>;
-  sentinelRetryStrategy?: (retryAttempts: number) => number;
+  sentinelRetryStrategy?: (retryAttempts: number) => number | void | null;
   preferredSlaves?: PreferredSlaves;
   connectTimeout?: number;
   enableTLSForSentinelMode?: boolean;


### PR DESCRIPTION
For TypeScript users, it is currently not possible to return an invalid delay in the `sentinelRetryStrategy` option.

The documentation says:
> If `sentinelRetryStrategy` returns a valid delay time, ioredis will try to reconnect from scratch.

So, I was curious what valid actually means here. It turns out, that a valid delay is any `number`.

```ts
const error = new Error(errorMsg);
if (typeof retryDelay === "number") {
  setTimeout(() => {
    resolve(connectToNext());
  }, retryDelay);
  eventEmitter("error", error);
} else {
  reject(error);
}
```
[Link](https://github.com/luin/ioredis/blob/4bce38b28a8f31f552bb3fce44ca0f413435d2c2/lib/connectors/SentinelConnector/index.ts#L112-L120) to the mentioned code.

However, the problem is that the `sentinelRetryStrategy` can either be `undefined` in `RedisOptions` (then it falls back to the [default retry strategy](https://github.com/luin/ioredis/blob/98ebeec1acd2067e52169f53e57e989ebbf671ff/lib/redis/RedisOptions.ts#L46-L48)), or it has to be a function matching the following [signature](https://github.com/luin/ioredis/blob/4bce38b28a8f31f552bb3fce44ca0f413435d2c2/lib/connectors/SentinelConnector/index.ts#L40):
```ts
(retryAttempts: number) => number;
```
This leaves TypeScript users paralized when they want to disable any further sentinel retries. So, I'm proposing to change the signature to match the one currently used by the `retryStrategy` [option](https://github.com/luin/ioredis/blob/98ebeec1acd2067e52169f53e57e989ebbf671ff/lib/redis/RedisOptions.ts#L13).

This change will still need to be adopted by [`@types/ioredis`](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/ioredis). Is there a plan to export the types directly from this package for the TypeScript users, so that the community maintained library does not have to be kept in sync?