### PR TITLE
Fix _readyCheck INFO parser's handling of colon characters

### DIFF
--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -503,9 +503,10 @@ Redis.prototype._readyCheck = function (callback) {
 
     const lines = res.split("\r\n");
     for (let i = 0; i < lines.length; ++i) {
-      const parts = lines[i].split(":");
-      if (parts[1]) {
-        info[parts[0]] = parts[1];
+      const [fieldName, ...fieldValueParts] = lines[i].split(":");
+      const fieldValue = fieldValueParts.join(":");
+      if (fieldValue) {
+        info[fieldName] = fieldValue;
       }
     }
 


### PR DESCRIPTION
This super simple PR fixes #1126, an issue which occurs when encountering `INFO` response field values containing the colon character.

The purpose of this patch is to have the exposed `serverInfo` client property fully conformant with potential unexpected values Redis can respond with.

I understand that the `serverInfo` property is not documented, though it has apparently come into direct use by external libraries. I'm curious what the official stance on this is, and if this should be considered a valid practice or rather a misstep.