### PR TITLE
use tls.ConnectionOptions instead of tls.SecureContextOptions

### DIFF
--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -6,7 +6,7 @@ import {
   sample,
   Debug,
 } from "../../utils";
-import { connect as createTLSConnection, SecureContextOptions } from "tls";
+import { connect as createTLSConnection, ConnectionOptions } from "tls";
 import {
   ITcpConnectionOptions,
   isIIpcConnectionOptions,
@@ -42,7 +42,7 @@ export interface ISentinelConnectionOptions extends ITcpConnectionOptions {
   preferredSlaves?: PreferredSlaves;
   connectTimeout?: number;
   enableTLSForSentinelMode?: boolean;
-  sentinelTLS?: SecureContextOptions;
+  sentinelTLS?: ConnectionOptions;
   natMap?: INatMap;
   updateSentinels?: boolean;
 }

--- a/lib/connectors/StandaloneConnector.ts
+++ b/lib/connectors/StandaloneConnector.ts
@@ -1,5 +1,5 @@
 import { createConnection, TcpNetConnectOpts, IpcNetConnectOpts } from "net";
-import { connect as createTLSConnection, SecureContextOptions } from "tls";
+import { connect as createTLSConnection, ConnectionOptions } from "tls";
 import { CONNECTION_CLOSED_ERROR_MSG } from "../utils";
 import AbstractConnector, { ErrorEmitter } from "./AbstractConnector";
 import { NetStream } from "../types";
@@ -11,11 +11,11 @@ export function isIIpcConnectionOptions(
 }
 
 export interface ITcpConnectionOptions extends TcpNetConnectOpts {
-  tls?: SecureContextOptions;
+  tls?: ConnectionOptions;
 }
 
 export interface IIpcConnectionOptions extends IpcNetConnectOpts {
-  tls?: SecureContextOptions;
+  tls?: ConnectionOptions;
 }
 
 export default class StandaloneConnector extends AbstractConnector {

--- a/test/functional/tls.ts
+++ b/test/functional/tls.ts
@@ -15,6 +15,10 @@ describe("tls option", () => {
         // @ts-ignore
         expect(op.ca).to.eql("123");
         // @ts-ignore
+        expect(op.servername).to.eql("localhost");
+        // @ts-ignore
+        expect(op.rejectUnauthorized).to.eql(false);
+        // @ts-ignore
         expect(op.port).to.eql(6379);
         const stream = net.createConnection(op);
         stream.on("connect", (data) => {
@@ -23,7 +27,9 @@ describe("tls option", () => {
         return stream;
       });
 
-      redis = new Redis({ tls: { ca: "123" } });
+      redis = new Redis({
+        tls: { ca: "123", servername: "localhost", rejectUnauthorized: false },
+      });
       redis.on("ready", () => {
         redis.disconnect();
         stub.restore();
@@ -68,6 +74,10 @@ describe("tls option", () => {
       const stub = sinon.stub(tls, "connect").callsFake((op) => {
         // @ts-ignore
         expect(op.ca).to.eql("123");
+        // @ts-ignore
+        expect(op.servername).to.eql("localhost");
+        // @ts-ignore
+        expect(op.rejectUnauthorized).to.eql(false);
         redis.disconnect();
         stub.restore();
         process.nextTick(done);
@@ -77,7 +87,7 @@ describe("tls option", () => {
       redis = new Redis({
         sentinels: [{ port: 27379 }],
         name: "my",
-        tls: { ca: "123" },
+        tls: { ca: "123", servername: "localhost", rejectUnauthorized: false },
         enableTLSForSentinelMode: true,
       });
     });
@@ -96,6 +106,10 @@ describe("tls option", () => {
         // @ts-ignore
         expect(op.ca).to.eql("123");
         // @ts-ignore
+        expect(op.servername).to.eql("localhost");
+        // @ts-ignore
+        expect(op.rejectUnauthorized).to.eql(false);
+        // @ts-ignore
         expect(op.port).to.eql(27379);
         const stream = net.createConnection(op);
         stream.on("connect", (data) => {
@@ -107,7 +121,11 @@ describe("tls option", () => {
       redis = new Redis({
         sentinels: [{ port: 27379 }],
         name: "my",
-        sentinelTLS: { ca: "123" },
+        sentinelTLS: {
+          ca: "123",
+          servername: "localhost",
+          rejectUnauthorized: false,
+        },
       });
       redis.on("ready", () => {
         redis.disconnect();

--- a/test/unit/connectors/connector.ts
+++ b/test/unit/connectors/connector.ts
@@ -32,11 +32,16 @@ describe("StandaloneConnector", () => {
       const spy = sinon.spy(tls, "connect");
       const connector = new StandaloneConnector({
         port: 6379,
-        tls: { ca: "on" },
+        tls: { ca: "on", servername: "localhost", rejectUnauthorized: false },
       });
       await connector.connect(() => {});
       expect(spy.calledOnce).to.eql(true);
-      expect(spy.firstCall.args[0]).to.eql({ port: 6379, ca: "on" });
+      expect(spy.firstCall.args[0]).to.eql({
+        port: 6379,
+        ca: "on",
+        servername: "localhost",
+        rejectUnauthorized: false,
+      });
       connector.disconnect();
     });
   });


### PR DESCRIPTION
Change TLS options to be consistent across the library and align with `tls.connect()` parameter types.

Allows sentinel connections to use all available TLS options. Right now the typings won't allow you to use the full range of TLS options for `sentinelTLS` that `tls.ConnectionOptions` provides.

**Currently:**

```typescript
const redis = new ioredis({
  sentinels: [{
    host: 'localhost',
    port: 26379,
  }],
  name: 'mymaster',
  sentinelTLS: {
    servername: 'localhost', // <- NOT ALLOWED, type error
  },
});
```

```typescript
const redis = new ioredis({
  host: 'localhost',
  port: 6379,
  tls: {
    servername: 'localhost', // <- ALLOWED
  },
});
```

`ConnectionOptions` is used by `tls.connect()`

```typescript
function connect(options: ConnectionOptions, secureConnectListener?: () => void): TLSSocket;
```

`ConnectionOptions` extends `SecureContextOptions`, `CommonConnectionOptions`

```typescript
interface ConnectionOptions extends SecureContextOptions, CommonConnectionOptions
```