### PR TITLE
fix(SENTINEL): disable active failover detection by default

### DIFF
--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -52,6 +52,7 @@ export interface ISentinelConnectionOptions extends ITcpConnectionOptions {
   natMap?: INatMap;
   updateSentinels?: boolean;
   sentinelMaxConnections?: number;
+  failoverDetector?: boolean;
 }
 
 export default class SentinelConnector extends AbstractConnector {
@@ -321,6 +322,9 @@ export default class SentinelConnector extends AbstractConnector {
   }
 
   private async initFailoverDetector(): Promise<void> {
+    if (!this.options.failoverDetector) {
+      return;
+    }
     // Move the current sentinel to the first position
     this.sentinelIterator.reset(true);
 

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -63,6 +63,7 @@ export const DEFAULT_REDIS_OPTIONS: IRedisOptions = {
   natMap: null,
   enableTLSForSentinelMode: false,
   updateSentinels: true,
+  failoverDetector: false,
   // Status
   username: null,
   password: null,

--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -98,6 +98,11 @@ const debug = Debug("redis");
  * @param {NatMap} [options.natMap=null] NAT map for sentinel connector.
  * @param {boolean} [options.updateSentinels=true] - Update the given `sentinels` list with new IP
  * addresses when communicating with existing sentinels.
+ * @param {boolean} [options.failoverDetector=false] - Detect failover actively by subscribing to the
+ * related channels. With this option disabled, ioredis is still able to detect failovers because Redis
+ * Sentinel will disconnect all clients whenever a failover happens, so ioredis will reconnect to the new
+ * master. This option is useful when you want to detect failover quicker, but it will create more TCP
+ * connections to Redis servers in order to subscribe to related channels.
 * @param {boolean} [options.enableAutoPipelining=false] - When enabled, all commands issued during an event loop
  * iteration are automatically wrapped in a pipeline and sent to the server at the same time.
  * This can dramatically improve performance.


### PR DESCRIPTION
There is an issue related to connections used for active failover detection for sentinels not being cleaned up properly: #1362. Given that not many users realize the usefulness of this feature, and the feature does create more connections, we disable it by default and allow users to enable it with the option`failoverDetector`.