### PR TITLE
Adjust README reconnectOnError code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,8 +661,8 @@ Besides auto-reconnect when the connection is closed, ioredis supports reconnect
 var redis = new Redis({
   reconnectOnError: function(err) {
     var targetError = "READONLY";
-    if (err.message.slice(0, targetError.length) === targetError) {
-      // Only reconnect when the error starts with "READONLY"
+    if (err.message.includes(targetError)) {
+      // Only reconnect when the error contains "READONLY"
       return true; // or `return 1;`
     }
   }


### PR DESCRIPTION
The existing README code sample checks for an error message that begins
with the string READONLY however if the error is produced from a lua
script the condition would not match it. A lua script READONLY error
looks like this:

```
127.0.0.1:7000> eval "redis.call('set', 'foo', 'bar')" 0
ERR Error running script (call to f_45e87c07f6aff394093b73766a458691d0460655): @user_script:1: @user_script: 1: -READONLY You can't write against a read only replica.
```

This changes the sample to instead check for READONLY as a substring