### PR TITLE
Use delay queue for commands in case of MOVED response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,9 +889,12 @@ cluster.get("foo", (err, res) => {
       will resend the commands after the specified time (in ms).
     - `retryDelayOnTryAgain`: If this option is a number (by default, it is `100`), the client
       will resend the commands rejected with `TRYAGAIN` error after the specified time (in ms).
+    - `retryDelayOnMoved`: By default, this value is `0` (in ms), which means when a `MOVED` error is received, the client will resend
+      the command instantly to the node returned together with the `MOVED` error. However, sometimes it takes time for a cluster to become
+      state stabilized after a failover, so adding a delay before resending can prevent a ping pong effect.
     - `redisOptions`: Default options passed to the constructor of `Redis` when connecting to a node.
-    - `slotsRefreshTimeout`: Milliseconds before a timeout occurs while refreshing slots from the cluster (default `1000`)
-    - `slotsRefreshInterval`: Milliseconds between every automatic slots refresh (default `5000`)
+    - `slotsRefreshTimeout`: Milliseconds before a timeout occurs while refreshing slots from the cluster (default `1000`).
+    - `slotsRefreshInterval`: Milliseconds between every automatic slots refresh (default `5000`).
 
 ### Read-write splitting
 

--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -95,6 +95,17 @@ export interface IClusterOptions {
   retryDelayOnTryAgain?: number;
 
   /**
+   * By default, this value is 0, which means when a `MOVED` error is received,
+   * the client will resend the command instantly to the node returned together with
+   * the `MOVED` error. However, sometimes it takes time for a cluster to become
+   * state stabilized after a failover, so adding a delay before resending can
+   * prevent a ping pong effect.
+   *
+   * @default 0
+   */
+  retryDelayOnMoved?: number;
+
+  /**
    * The milliseconds before a timeout occurs while refreshing
    * slots from the cluster.
    *
@@ -184,6 +195,7 @@ export const DEFAULT_CLUSTER_OPTIONS: IClusterOptions = {
   enableReadyCheck: true,
   scaleReads: "master",
   maxRedirections: 16,
+  retryDelayOnMoved: 0,
   retryDelayOnFailover: 100,
   retryDelayOnClusterDown: 100,
   retryDelayOnTryAgain: 100,


### PR DESCRIPTION
When a MOVED response is received from the cluster resend the commands using a delayed queue