### PR TITLE
Elasticache: Abort incomplete pipelines and transactions upon reconnect

### DIFF
--- a/examples/basic_operations.js
+++ b/examples/basic_operations.js
@@ -33,7 +33,7 @@ redis.sadd("set", [1, 3, 5, 7]);
 redis.spop("set"); // Promise resolves to "5" or another item in the set
 
 // Most responses are strings, or arrays of strings
-redis.zadd("sortedSet", 1, "one", 2, "dos", 4, "quatro", 3, "three")
+redis.zadd("sortedSet", 1, "one", 2, "dos", 4, "quatro", 3, "three");
 redis.zrange("sortedSet", 0, 2, "WITHSCORES").then(res => console.log(res)); // Promise resolves to ["one", "1", "dos", "2", "three", "3"] as if the command was ` redis> ZRANGE sortedSet 0 2 WITHSCORES `
 
 // Some responses have transformers to JS values

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -154,6 +154,8 @@ export default class Command implements ICommand {
   private callback: CallbackFunction;
   private transformed: boolean = false;
   public isCustomCommand: boolean = false;
+  public inTransaction: boolean = false;
+  public pipelineIndex?: number;
 
   private slot?: number | null;
   private keys?: Array<string | Buffer>;

--- a/test/functional/elasticache.ts
+++ b/test/functional/elasticache.ts
@@ -1,0 +1,153 @@
+import Redis from "../../lib/redis";
+import { expect } from "chai";
+import MockServer from "../helpers/mock_server";
+
+// AWS Elasticache closes the connection immediately when it encounters a READONLY error
+function simulateElasticache(options: {
+  reconnectOnErrorValue: boolean | number;
+}) {
+  let inTransaction = false;
+  const mockServer = new MockServer(30000, (argv, socket, flags) => {
+    switch (argv[0]) {
+      case "multi":
+        inTransaction = true;
+        return MockServer.raw("+OK\r\n");
+      case "del":
+        flags.disconnect = true;
+        return new Error(
+          "READONLY You can't write against a read only replica."
+        );
+      case "get":
+        return inTransaction ? MockServer.raw("+QUEUED\r\n") : argv[1];
+      case "exec":
+        inTransaction = false;
+        return [];
+    }
+  });
+
+  return new Redis({
+    port: 30000,
+    reconnectOnError(err: Error): boolean | number {
+      // bring the mock server back up
+      mockServer.connect();
+      return options.reconnectOnErrorValue;
+    }
+  });
+}
+
+function expectReplyError(err) {
+  expect(err).to.exist;
+  expect(err.name).to.eql("ReplyError");
+}
+
+function expectAbortError(err) {
+  expect(err).to.exist;
+  expect(err.name).to.eql("AbortError");
+  expect(err.message).to.eql("Command aborted due to connection close");
+}
+
+describe("elasticache", function() {
+  it("should abort a failed transaction when connection is lost", function(done) {
+    const redis = simulateElasticache({ reconnectOnErrorValue: true });
+
+    redis
+      .multi()
+      .del("foo")
+      .del("bar")
+      .exec(err => {
+        expectAbortError(err);
+        expect(err.command).to.eql({
+          name: "exec",
+          args: []
+        });
+        expect(err.previousErrors).to.have.lengthOf(2);
+        expectReplyError(err.previousErrors[0]);
+        expect(err.previousErrors[0].command).to.eql({
+          name: "del",
+          args: ["foo"]
+        });
+        expectAbortError(err.previousErrors[1]);
+        expect(err.previousErrors[1].command).to.eql({
+          name: "del",
+          args: ["bar"]
+        });
+
+        // ensure we've recovered into a healthy state
+        redis.get("foo", (err, res) => {
+          expect(res).to.eql("foo");
+          done();
+        });
+      });
+  });
+
+  it("should not resend failed transaction commands", function(done) {
+    const redis = simulateElasticache({ reconnectOnErrorValue: 2 });
+    redis
+      .multi()
+      .del("foo")
+      .get("bar")
+      .exec(err => {
+        expectAbortError(err);
+        expect(err.command).to.eql({
+          name: "exec",
+          args: []
+        });
+        expect(err.previousErrors).to.have.lengthOf(2);
+        expectAbortError(err.previousErrors[0]);
+        expect(err.previousErrors[0].command).to.eql({
+          name: "del",
+          args: ["foo"]
+        });
+        expectAbortError(err.previousErrors[1]);
+        expect(err.previousErrors[1].command).to.eql({
+          name: "get",
+          args: ["bar"]
+        });
+
+        // ensure we've recovered into a healthy state
+        redis.get("foo", (err, res) => {
+          expect(res).to.eql("foo");
+          done();
+        });
+      });
+  });
+
+  it("should resend intact pipelines", function(done) {
+    const redis = simulateElasticache({ reconnectOnErrorValue: true });
+
+    let p1Result;
+    redis
+      .pipeline()
+      .del("foo")
+      .get("bar")
+      .exec((err, result) => (p1Result = result));
+
+    redis
+      .pipeline()
+      .get("baz")
+      .get("qux")
+      .exec((err, p2Result) => {
+        // First pipeline should have been aborted
+        expect(p1Result).to.have.lengthOf(2);
+        expect(p1Result[0]).to.have.lengthOf(1);
+        expect(p1Result[1]).to.have.lengthOf(1);
+        expectReplyError(p1Result[0][0]);
+        expect(p1Result[0][0].command).to.eql({
+          name: "del",
+          args: ["foo"]
+        });
+        expectAbortError(p1Result[1][0]);
+        expect(p1Result[1][0].command).to.eql({
+          name: "get",
+          args: ["bar"]
+        });
+
+        // Second pipeline was intact and should have been retried successfully
+        expect(p2Result).to.have.lengthOf(2);
+        expect(p2Result[0]).to.eql([null, "baz"]);
+        expect(p2Result[1]).to.eql([null, "qux"]);
+
+        done();
+      });
+  });
+});

--- a/test/helpers/mock_server.ts
+++ b/test/helpers/mock_server.ts
@@ -32,7 +32,14 @@ export function getConnectionName(socket: Socket): string | undefined {
   return connectionNameMap.get(socket);
 }
 
-export type MockServerHandler = (reply: any, socket: Socket) => any;
+interface IFlags {
+  disconnect?: boolean;
+}
+export type MockServerHandler = (
+  reply: any,
+  socket: Socket,
+  flags: IFlags
+) => any;
 
 export default class MockServer extends EventEmitter {
   static REDIS_OK = "+OK";
@@ -84,7 +91,12 @@ export default class MockServer extends EventEmitter {
             this.write(c, this.slotTable);
             return;
           }
-          this.write(c, this.handler && this.handler(reply, c));
+          let flags: Flags = {};
+          let handlerResult = this.handler && this.handler(reply, c, flags);
+          this.write(c, handlerResult);
+          if (flags.disconnect) {
+            this.disconnect();
+          }
         },
         returnError: function() {}
       });

