### PR TITLE
Adds auth support for Redis 6

### DIFF
--- a/examples/basic_operations.js
+++ b/examples/basic_operations.js
@@ -2,6 +2,7 @@ const Redis = require("ioredis");
 const redis = new Redis({
   port: process.env.redisPort,
   host: process.env.redisEndpoint,
+  username: process.env.redisUsername,
   password: process.env.redisPW,
 });
 

--- a/lib/cluster/ClusterSubscriber.ts
+++ b/lib/cluster/ClusterSubscriber.ts
@@ -74,6 +74,7 @@ export default class ClusterSubscriber {
     this.subscriber = new Redis({
       port: options.port,
       host: options.host,
+      username: options.username,
       password: options.password,
       enableReadyCheck: true,
       connectionName: SUBSCRIBER_CONNECTION_NAME,

--- a/lib/cluster/util.ts
+++ b/lib/cluster/util.ts
@@ -7,6 +7,7 @@ export type NodeRole = "master" | "slave" | "all";
 export interface IRedisOptions {
   port: number;
   host: string;
+  username?: string;
   password?: string;
   [key: string]: any;
 }

--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -35,6 +35,7 @@ export { ISentinelAddress, SentinelIterator };
 export interface ISentinelConnectionOptions extends ITcpConnectionOptions {
   role: "master" | "slave";
   name: string;
+  sentinelUsername?: string;
   sentinelPassword?: string;
   sentinels: Array<Partial<ISentinelAddress>>;
   sentinelRetryStrategy?: (retryAttempts: number) => number | void | null;
@@ -278,6 +279,7 @@ export default class SentinelConnector extends AbstractConnector {
     const client = new Redis({
       port: endpoint.port || 26379,
       host: endpoint.host,
+      username: this.options.sentinelUsername || null,
       password: this.options.sentinelPassword || null,
       family:
         endpoint.family ||

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -14,6 +14,7 @@ export interface IRedisOptions
   keepAlive?: number;
   noDelay?: boolean;
   connectionName?: string;
+  username?: string;
   password?: string;
   db?: number;
   dropBufferSupport?: boolean;
@@ -50,6 +51,7 @@ export const DEFAULT_REDIS_OPTIONS: IRedisOptions = {
   enableTLSForSentinelMode: false,
   updateSentinels: true,
   // Status
+  username: null,
   password: null,
   db: 0,
   // Others

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -25,13 +25,21 @@ export function connectHandler(self) {
           return;
         }
         if (err) {
-          if (err.message.indexOf("no password is set") === -1) {
-            flushed = true;
-            self.recoverFromFatalError(err, err);
-          } else {
+          if (err.message.indexOf("no password is set") !== -1) {
             console.warn(
               "[WARN] Redis server does not require a password, but a password was supplied."
             );
+          } else if (
+            err.message.indexOf(
+              "without any password configured for the default user"
+            ) !== -1
+          ) {
+            console.warn(
+              "[WARN] This Redis server's `default` user does not require a password, but a password was supplied"
+            );
+          } else {
+            flushed = true;
+            self.recoverFromFatalError(err, err);
           }
         }
       });

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -37,6 +37,14 @@ export function connectHandler(self) {
             console.warn(
               "[WARN] This Redis server's `default` user does not require a password, but a password was supplied"
             );
+          } else if (
+            err.message.indexOf(
+              "wrong number of arguments for 'auth' command"
+            ) !== -1
+          ) {
+            console.warn(
+              `[ERROR] The server returned "wrong number of arguments for 'auth' command". You are probably passing both username and password to Redis version 5 or below. You should only pass the 'password' option for Redis version 5 and under.`
+            );
           } else {
             flushed = true;
             self.recoverFromFatalError(err, err);

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -279,7 +279,7 @@ Redis.prototype.connect = function (callback) {
     this.condition = {
       select: options.db,
       auth:
-        options.username && options.username.length > 0
+        options.username
           ? [options.username, options.password]
           : options.password,
       subscriber: false,

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -42,6 +42,7 @@ const debug = Debug("redis");
  * it to reduce the latency.
  * @param {string} [options.connectionName=null] - Connection name.
  * @param {number} [options.db=0] - Database index to use.
+ * @param {string} [options.username=null] - If set, client will send AUTH command with this user and password when connected.
  * @param {string} [options.password=null] - If set, client will send AUTH command
  * with the value of this option when connected.
  * @param {boolean} [options.dropBufferSupport=false] - Drop the buffer support for better performance.
@@ -277,7 +278,10 @@ Redis.prototype.connect = function (callback) {
 
     this.condition = {
       select: options.db,
-      auth: options.password,
+      auth:
+        options.username && options.username.length > 0
+          ? [options.username, options.password]
+          : options.password,
       subscriber: false,
     };
 

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -257,7 +257,11 @@ export function parseURL(url) {
 
   const result: any = {};
   if (parsed.auth) {
-    result.password = parsed.auth.split(":")[1];
+    const parsedAuth = parsed.auth.split(":");
+    if (parsedAuth[0].length > 0) {
+      result.username = parsedAuth[0];
+    }
+    result.password = parsedAuth[1];
   }
   if (parsed.pathname) {
     if (parsed.protocol === "redis:" || parsed.protocol === "rediss:") {

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -258,7 +258,7 @@ export function parseURL(url) {
   const result: any = {};
   if (parsed.auth) {
     const parsedAuth = parsed.auth.split(":");
-    if (parsedAuth[0].length > 0) {
+    if (parsedAuth[0]) {
       result.username = parsedAuth[0];
     }
     result.password = parsedAuth[1];

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "test": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_LOG_ERROR=true NODE_ENV=test mocha \"test/**/*.ts\"",
+    "test-single": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_LOG_ERROR=true NODE_ENV=test mocha $1",
     "lint": "eslint --ext .js,.ts .",
     "format": "prettier --write \"{,!(node_modules)/**/}*.{js,ts}\"",
     "format-check": "prettier --check \"{,!(node_modules)/**/}*.{js,ts}\"",

--- a/test/functional/auth.ts
+++ b/test/functional/auth.ts
@@ -4,6 +4,7 @@ import Redis from "../../lib/redis";
 import * as sinon from "sinon";
 
 describe("auth", function () {
+  /* General non-Redis-version specific tests */
   it("should send auth before other commands", function (done) {
     let authed = false;
     new MockServer(17379, (argv) => {
@@ -42,67 +43,209 @@ describe("auth", function () {
     });
   });
 
-  it('should not emit "error" when the server doesn\'t need auth', function (done) {
-    new MockServer(17379, function (argv) {
-      if (argv[0] === "auth" && argv[1] === "pass") {
-        return new Error("ERR Client sent AUTH, but no password is set");
-      }
-    });
-    let errorEmited = false;
-    const redis = new Redis({ port: 17379, password: "pass" });
-    redis.on("error", function () {
-      errorEmited = true;
-    });
-    const stub = sinon.stub(console, "warn").callsFake((warn) => {
-      if (warn.indexOf("but a password was supplied") !== -1) {
-        stub.restore();
-        setTimeout(function () {
-          expect(errorEmited).to.eql(false);
+  describe("auth:redis5-specific", function () {
+    it("should handle auth with Redis URL string (redis://:foo@bar.com/) correctly", function (done) {
+      const password = "pass";
+      let redis;
+      new MockServer(17379, function (argv) {
+        if (argv[0] === "auth" && argv[1] === password) {
           redis.disconnect();
           done();
-        }, 0);
-      }
+        }
+      });
+      redis = new Redis(`redis://:${password}@localhost:17379/`);
     });
-  });
 
-  it('should emit "error" when the password is wrong', function (done) {
-    new MockServer(17379, function (argv) {
-      if (argv[0] === "auth" && argv[1] === "pass") {
-        return new Error("ERR invalid password");
-      }
+    it('should not emit "error" when the server doesn\'t need auth', function (done) {
+      new MockServer(17379, function (argv) {
+        if (argv[0] === "auth" && argv[1] === "pass") {
+          return new Error("ERR Client sent AUTH, but no password is set");
+        }
+      });
+      let errorEmited = false;
+      const redis = new Redis({ port: 17379, password: "pass" });
+      redis.on("error", function () {
+        errorEmited = true;
+      });
+      const stub = sinon.stub(console, "warn").callsFake((warn) => {
+        if (warn.indexOf("but a password was supplied") !== -1) {
+          stub.restore();
+          setTimeout(function () {
+            expect(errorEmited).to.eql(false);
+            redis.disconnect();
+            done();
+          }, 0);
+        }
+      });
     });
-    const redis = new Redis({ port: 17379, password: "pass" });
-    let pending = 2;
-    function check() {
-      if (!--pending) {
+
+    it('should emit "error" when the password is wrong', function (done) {
+      new MockServer(17379, function (argv) {
+        if (argv[0] === "auth" && argv[1] === "pass") {
+          return new Error("ERR invalid password");
+        }
+      });
+      const redis = new Redis({ port: 17379, password: "pass" });
+      let pending = 2;
+      function check() {
+        if (!--pending) {
+          redis.disconnect();
+          done();
+        }
+      }
+      redis.on("error", function (error) {
+        expect(error).to.have.property("message", "ERR invalid password");
+        check();
+      });
+      redis.get("foo", function (err, res) {
+        expect(err.message).to.eql("ERR invalid password");
+        check();
+      });
+    });
+
+    it('should emit "error" when password is not provided', function (done) {
+      new MockServer(17379, function (argv) {
+        if (argv[0] === "info") {
+          return new Error("NOAUTH Authentication required.");
+        }
+      });
+      const redis = new Redis({ port: 17379 });
+      redis.on("error", function (error) {
+        expect(error).to.have.property(
+          "message",
+          "NOAUTH Authentication required."
+        );
         redis.disconnect();
         done();
-      }
-    }
-    redis.on("error", function (error) {
-      expect(error).to.have.property("message", "ERR invalid password");
-      check();
-    });
-    redis.get("foo", function (err, res) {
-      expect(err.message).to.eql("ERR invalid password");
-      check();
+      });
     });
   });
 
-  it('should emit "error" when password is not provided', function (done) {
-    new MockServer(17379, function (argv) {
-      if (argv[0] === "info") {
-        return new Error("NOAUTH Authentication required.");
-      }
+  describe("auth:redis6-specific", function () {
+    /*Redis 6 specific tests */
+    it("should handle username and password auth (Redis >=6) correctly", function (done) {
+      let username = "user";
+      let password = "pass";
+      let redis;
+      new MockServer(17379, function (argv) {
+        if (
+          argv[0] === "auth" &&
+          argv[1] === username &&
+          argv[2] === password
+        ) {
+          redis.disconnect();
+          done();
+        }
+      });
+      redis = new Redis({ port: 17379, username, password });
     });
-    const redis = new Redis({ port: 17379 });
-    redis.on("error", function (error) {
-      expect(error).to.have.property(
-        "message",
-        "NOAUTH Authentication required."
-      );
-      redis.disconnect();
-      done();
+
+    it("should handle auth with Redis URL string with username and password (Redis >=6) (redis://foo:bar@baz.com/) correctly", function (done) {
+      let username = "user";
+      let password = "pass";
+      let redis;
+      new MockServer(17379, function (argv) {
+        if (
+          argv[0] === "auth" &&
+          argv[1] === username &&
+          argv[2] === password
+        ) {
+          redis.disconnect();
+          done();
+        }
+      });
+      redis = new Redis(`redis://user:pass@localhost:17379/`);
+    });
+
+    it('should not emit "error" when the Redis >=6 server doesn\'t need auth', function (done) {
+      new MockServer(17379, function (argv) {
+        if (argv[0] === "auth" && argv[1] === "pass") {
+          return new Error(
+            "ERR AUTH <password> called without any password configured for the default user. Are you sure your configuration is correct?"
+          );
+        }
+      });
+      let errorEmited = false;
+      const redis = new Redis({ port: 17379, password: "pass" });
+      redis.on("error", function () {
+        console.log("boop");
+        errorEmited = true;
+      });
+      const stub = sinon.stub(console, "warn").callsFake((warn) => {
+        if (warn.indexOf("`default` user does not require a password") !== -1) {
+          stub.restore();
+          setTimeout(function () {
+            expect(errorEmited).to.eql(false);
+            redis.disconnect();
+            done();
+          }, 0);
+        }
+      });
+    });
+
+    it('should emit "error" when passing username but not password to Redis >=6 instance', function (done) {
+      let username = "user";
+      let password = "pass";
+      let redis;
+      new MockServer(17379, function (argv) {
+        if (argv[0] === "auth") {
+          if (argv[1] === username && argv[2] === password) {
+            return "OK";
+          } else {
+            return new Error("WRONGPASS invalid username-password pair");
+          }
+        }
+      });
+      redis = new Redis({ port: 17379, username });
+      redis.on("error", function (error) {
+        expect(error).to.have.property(
+          "message",
+          "WRONGPASS invalid username-password pair"
+        );
+        redis.disconnect();
+        done();
+      });
+    });
+
+    it('should emit "error" when the password is wrong', function (done) {
+      let username = "user";
+      let password = "pass";
+      let redis;
+      new MockServer(17379, function (argv) {
+        if (argv[0] === "auth") {
+          if (argv[1] === username && argv[2] === password) {
+            return "OK";
+          } else {
+            return new Error("WRONGPASS invalid username-password pair");
+          }
+        }
+      });
+      redis = new Redis({ port: 17379, username, password: "notpass" });
+      redis.on("error", function (error) {
+        expect(error).to.have.property(
+          "message",
+          "WRONGPASS invalid username-password pair"
+        );
+        redis.disconnect();
+        done();
+      });
+    });
+
+    it('should emit "error" when password is required but not provided', function (done) {
+      new MockServer(17379, function (argv) {
+        if (argv[0] === "info") {
+          return new Error("NOAUTH Authentication required.");
+        }
+      });
+      const redis = new Redis({ port: 17379 });
+      redis.on("error", function (error) {
+        expect(error).to.have.property(
+          "message",
+          "NOAUTH Authentication required."
+        );
+        redis.disconnect();
+        done();
+      });
     });
   });
 });

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -193,6 +193,7 @@ describe("utils", function () {
         port: "6380",
         db: "4",
         password: "pass",
+        username: "user",
         key: "value",
       });
       expect(utils.parseURL("redis://127.0.0.1/")).to.eql({
@@ -205,6 +206,7 @@ describe("utils", function () {
         port: "6380",
         db: "4",
         password: "pass",
+        username: "user",
         key: "value",
       });
     });


### PR DESCRIPTION
This PR contains the following changes:
- Adds the `username` optional key to the `IRedisOptions` interface and instantiation options.
- Adds 2 extra error handlers for handling Redis 6 default user not needing password and user passing username and password to a Redis <=5 instance (https://github.com/luin/ioredis/pull/1130/files#diff-43fd638f7be3d3664e2c4ee36dbdf059R32-R50)
- Update URL parser to handle for username passed in redis URL
- Tests for redis 5 and redis 6 using the new auth code.

Fixes luin/ioredis#1097