### PR TITLE
Fix cluster issues when code is processed by babel

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -32,7 +32,8 @@ export default function Pipeline(redis) {
   Commander.call(this);
 
   this.redis = redis;
-  this.isCluster = this.redis.constructor.name === "Cluster";
+  this.isCluster =
+    this.redis.constructor.name === "Cluster" || this.redis.isCluster;
   this.isPipeline = true;
   this.options = redis.options;
   this._queue = [];


### PR DESCRIPTION
Closes #1288

There's already a property `isCluster` so we should just use it. The string detection is kept for BC and will be removed in the next major version.