### PR TITLE
Handle connection after connect event was emitted

### DIFF
--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -304,7 +304,11 @@ Redis.prototype.connect = function (callback) {
           stream.setKeepAlive(true, options.keepAlive);
         }
 
-        stream.once(CONNECT_EVENT, eventHandler.connectHandler(_this));
+        if (stream.connecting) {
+          stream.once(CONNECT_EVENT, eventHandler.connectHandler(_this));
+        } else {
+          process.nextTick(eventHandler.connectHandler(_this));
+        }
         stream.once("error", eventHandler.errorHandler(_this));
         stream.once("close", eventHandler.closeHandler(_this));
 

--- a/test/functional/connection.ts
+++ b/test/functional/connection.ts
@@ -4,6 +4,7 @@ import * as sinon from "sinon";
 import { expect } from "chai";
 import MockServer from "../helpers/mock_server";
 import * as Bluebird from "bluebird";
+import { StandaloneConnector } from "../../lib/connectors";
 
 describe("connection", function () {
   it('should emit "connect" when connected', function (done) {
@@ -421,6 +422,14 @@ describe("connection", function () {
         Redis.Promise = Promise;
         redis.disconnect();
         done();
+      });
+    });
+
+    it("works when connection established before promise is resolved", (done) => {
+      const socket = new net.Socket();
+      sinon.stub(StandaloneConnector.prototype, "connect").resolves(socket);
+      socket.connect(6379, "127.0.0.1").on("connect", () => {
+        new Redis().on("connect", () => done());
       });
     });
   });


### PR DESCRIPTION
It's possible for connect promise to resolve after the resolved
connection has already been established, which means we miss the connect
event. This can happen when Bluebird is set as the global Promise, and
we connect to an ip address host for example. This fix checks to see if
that's the case and invokes the connection handler directly. Thanks
@luin for the recommendation.

Fixes #977