### PR TITLE
Ignore empty hosts returned by CLUSTER SLOTS

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -776,6 +776,9 @@ class Cluster extends EventEmitter {
 
           const keys = [];
           for (let j = 2; j < items.length; j++) {
+            if (!items[j][0]) {
+              continue;
+            }
             items[j] = this.natMapper({ host: items[j][0], port: items[j][1] });
             items[j].readOnly = j !== 2;
             nodes.push(items[j]);


### PR DESCRIPTION
When some nodes disconnected from the cluster, there will be left with some empty addresses.
![nodes](https://user-images.githubusercontent.com/705581/70680306-cf9b6900-1cd2-11ea-9d70-472bc6283139.png)
Then the `CLUSTER SLOTS` will reply with empty hosts.
![slots](https://user-images.githubusercontent.com/705581/70680270-aa0e5f80-1cd2-11ea-85e3-a6237da01313.png)
`ioredis` then convert the empty address `:0` to `127.0.0.1:6379` internally and try to connect them.
![connectionPool](https://user-images.githubusercontent.com/705581/70680410-2d2fb580-1cd3-11ea-9c02-4f4405f384ed.png)
Even worse, when `scaleReads=='slaves'`, it may try to sendCommand to `:0`.
So we'd better just ignore these empty addresses.