### PR TITLE
fix: Fix autopipeline and downgrade p-map to support Node 6. [#1216]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: node_js
 
 node_js:
+  - "6"
   - "8"
-  - "9"
   - "10"
-  - "11"
   - "12"
+  - "14"
+  - "15"
 
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "10"
   - "12"
   - "14"
-  - "15"
 
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "6"
   - "8"
   - "10"
   - "12"

--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -17,7 +17,7 @@ export const notAllowedAutoPipelineCommands = [
   "unpsubscribe",
 ];
 
-function findAutoPipeline(client, ...args: Array<string>): string {
+function findAutoPipeline(client, _commandName, ...args: Array<string>): string {
   if (!client.isCluster) {
     return "main";
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -477,6 +477,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
       "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -868,7 +869,8 @@
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -2471,7 +2473,8 @@
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -3385,12 +3388,9 @@
       }
     },
     "p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "requires": {
-        "aggregate-error": "^3.0.0"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
     },
     "p-reduce": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "denque": "^1.1.0",
     "lodash.defaults": "^4.2.0",
     "lodash.flatten": "^4.4.0",
-    "p-map": "^4.0.0",
+    "p-map": "^2.1.0",
     "redis-commands": "1.6.0",
     "redis-errors": "^1.2.0",
     "redis-parser": "^3.0.0",


### PR DESCRIPTION
## What's in there?

[x] Fixes a severe autopipeline bug that prevented correct routing.
[x] Fixes #1216 by downgrading `p-map` to `2.1.0`, which is the last one that supports Node 6.
[x] Changes the Travis matrix to run against all Node even version >= 6, plus the current unstable one.

## Note to reviewers

The autopipeline bug was not catch from the test suite since testing for cluster goes against a mock cluster.
Shall we change this to test against a real cluster?
