### PR TITLE
Correctly type dns callback

### DIFF
--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -4,9 +4,9 @@ import { lookup } from "dns";
 export type DNSLookupFunction = (
   hostname: string,
   callback: (
-    err: NodeJS.ErrnoException,
+    err: NodeJS.ErrnoException | undefined,
     address: string,
-    family: number
+    family?: number
   ) => void
 ) => void;
 export interface INatMap {


### PR DESCRIPTION
Only `address` seems to be required. 