### PR TITLE
refactor: limit `info` on readyCheck to `persistence` section

### DIFF
--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -526,7 +526,7 @@ Redis.prototype.flushQueue = function (error, options) {
  */
 Redis.prototype._readyCheck = function (callback) {
   const _this = this;
-  this.info(function (err, res) {
+  this.info('persistence', function (err, res) {
     if (err) {
       return callback(err);
     }

--- a/test/functional/ready_check.ts
+++ b/test/functional/ready_check.ts
@@ -5,7 +5,7 @@ describe("ready_check", function () {
   it("should retry when redis is not ready", function (done) {
     const redis = new Redis({ lazyConnect: true });
 
-    sinon.stub(redis, "info").callsFake((callback) => {
+    sinon.stub(redis, "info").callsFake((_section, callback) => {
       callback(null, "loading:1\r\nloading_eta_seconds:7");
     });
     // @ts-ignore
@@ -28,7 +28,7 @@ describe("ready_check", function () {
       },
     });
 
-    sinon.stub(redis, "info").callsFake((callback) => {
+    sinon.stub(redis, "info").callsFake((_section, callback) => {
       callback(new Error("info error"));
     });
 


### PR DESCRIPTION
Related: #1211

Limits the `info` call on `readyCheck` to just `persistence` section, allowing users to specify the exact acl (`+info|persistence`) that `ioredis` needs on `readyCheck`