### PR TITLE
Fix cluster subscriber connection leaking

### DIFF
--- a/lib/cluster/ClusterSubscriber.ts
+++ b/lib/cluster/ClusterSubscriber.ts
@@ -1,12 +1,10 @@
 import { EventEmitter } from "events";
 import ConnectionPool from "./ConnectionPool";
-import { getNodeKey } from "./util";
+import { getConnectionName, getNodeKey } from "./util";
 import { sample, noop, Debug } from "../utils";
 import Redis from "../redis";
 
 const debug = Debug("cluster:subscriber");
-
-const SUBSCRIBER_CONNECTION_NAME = "ioredisClusterSubscriber";
 
 export default class ClusterSubscriber {
   private started = false;
@@ -81,7 +79,7 @@ export default class ClusterSubscriber {
       username: options.username,
       password: options.password,
       enableReadyCheck: true,
-      connectionName: SUBSCRIBER_CONNECTION_NAME,
+      connectionName: getConnectionName("subscriber", options.connectionName),
       lazyConnect: true,
       tls: options.tls,
     });

--- a/lib/cluster/ClusterSubscriber.ts
+++ b/lib/cluster/ClusterSubscriber.ts
@@ -50,6 +50,10 @@ export default class ClusterSubscriber {
       lastActiveSubscriber.disconnect();
     }
 
+    if (this.subscriber) {
+      this.subscriber.disconnect();
+    }
+
     const sampleNode = sample(this.connectionPool.getNodes());
     if (!sampleNode) {
       debug(
@@ -113,7 +117,10 @@ export default class ClusterSubscriber {
                 this.lastActiveSubscriber = this.subscriber;
               }
             })
-            .catch(noop);
+            .catch(() => {
+              // TODO: should probably disconnect the subscriber and try again.
+              debug("failed to %s %d channels", type, channels.length);
+            });
         }
       }
     } else {

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -11,6 +11,7 @@ import {
   nodeKeyToRedisOptions,
   groupSrvRecords,
   weightSrvRecords,
+  getConnectionName,
 } from "./util";
 import ClusterSubscriber from "./ClusterSubscriber";
 import DelayQueue from "./DelayQueue";
@@ -791,7 +792,10 @@ class Cluster extends EventEmitter {
       enableOfflineQueue: true,
       enableReadyCheck: false,
       retryStrategy: null,
-      connectionName: "ioredisClusterRefresher",
+      connectionName: getConnectionName(
+        "refresher",
+        this.options.redisOptions && this.options.redisOptions.connectionName
+      ),
     });
 
     // Ignore error events since we will handle

--- a/lib/cluster/util.ts
+++ b/lib/cluster/util.ts
@@ -119,3 +119,8 @@ export function weightSrvRecords(recordsGroup: ISrvRecordsGroup): SrvRecord {
     }
   }
 }
+
+export function getConnectionName(component, nodeConnectionName) {
+  const prefix = `ioredis-cluster(${component})`;
+  return nodeConnectionName ? `${prefix}:${nodeConnectionName}` : prefix;
+}

--- a/test/functional/cluster/ClusterSubscriber.ts
+++ b/test/functional/cluster/ClusterSubscriber.ts
@@ -1,0 +1,36 @@
+import ConnectionPool from "../../../lib/cluster/ConnectionPool";
+import ClusterSubscriber from "../../../lib/cluster/ClusterSubscriber";
+import { EventEmitter } from "events";
+import MockServer from "../../helpers/mock_server";
+import { expect } from "chai";
+
+describe("ClusterSubscriber", () => {
+  it("cleans up subscribers when selecting a new one", async () => {
+    const pool = new ConnectionPool({});
+    const subscriber = new ClusterSubscriber(pool, new EventEmitter());
+
+    let rejectSubscribes = false;
+    const server = new MockServer(30000, (argv) => {
+      if (rejectSubscribes && argv[0] === "subscribe") {
+        return new Error("Failed to subscribe");
+      }
+      return "OK";
+    });
+
+    pool.findOrCreate({ host: "127.0.0.1", port: 30000 });
+
+    subscriber.start();
+    await subscriber.getInstance().subscribe("foo");
+    rejectSubscribes = true;
+
+    subscriber.start();
+    await subscriber.getInstance().echo("hello");
+
+    subscriber.start();
+    await subscriber.getInstance().echo("hello");
+
+    expect(server.getAllClients()).to.have.lengthOf(1);
+    subscriber.stop();
+    pool.reset([]);
+  });
+});

--- a/test/functional/cluster/pub_sub.ts
+++ b/test/functional/cluster/pub_sub.ts
@@ -21,7 +21,7 @@ describe("cluster:pub/sub", function () {
     const sub = new Cluster(options);
 
     sub.subscribe("test cluster", function () {
-      node1.write(node1.findClientByName("ioredisClusterSubscriber"), [
+      node1.write(node1.findClientByName("ioredis-cluster(subscriber)"), [
         "message",
         "test channel",
         "hi",
@@ -61,7 +61,7 @@ describe("cluster:pub/sub", function () {
       }
       if (argv[0] === "subscribe") {
         expect(c.password).to.eql("abc");
-        expect(getConnectionName(c)).to.eql("ioredisClusterSubscriber");
+        expect(getConnectionName(c)).to.eql("ioredis-cluster(subscriber)");
       }
       if (argv[0] === "cluster" && argv[1] === "slots") {
         return [[0, 16383, ["127.0.0.1", 30001]]];

--- a/test/helpers/mock_server.ts
+++ b/test/helpers/mock_server.ts
@@ -173,4 +173,8 @@ export default class MockServer extends EventEmitter {
         return getConnectionName(client) === name;
       });
   }
+
+  getAllClients(): Socket[] {
+    return this.clients.filter(Boolean);
+  }
 }


### PR DESCRIPTION
This PR fixes #1325:

1. Close existing subscriber connections before selecting a new one.
2. Use the connection name provided in options for internal connections.

To test:
1. Make sure the leaking issue is fixed.
2. Make sure the connection names for refresher and subscriber are correct.