### PR TITLE
fix: auth command should be not allowed in auto pipeline.

### DIFF
--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -5,6 +5,7 @@ import asCallback from "standard-as-callback";
 export const kExec = Symbol("exec");
 export const kCallbacks = Symbol("callbacks");
 export const notAllowedAutoPipelineCommands = [
+  "auth",
   "info",
   "script",
   "quit",
@@ -17,7 +18,11 @@ export const notAllowedAutoPipelineCommands = [
   "unpsubscribe",
 ];
 
-function findAutoPipeline(client, _commandName, ...args: Array<string>): string {
+function findAutoPipeline(
+  client,
+  _commandName,
+  ...args: Array<string>
+): string {
   if (!client.isCluster) {
     return "main";
   }


### PR DESCRIPTION
The auth command should be sent before other commands.
So it should be exclude from auto pipeline command list as well.

The issue is related to #1238 