--- a/test/unit/pipeline.ts
+++ b/test/unit/pipeline.ts
@@ -1,0 +1,69 @@
+import * as sinon from "sinon";
+import { expect } from "chai";
+import Pipeline from "../../lib/pipeline";
+import Commander from "../../lib/commander";
+import Redis from "../../lib/redis";
+
+describe("Pipeline", function() {
+  beforeEach(() => {
+    sinon.stub(Redis.prototype, "connect").resolves();
+    sinon.stub(Commander.prototype, "sendCommand").callsFake(command => {
+      return command;
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should properly mark commands as transactions", function() {
+    const redis = new Redis();
+    const p = new Pipeline(redis);
+    let i = 0;
+
+    function validate(name, inTransaction) {
+      const command = p._queue[i++];
+      expect(command.name).to.eql(name);
+      expect(command.inTransaction).to.eql(inTransaction);
+    }
+
+    p.get();
+    p.multi();
+    p.get();
+    p.multi();
+    p.exec();
+    p.exec();
+    p.get();
+
+    validate("get", false);
+    validate("multi", true);
+    validate("get", true);
+    validate("multi", true);
+    validate("exec", true);
+    validate("exec", false);
+    validate("get", false);
+  });
+
+  it("should properly set pipelineIndex on commands", function() {
+    const redis = new Redis();
+    const p = new Pipeline(redis);
+    let i = 0;
+
+    function validate(name) {
+      const command = p._queue[i];
+      expect(command.name).to.eql(name);
+      expect(command.pipelineIndex).to.eql(i);
+      i++;
+    }
+
+    p.get();
+    p.set();
+    p.del();
+    p.ping();
+
+    validate("get");
+    validate("set");
+    validate("del");
+    validate("ping");
+  });
+});


### PR DESCRIPTION
Elasticache severs the connection immediately after it returns a
READONLY error.  This can sometimes leave queued up pipelined commands
in an inconsistent state when the connection is reestablished. For
example, if a pipeline has 6 commands and the second one generates a
READONLY error, Elasticache will only return results for the first two
before severing the connection. Upon reconnect, the pipeline still
thinks it has 6 commands to send but the commandQueue has only 4. This
fix will detect any pipeline command sets that only had a partial
response before connection loss, and abort them.

This Elasticache behavior also affects transactions. If reconnectOnError
returns 2, some transaction fragments may end up in the offlineQueue.
This fix will check the offlineQueue for any such transaction fragments
and abort them, so that we don't send mismatched multi/exec to redis
upon reconnection.

- Introduced piplineIndex property on pipelined commands to allow for later
cleanup
- Added a routine to event_handler that aborts any pipelined commands inside
commandQueue and offlineQueue that were interrupted in the middle of the
pipeline
- Added a routine to event_handler that removes any transaction
fragments from the offline queue
- Introduced inTransaction property on commands to simplify pipeline logic
- Added a flags param to mock_server to allow the Elasticache disconnect
behavior to be simulated
- Added a reconnect_on_error test case for transactions
- Added some test cases testing for correct handling of this unique elasticache
behavior
- Added unit tests to validate inTransaction and pipelineIndex setting

Fixes #965

---

You can simulate this Elasticache disconnect behavior on a local redis instance by modifying the source like so:

```
diff --git a/src/server.c b/src/server.c
index f6faa61a..31721551 100644
--- a/src/server.c
+++ b/src/server.c
@@ -2702,7 +2702,9 @@ int processCommand(client *c) {
         !(c->flags & CLIENT_MASTER) &&
         c->cmd->flags & CMD_WRITE)
     {
+        flagTransaction(c);
         addReply(c, shared.roslaveerr);
+        c->flags |= CLIENT_CLOSE_AFTER_REPLY;
         return C_OK;
     }
```

(Thanks for the [idea](https://github.com/luin/ioredis/pull/1010#issuecomment-602732635) @luin)