### PR TITLE
fix: clear script caches interval on each connection attempt

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -185,6 +185,7 @@ class Cluster extends EventEmitter {
         return;
       }
 
+      clearInterval(this._addedScriptHashesCleanInterval);
       this._addedScriptHashesCleanInterval = setInterval(() => {
         this._addedScriptHashes = {};
       }, this.options.maxScriptsCachingTime);

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -296,6 +296,7 @@ Redis.prototype.connect = function (callback) {
       return;
     }
 
+    clearInterval(this._addedScriptHashesCleanInterval);
     this._addedScriptHashesCleanInterval = setInterval(() => {
       this._addedScriptHashes = {};
     }, this.options.maxScriptsCachingTime);


### PR DESCRIPTION
Follow-up fix for: #1215

After using tools like ```why-is-node-running```, I saw:

```ts
this._addedScriptHashesCleanInterval = setInterval(() => {
  this._addedScriptHashes = {};
}, this.options.maxScriptsCachingTime);
```

appearing multiple times (after ```quit``` was called), which means ```quit``` was only clearing the last of them, but there were many that were overwritten by that same call when connect is called multiple times (as in not  connecting the first time). This PR ensures that the interval is cleared before assigning a new one to the variable holding them.