### PR TITLE
fix: support parallel script execution in pipelines

### DIFF
--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -313,12 +313,15 @@ Pipeline.prototype.exec = function (callback: CallbackFunction) {
 
     const script = this._shaToScript[item.args[0]];
 
-    if (!script || this.redis._addedScriptHashes[script.sha]) {
+    if (
+      !script ||
+      this.redis._addedScriptHashes[script.sha] ||
+      scripts.includes(script)
+    ) {
       continue;
     }
 
     scripts.push(script);
-    this.redis._addedScriptHashes[script.sha] = true;
   }
 
   const _this = this;
@@ -330,7 +333,12 @@ Pipeline.prototype.exec = function (callback: CallbackFunction) {
   if (this.isCluster) {
     return pMap(scripts, (script) => _this.redis.script("load", script.lua), {
       concurrency: 10,
-    }).then(execPipeline);
+    }).then(function () {
+      for (let i = 0; i < scripts.length; i++) {
+        _this.redis._addedScriptHashes[scripts[i].sha] = true;
+      }
+      return execPipeline();
+    });
   }
 
   return this.redis
@@ -352,7 +360,12 @@ Pipeline.prototype.exec = function (callback: CallbackFunction) {
         })
       );
     })
-    .then(execPipeline);
+    .then(function () {
+      for (let i = 0; i < scripts.length; i++) {
+        _this.redis._addedScriptHashes[scripts[i].sha] = true;
+      }
+      return execPipeline();
+    });
 
   function execPipeline() {
     let data = "";

--- a/test/functional/pipeline.ts
+++ b/test/functional/pipeline.ts
@@ -320,6 +320,28 @@ describe("pipeline", function () {
         });
       });
     });
+
+    it("should support parallel script execution", function (done) {
+      const random = `${Math.random()}`;
+      const redis = new Redis();
+      redis.defineCommand("something", {
+        numberOfKeys: 0,
+        lua: `return "${random}"`,
+      });
+      Promise.all([
+        redis.multi([["something"]]).exec(),
+        redis.multi([["something"]]).exec(),
+      ])
+        .then(([[first], [second]]) => {
+          expect(first[0]).to.equal(null);
+          expect(first[1]).to.equal(random);
+          expect(second[0]).to.equal(null);
+          expect(second[1]).to.equal(random);
+          redis.disconnect();
+          done();
+        })
+        .catch(done);
+    });
   });
 
   describe("#length", function () {


### PR DESCRIPTION
Fixes #1303

Support parallel .multi script execution by delaying the assignment of the load confirmation.



btw. regarding the project setup: the package-lock.json links to `http://artprod.dev.bloomberg.com/artifactory/api/npm/npm-repos/` as npm registry, which isn't publicly available. Therefore `npm install` and `npm ci` fails locally. By replacing all the urls with the npm registry, the npm install works again.