### PR TITLE
clears commandTimeout timer as each respective command gets fulfilled

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -156,6 +156,7 @@ export default class Command implements ICommand {
   public isCustomCommand = false;
   public inTransaction = false;
   public pipelineIndex?: number;
+  private _commandTimeoutTimer?: number;
 
   private slot?: number | null;
   private keys?: Array<string | Buffer>;

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -344,6 +344,7 @@ export default class Command implements ICommand {
       try {
         if (this._commandTimeoutTimer) {
           clearTimeout(this._commandTimeoutTimer);
+          delete this._commandTimeoutTimer;
         }
 
         resolve(this.transformReply(value));

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -156,7 +156,7 @@ export default class Command implements ICommand {
   public isCustomCommand = false;
   public inTransaction = false;
   public pipelineIndex?: number;
-  private _commandTimeoutTimer?: number;
+  private _commandTimeoutTimer?: Timeout;
 
   private slot?: number | null;
   private keys?: Array<string | Buffer>;

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -156,7 +156,7 @@ export default class Command implements ICommand {
   public isCustomCommand = false;
   public inTransaction = false;
   public pipelineIndex?: number;
-  private _commandTimeoutTimer?: Timeout;
+  private _commandTimeoutTimer?: ReturnType<typeof setTimeout>;
 
   private slot?: number | null;
   private keys?: Array<string | Buffer>;

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -156,7 +156,7 @@ export default class Command implements ICommand {
   public isCustomCommand = false;
   public inTransaction = false;
   public pipelineIndex?: number;
-  private _commandTimeoutTimer?: ReturnType<typeof setTimeout>;
+  private _commandTimeoutTimer?: NodeJS.Timeout;
 
   private slot?: number | null;
   private keys?: Array<string | Buffer>;

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -342,6 +342,10 @@ export default class Command implements ICommand {
   private _convertValue(resolve: Function): (result: any) => void {
     return (value) => {
       try {
+        if (this._commandTimeoutTimer) {
+          clearTimeout(this._commandTimeoutTimer);
+        }
+
         resolve(this.transformReply(value));
         this.isResolved = true;
       } catch (err) {

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -343,8 +343,9 @@ export default class Command implements ICommand {
   private _convertValue(resolve: Function): (result: any) => void {
     return (value) => {
       try {
-        if (this._commandTimeoutTimer) {
-          clearTimeout(this._commandTimeoutTimer);
+        const existingTimer = this._commandTimeoutTimer;
+        if (existingTimer) {
+          clearTimeout(existingTimer);
           delete this._commandTimeoutTimer;
         }
 
@@ -375,6 +376,20 @@ export default class Command implements ICommand {
     }
 
     return result;
+  }
+
+  /**
+   * Set the wait time before terminating the attempt to execute a command
+   * and generating an error.
+   */
+  public setTimeout(ms: number) {
+    if (!this._commandTimeoutTimer) {
+      this._commandTimeoutTimer = setTimeout(() => {
+        if (!this.isResolved) {
+          this.reject(new Error("Command timed out"));
+        }
+      }, ms);
+    }
   }
 }
 

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -690,7 +690,7 @@ addTransactionSupport(Redis.prototype);
  * ```
  * @private
  */
-Redis.prototype.sendCommand = function (command, stream) {
+Redis.prototype.sendCommand = function (command: Command, stream) {
   if (this.status === "wait") {
     this.connect().catch(noop);
   }
@@ -711,11 +711,7 @@ Redis.prototype.sendCommand = function (command, stream) {
   }
 
   if (typeof this.options.commandTimeout === "number") {
-    command._commandTimeoutTimer = setTimeout(() => {
-      if (!command.isResolved) {
-        command.reject(new Error("Command timed out"));
-      }
-    }, this.options.commandTimeout);
+    command.setTimeout(this.options.commandTimeout);
   }
 
   if (command.name === "quit") {

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -710,7 +710,7 @@ Redis.prototype.sendCommand = function (command, stream) {
     return command.promise;
   }
 
-  if (typeof this.options.commandTimeout === "number" && command.name !== 'cluster') {
+  if (typeof this.options.commandTimeout === "number") {
     command._commandTimeoutTimer = setTimeout(() => {
       if (!command.isResolved) {
         command.reject(new Error("Command timed out"));

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -710,8 +710,8 @@ Redis.prototype.sendCommand = function (command, stream) {
     return command.promise;
   }
 
-  if (typeof this.options.commandTimeout === "number") {
-    setTimeout(() => {
+  if (typeof this.options.commandTimeout === "number" && command.name !== 'cluster') {
+    command._commandTimeoutTimer = setTimeout(() => {
       if (!command.isResolved) {
         command.reject(new Error("Command timed out"));
       }

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -111,7 +111,7 @@ export function wrapMultiResult(arr) {
  * ```
  * @private
  */
-export function isInt(value) {
+export function isInt(value): value is string {
   const x = parseFloat(value);
   return !isNaN(value) && (x | 0) === x;
 }

--- a/test/functional/commandTimeout.ts
+++ b/test/functional/commandTimeout.ts
@@ -22,4 +22,16 @@ describe("commandTimeout", function () {
     });
     clock.tick(1000);
   });
+
+  it("does not leak timers for commands in offline queue", async function () {
+    const server = new MockServer(30001);
+
+    const redis = new Redis({ port: 30001, commandTimeout: 1000 });
+    const clock = sinon.useFakeTimers();
+    await redis.hget("foo");
+    expect(clock.countTimers()).to.eql(0);
+    clock.restore();
+    redis.disconnect();
+    await new Promise((resolve) => server.disconnect(() => resolve(null)));
+  });
 });

--- a/test/functional/commandTimeout.ts
+++ b/test/functional/commandTimeout.ts
@@ -32,6 +32,6 @@ describe("commandTimeout", function () {
     expect(clock.countTimers()).to.eql(0);
     clock.restore();
     redis.disconnect();
-    await new Promise((resolve) => server.disconnect(() => resolve(null)));
+    await server.disconnectPromise();
   });
 });


### PR DESCRIPTION
Currently, using the `commandTimeout` option is creating one timer per command and they're not being cleared as each command gets fulfilled. This PR does that.