### PR TITLE
Handle stream errors thrown immediately

### DIFF
--- a/lib/connectors/AbstractConnector.ts
+++ b/lib/connectors/AbstractConnector.ts
@@ -4,7 +4,6 @@ export type ErrorEmitter = (type: string, err: Error) => void;
 
 export default abstract class AbstractConnector {
   protected connecting = false;
-  protected stream: NetStream;
 
   public check(info: any): boolean {
     return true;
@@ -12,10 +11,7 @@ export default abstract class AbstractConnector {
 
   public disconnect(): void {
     this.connecting = false;
-    if (this.stream) {
-      this.stream.end();
-    }
   }
 
-  public abstract connect(_: ErrorEmitter): Promise<NetStream>;
+  public abstract connect(_: ErrorEmitter): Promise<() => NetStream>;
 }

--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -82,14 +82,14 @@ export default class SentinelConnector extends AbstractConnector {
     return roleMatches;
   }
 
-  public connect(eventEmitter: ErrorEmitter): Promise<NetStream> {
+  public connect(eventEmitter: ErrorEmitter): Promise<() => NetStream> {
     this.connecting = true;
     this.retryAttempts = 0;
 
     let lastError;
 
     const connectToNext = () =>
-      new Promise<NetStream>((resolve, reject) => {
+      new Promise<() => NetStream>((resolve, reject) => {
         const endpoint = this.sentinelIterator.next();
 
         if (endpoint.done) {
@@ -131,12 +131,11 @@ export default class SentinelConnector extends AbstractConnector {
             debug("resolved: %s:%s", resolved.host, resolved.port);
             if (this.options.enableTLSForSentinelMode && this.options.tls) {
               Object.assign(resolved, this.options.tls);
-              this.stream = createTLSConnection(resolved);
+              resolve(() => createTLSConnection(resolved));
             } else {
-              this.stream = createConnection(resolved);
+              resolve(() => createConnection(resolved));
             }
             this.sentinelIterator.reset(true);
-            resolve(this.stream);
           } else {
             const endpointAddress =
               endpoint.value.host + ":" + endpoint.value.port;

--- a/lib/connectors/StandaloneConnector.ts
+++ b/lib/connectors/StandaloneConnector.ts
@@ -52,13 +52,9 @@ export default class StandaloneConnector extends AbstractConnector {
     }
 
     // TODO:
-    // We use native Promise here since other Promise
-    // implementation may use different schedulers that
-    // cause issue when the stream is resolved in the
-    // next tick.
     // Should use the provided promise in the next major
-    // version and do not connect before resolved.
-    return new Promise<NetStream>((resolve, reject) => {
+    // version.
+    return new Promise<() => NetStream>((resolve, reject) => {
       process.nextTick(() => {
         if (!this.connecting) {
           reject(new Error(CONNECTION_CLOSED_ERROR_MSG));
@@ -67,16 +63,14 @@ export default class StandaloneConnector extends AbstractConnector {
 
         try {
           if (options.tls) {
-            this.stream = createTLSConnection(connectionOptions);
+            resolve(() => createTLSConnection(connectionOptions));
           } else {
-            this.stream = createConnection(connectionOptions);
+            resolve(() => createConnection(connectionOptions));
           }
         } catch (err) {
           reject(err);
           return;
         }
-
-        resolve(this.stream);
       });
     });
   }

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -318,7 +318,7 @@ Redis.prototype.connect = function (callback) {
       this.connector.connect(function (type, err) {
         _this.silentEmit(type, err);
       }),
-      function (err, stream) {
+      function (err, createStream) {
         if (err) {
           _this.flushQueue(err);
           _this.silentEmit("error", err);
@@ -331,6 +331,7 @@ Redis.prototype.connect = function (callback) {
           CONNECT_EVENT = "connect";
         }
 
+        const stream = createStream();
         _this.stream = stream;
         if (typeof options.keepAlive === "number") {
           stream.setKeepAlive(true, options.keepAlive);
@@ -381,7 +382,7 @@ Redis.prototype.connect = function (callback) {
 
         const connectionReadyHandler = function () {
           _this.removeListener("close", connectionCloseHandler);
-          resolve();
+          resolve(undefined);
         };
         var connectionCloseHandler = function () {
           _this.removeListener("ready", connectionReadyHandler);
@@ -419,6 +420,9 @@ Redis.prototype.disconnect = function (reconnect) {
     eventHandler.closeHandler(this)();
   } else {
     this.connector.disconnect();
+    if (this.stream) {
+      this.stream.end();
+    }
   }
 };
 


### PR DESCRIPTION
Currently, a stream (ex `net.Socket`) is returned via a Promise, and error
handlers are attached to the stream in the Promise callback.

However, if the errors are thrown immediately (ex with `process.nextTick()`),
the error handlers will get no chance to attach to the stream, thus
unhandled error events will be thrown.

This PR makes all connectors resolve a factory instead of a created stream,
so the event handlers can be attached in the same tick.

Closes #1236
Closes #1209
Closes #1289