### PR TITLE
fix: prevent exception when send custom command

### DIFF
--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -663,6 +663,7 @@ Redis.prototype.sendCommand = function(command, stream) {
     this.status === "ready" ||
     (!stream &&
       this.status === "connect" &&
+      commands.exists(command.name) &&
       commands.hasFlag(command.name, "loading"));
   if (!this.stream) {
     writable = false;


### PR DESCRIPTION
When send command not in `redis-commands`, it may raise exception 'Unknown command' when `status` not 'ready'.