### PR TITLE
Reuse the  args logic of `hset` and `hmset`

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -382,10 +382,7 @@ const msetArgumentTransformer = function (args) {
   return args;
 };
 
-Command.setArgumentTransformer("mset", msetArgumentTransformer);
-Command.setArgumentTransformer("msetnx", msetArgumentTransformer);
-
-Command.setArgumentTransformer("hmset", function (args) {
+const hsetArgumentTransformer = function (args) {
   if (args.length === 2) {
     if (typeof Map !== "undefined" && args[1] instanceof Map) {
       return [args[0]].concat(convertMapToArray(args[1]));
@@ -395,7 +392,13 @@ Command.setArgumentTransformer("hmset", function (args) {
     }
   }
   return args;
-});
+}
+
+Command.setArgumentTransformer("mset", msetArgumentTransformer);
+Command.setArgumentTransformer("msetnx", msetArgumentTransformer);
+
+Command.setArgumentTransformer("hset", hsetArgumentTransformer);
+Command.setArgumentTransformer("hmset", hsetArgumentTransformer);
 
 Command.setReplyTransformer("hgetall", function (result) {
   if (Array.isArray(result)) {
@@ -406,18 +409,6 @@ Command.setReplyTransformer("hgetall", function (result) {
     return obj;
   }
   return result;
-});
-
-Command.setArgumentTransformer("hset", function (args) {
-  if (args.length === 2) {
-    if (typeof Map !== "undefined" && args[1] instanceof Map) {
-      return [args[0]].concat(convertMapToArray(args[1]));
-    }
-    if (typeof args[1] === "object" && args[1] !== null) {
-      return [args[0]].concat(convertObjectToArray(args[1]));
-    }
-  }
-  return args;
 });
 
 class MixedBuffers {


### PR DESCRIPTION
`hset` and `hmset` have the same logic when processing parameter conversion, so use the same function variable to reuse the same processing.