### PR TITLE
Connect to Redis through SRV record as a service discovery layer

### DIFF
--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -130,6 +130,7 @@ export interface IClusterOptions {
    */
   dnsLookup?: DNSLookupFunction;
   natMap?: INatMap;
+  useSRVRecord?: boolean;
 
   /**
    * See Redis class.
@@ -165,6 +166,7 @@ export const DEFAULT_CLUSTER_OPTIONS: IClusterOptions = {
   slotsRefreshTimeout: 1000,
   slotsRefreshInterval: 5000,
   dnsLookup: lookup,
+  useSRVRecord: false,
   enableAutoPipelining: false,
   autoPipeliningIgnoredCommands: [],
   maxScriptsCachingTime: 60000,


### PR DESCRIPTION
Connect to Redis using a DNS service discovery layer, the SRV record holds a URL and port that allows changing the port and host without application code change.