### PR TITLE
fix: revert parsing username via URI due to potential breaking changes

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -258,9 +258,6 @@ export function parseURL(url) {
   const result: any = {};
   if (parsed.auth) {
     const parsedAuth = parsed.auth.split(":");
-    if (parsedAuth[0]) {
-      result.username = parsedAuth[0];
-    }
     result.password = parsedAuth[1];
   }
   if (parsed.pathname) {

--- a/test/functional/auth.ts
+++ b/test/functional/auth.ts
@@ -170,23 +170,6 @@ describe("auth", function () {
       redis = new Redis({ port: 17379, username, password });
     });
 
-    it("should handle auth with Redis URL string with username and password (Redis >=6) (redis://foo:bar@baz.com/) correctly", function (done) {
-      let username = "user";
-      let password = "pass";
-      let redis;
-      new MockServer(17379, function (argv) {
-        if (
-          argv[0] === "auth" &&
-          argv[1] === username &&
-          argv[2] === password
-        ) {
-          redis.disconnect();
-          done();
-        }
-      });
-      redis = new Redis(`redis://user:pass@localhost:17379/`);
-    });
-
     it('should not emit "error" when the Redis >=6 server doesn\'t need auth', function (done) {
       new MockServer(17379, function (argv) {
         if (argv[0] === "auth" && argv[1] === "pass") {

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -193,7 +193,6 @@ describe("utils", function () {
         port: "6380",
         db: "4",
         password: "pass",
-        username: "user",
         key: "value",
       });
       expect(utils.parseURL("redis://127.0.0.1/")).to.eql({
@@ -206,7 +205,6 @@ describe("utils", function () {
         port: "6380",
         db: "4",
         password: "pass",
-        username: "user",
         key: "value",
       });
     });


### PR DESCRIPTION
Closes #1132.

Previously, users can specify the username in Redis connect URI unintentionally so parsing username leads potential breaking changes in this case. We still support `username` parameter so users can opt-in ACL explicitly.