### PR TITLE
perf: Serialize error stack only when needed

### DIFF
--- a/benchmarks/errorStack.ts
+++ b/benchmarks/errorStack.ts
@@ -1,0 +1,38 @@
+import { cronometro } from "cronometro";
+import Redis from "../lib/redis";
+
+let redis;
+
+cronometro(
+  {
+    default: {
+      test() {
+        return redis.set("foo", "bar");
+      },
+      before(cb) {
+        redis = new Redis();
+        cb();
+      },
+      after(cb) {
+        redis.quit();
+        cb();
+      },
+    },
+    "showFriendlyErrorStack=true": {
+      test() {
+        return redis.set("foo", "bar");
+      },
+      before(cb) {
+        redis = new Redis({ showFriendlyErrorStack: true });
+        cb();
+      },
+      after(cb) {
+        redis.quit();
+        cb();
+      },
+    },
+  },
+  {
+    print: { compare: true },
+  }
+);

--- a/lib/command.ts
+++ b/lib/command.ts
@@ -20,7 +20,7 @@ interface ICommandOptions {
    * @memberof ICommandOptions
    */
   replyEncoding?: string | null;
-  errorStack?: string;
+  errorStack?: Error;
   keyPrefix?: string;
   /**
    * Force the command to be readOnly so it will also execute on slaves
@@ -149,7 +149,7 @@ export default class Command implements ICommand {
   public isReadOnly?: boolean;
 
   private replyEncoding: string | null;
-  private errorStack: string;
+  private errorStack: Error;
   public args: CommandParameter[];
   private callback: CallbackFunction;
   private transformed = false;
@@ -215,7 +215,7 @@ export default class Command implements ICommand {
       this.resolve = this._convertValue(resolve);
       if (this.errorStack) {
         this.reject = (err) => {
-          reject(optimizeErrorStack(err, this.errorStack, __dirname));
+          reject(optimizeErrorStack(err, this.errorStack.stack, __dirname));
         };
       } else {
         this.reject = reject;

--- a/lib/commander.ts
+++ b/lib/commander.ts
@@ -160,9 +160,7 @@ function generateFunction(
     }
 
     const options = {
-      errorStack: this.options.showFriendlyErrorStack
-        ? new Error().stack
-        : undefined,
+      errorStack: this.options.showFriendlyErrorStack ? new Error() : undefined,
       keyPrefix: this.options.keyPrefix,
       replyEncoding: _encoding,
     };
@@ -226,7 +224,7 @@ function generateScriptingFunction(
     }
 
     if (this.options.showFriendlyErrorStack) {
-      options.errorStack = new Error().stack;
+      options.errorStack = new Error();
     }
 
     // No auto pipeline, use regular command sending


### PR DESCRIPTION
Improving Error stack serialization performance when `showFriendlyErrorStack=true`.

With current implementation there's about 30% overhead because the stack trace is serialized even when it's not actually needed.

With proposed change the overhead is somewhere between 1-5% on Node 14. There were improvements related to stack trace serialization in Node 12.

On the attached benchmark results, first run is on old code, second run on new code. Benchmark code also committed.

![image](https://user-images.githubusercontent.com/191152/120192643-1ca33000-c224-11eb-8cf7-1ff44cb59f40.png)