### PR TITLE
fix: minor compatibility issues caused by TypeScript upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4295,9 +4295,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.9",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
-      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "unbox-primitive": {


### PR DESCRIPTION
Closes #1308

TypeScript 3.9 changes the export signatures that cause some compatibility issues. This PR downgrade it to 3.8.3 to solve the issue. We'll consider TypeScript upgrade as a breaking change so will include it in the next major version.