### PR TITLE
feat: ability force custom scripts to be readOnly and execute on slaves

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -554,8 +554,9 @@ class Cluster extends EventEmitter {
     let to = this.options.scaleReads;
     if (to !== "master") {
       const isCommandReadOnly =
-        commands.exists(command.name) &&
-        commands.hasFlag(command.name, "readonly");
+        command.isReadOnly ||
+        (commands.exists(command.name) &&
+          commands.hasFlag(command.name, "readonly"));
       if (!isCommandReadOnly) {
         to = "master";
       }

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -22,6 +22,10 @@ interface ICommandOptions {
   replyEncoding?: string | null;
   errorStack?: string;
   keyPrefix?: string;
+  /**
+   * Force the command to be readOnly so it will also execute on slaves
+   */
+  readOnly?: boolean;
 }
 
 type ArgumentTransformer = (args: any[]) => any[];
@@ -142,6 +146,7 @@ export default class Command implements ICommand {
   }
 
   public ignore?: boolean;
+  public isReadOnly?: boolean;
 
   private replyEncoding: string | null;
   private errorStack: string;
@@ -184,6 +189,10 @@ export default class Command implements ICommand {
 
     if (options.keyPrefix) {
       this._iterateKeys(key => options.keyPrefix + key);
+    }
+
+    if (options.readOnly) {
+      this.isReadOnly = true;
     }
   }
 

--- a/lib/commander.ts
+++ b/lib/commander.ts
@@ -78,13 +78,15 @@ Commander.prototype.send_command = Commander.prototype.call;
  * @param {object} definition
  * @param {string} definition.lua - the lua code
  * @param {number} [definition.numberOfKeys=null] - the number of keys.
+ * @param {boolean} [definition.readOnly=false] - force this script to be readonly so it executes on slaves as well.
  * If omit, you have to pass the number of keys as the first argument every time you invoke the command
  */
 Commander.prototype.defineCommand = function(name, definition) {
   var script = new Script(
     definition.lua,
     definition.numberOfKeys,
-    this.options.keyPrefix
+    this.options.keyPrefix,
+    definition.readOnly
   );
   this.scriptsSet[name] = script;
   this[name] = generateScriptingFunction(script, "utf8");

--- a/lib/script.ts
+++ b/lib/script.ts
@@ -10,7 +10,8 @@ export default class Script {
   constructor(
     private lua: string,
     private numberOfKeys: number = null,
-    private keyPrefix: string = ""
+    private keyPrefix: string = "",
+    private readOnly: boolean = false
   ) {
     this.sha = createHash("sha1")
       .update(lua)
@@ -28,6 +29,9 @@ export default class Script {
     }
     if (this.keyPrefix) {
       options.keyPrefix = this.keyPrefix;
+    }
+    if (this.readOnly) {
+      options.readOnly = true;
     }
 
     const evalsha = new Command("evalsha", [this.sha].concat(args), options);

--- a/test/functional/maxRetriesPerRequest.ts
+++ b/test/functional/maxRetriesPerRequest.ts
@@ -5,6 +5,7 @@ import { MaxRetriesPerRequestError } from "../../lib/errors";
 describe("maxRetriesPerRequest", function() {
   it("throw the correct error when reached the limit", function(done) {
     var redis = new Redis(9999, {
+      connectTimeout: 1,
       retryStrategy() {
         return 1;
       }


### PR DESCRIPTION
This introduces a new option for defineCommand: readOnly

It tells ioredis that this command is safe to be executed on slaves and allows the option scaleReads to also apply to the custom command.