### PR TITLE
Detect failover from +switch-master messages

### DIFF
--- a/lib/connectors/SentinelConnector/FailoverDetector.ts
+++ b/lib/connectors/SentinelConnector/FailoverDetector.ts
@@ -1,0 +1,73 @@
+import { Debug } from "../../utils";
+import SentinelConnector from "./index";
+import { ISentinel } from "./types";
+
+const debug = Debug("FailoverDetector");
+
+const CHANNEL_NAME = "+switch-master";
+
+export class FailoverDetector {
+  private connector: SentinelConnector;
+  private sentinels: ISentinel[];
+  private isDisconnected = false;
+
+  // sentinels can't be used for regular commands after this
+  constructor(connector: SentinelConnector, sentinels: ISentinel[]) {
+    this.connector = connector;
+    this.sentinels = sentinels;
+  }
+
+  public cleanup() {
+    this.isDisconnected = true;
+
+    for (const sentinel of this.sentinels) {
+      if (sentinel.isConnected) {
+        sentinel.getClient().disconnect();
+      }
+    }
+  }
+
+  public getClients() {
+    return this.sentinels.map((sentinel) => sentinel.getClient());
+  }
+
+  public async subscribe() {
+    debug("Starting FailoverDetector");
+
+    const promises: Promise<unknown>[] = [];
+
+    for (const sentinel of this.sentinels) {
+      const client = sentinel.getClient();
+
+      const promise = client.subscribe(CHANNEL_NAME).catch((err) => {
+        debug(
+          "Failed to subscribe to failover messages on sentinel %s:%s (%s)",
+          sentinel.address.host || "127.0.0.1",
+          sentinel.address.port || 26739,
+          err.message
+        );
+      });
+
+      promises.push(promise);
+
+      client.on("message", (channel: string) => {
+        if (!this.isDisconnected && channel === CHANNEL_NAME) {
+          this.disconnect();
+        }
+      });
+    }
+
+    await Promise.all(promises);
+  }
+
+  private disconnect() {
+    // Avoid disconnecting more than once per failover.
+    // A new FailoverDetector will be created after reconnecting.
+    this.isDisconnected = true;
+
+    debug("Failover detected, disconnecting");
+
+    // Will call this.cleanup()
+    this.connector.disconnect();
+  }
+}

--- a/lib/connectors/SentinelConnector/types.ts
+++ b/lib/connectors/SentinelConnector/types.ts
@@ -1,4 +1,32 @@
+import { IRedisOptions } from "../../redis/RedisOptions";
+
 export interface ISentinelAddress {
   port: number;
   host: string;
+  family?: number;
+}
+
+// TODO: A proper typedef. This one only declares a small subset of all the members.
+export interface IRedisClient {
+  options: IRedisOptions;
+  sentinel(subcommand: "sentinels", name: string): Promise<string[]>;
+  sentinel(
+    subcommand: "get-master-addr-by-name",
+    name: string
+  ): Promise<string[]>;
+  sentinel(subcommand: "slaves", name: string): Promise<string[]>;
+  subscribe(...channelNames: string[]): Promise<number>;
+  on(
+    event: "message",
+    callback: (channel: string, message: string) => void
+  ): void;
+  on(event: "error", callback: (error: Error) => void): void;
+  on(event: "reconnecting", callback: () => void): void;
+  disconnect(): void;
+}
+
+export interface ISentinel {
+  address: Partial<ISentinelAddress>;
+  isConnected: boolean;
+  getClient: () => IRedisClient;
 }

--- a/lib/connectors/SentinelConnector/types.ts
+++ b/lib/connectors/SentinelConnector/types.ts
@@ -27,6 +27,5 @@ export interface IRedisClient {
 
 export interface ISentinel {
   address: Partial<ISentinelAddress>;
-  isConnected: boolean;
-  getClient: () => IRedisClient;
+  client: IRedisClient;
 }

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -52,6 +52,14 @@ export const DEFAULT_REDIS_OPTIONS: IRedisOptions = {
   sentinelRetryStrategy: function (times) {
     return Math.min(times * 10, 1000);
   },
+  sentinelReconnectStrategy: function () {
+    // This strategy only applies when sentinels are used for detecting
+    // a failover, not during initial master resolution.
+    // The deployment can still function when some of the sentinels are down
+    // for a long period of time, so we may not want to attempt reconnection
+    // very often. Therefore the default interval is fairly long (1 minute).
+    return 60000;
+  },
   natMap: null,
   enableTLSForSentinelMode: false,
   updateSentinels: true,
@@ -75,4 +83,5 @@ export const DEFAULT_REDIS_OPTIONS: IRedisOptions = {
   enableAutoPipelining: false,
   autoPipeliningIgnoredCommands: [],
   maxScriptsCachingTime: 60000,
+  sentinelMaxConnections: 10,
 };

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -153,7 +153,10 @@ function Redis() {
   if (this.options.Connector) {
     this.connector = new this.options.Connector(this.options);
   } else if (this.options.sentinels) {
-    this.connector = new SentinelConnector(this.options);
+    const sentinelConnector = new SentinelConnector(this.options);
+    sentinelConnector.emitter = this;
+
+    this.connector = sentinelConnector;
   } else {
     this.connector = new StandaloneConnector(this.options);
   }

--- a/test/helpers/mock_server.ts
+++ b/test/helpers/mock_server.ts
@@ -124,6 +124,10 @@ export default class MockServer extends EventEmitter {
     this.socket.destroy(callback);
   }
 
+  disconnectPromise() {
+    return new Promise<void>((resolve) => this.disconnect(resolve));
+  }
+
   broadcast(data: any) {
     this.clients
       .filter((c) => c)

--- a/test/helpers/once.ts
+++ b/test/helpers/once.ts
@@ -1,0 +1,28 @@
+// TODO: use 'import { once } from "events";' instead of this
+// after upgrading minimum Node.js version to 10.16+
+
+// This polyfill is from https://github.com/davidmarkclements/events.once
+
+import EventEmitter from "events";
+
+export const once = <T extends any[]>(
+  emitter: EventEmitter,
+  name: string
+): Promise<T> => {
+  return new Promise((resolve, reject) => {
+    const onceError = name === "error";
+    const listener = onceError
+      ? resolve
+      : (...args: any[]) => {
+          emitter.removeListener("error", error);
+          resolve(args as T);
+        };
+    emitter.once(name, listener);
+    if (onceError) return;
+    const error = (err: any) => {
+      emitter.removeListener(name, listener);
+      reject(err);
+    };
+    emitter.once("error", error);
+  });
+};


### PR DESCRIPTION
Fixes #1314

While working on this, I forgot about the `lastActiveSentinel` suggestion from the other issue. At this point, I'm not sure if it's needed, but I can still add it if it is.

I've tested this with various failure scenarios in a Docker cluster and it successfully reconnected in all of them. I also simulated many of the scenarios in new test cases.