### PR TITLE
Prevent duplicate intervals being set.

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -185,6 +185,7 @@ class Cluster extends EventEmitter {
         return;
       }
 
+      clearInterval(this._addedScriptHashesCleanInterval);
       this._addedScriptHashesCleanInterval = setInterval(() => {
         this._addedScriptHashes = {};
       }, this.options.maxScriptsCachingTime);

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -295,7 +295,7 @@ Redis.prototype.connect = function (callback) {
       reject(new Error("Redis is already connecting/connected"));
       return;
     }
-
+    clearInterval(this._addedScriptHashesCleanInterval);
     this._addedScriptHashesCleanInterval = setInterval(() => {
       this._addedScriptHashes = {};
     }, this.options.maxScriptsCachingTime);


### PR DESCRIPTION
After calling `redis.quit` there are still many open `setInterval` handles that have not been cleared.

These uncleared `setInternal` appear to be because everytime `connect` is called in the `reconnectTimeout` the `this._addedScriptHashesCleanInterval` is overridden by the old one, which is still running in the background.

https://github.com/luin/ioredis/blob/v4.19.2/lib/cluster/index.ts#L311-L313

When you call `redis.quit` it only clears the current one retained by `this._addedScriptHashesCleanInterval`.

```
[WTF Node?] open handles:
- File descriptors: (note: stdio always exists)
  - fd 1 (tty) (stdio)
  - fd 0 (tty)
  - fd 2 (tty) (stdio)
- Intervals:
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
  - (60000 ~ 60 s) (anonymous) @ /srv/app/node_modules/ioredis/built/redis/index.js:258
```