### PR TITLE
add RedisReadable and RedisWritable

### DIFF
--- a/lib/ScanStream.ts
+++ b/lib/ScanStream.ts
@@ -16,7 +16,7 @@ export interface IScanStreamOptions extends ReadableOptions {
 }
 
 /**
- * Convenient class to convert the process of scaning keys to a readable stream.
+ * Convenient class to convert the process of scanning keys to a readable stream.
  *
  * @export
  * @class ScanStream

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,8 @@ export { default } from "./redis";
 export { default as Cluster } from "./cluster";
 export { default as Command } from "./command";
 export { default as ScanStream } from "./ScanStream";
+export { default as RedisReadable } from "./streams/RedisReadable";
+export { default as RedisWritable } from "./streams/RedisWritable";
 export { default as Pipeline } from "./pipeline";
 export { default as AbstractConnector } from "./connectors/AbstractConnector";
 export {

--- a/lib/streams/RedisReadable.ts
+++ b/lib/streams/RedisReadable.ts
@@ -1,0 +1,114 @@
+import { Readable, ReadableOptions } from "stream";
+
+/**
+ * Options for RedisReadable
+ *
+ * @export
+ * @interface RedisReadable
+ * @extends {ReadableOptions}
+ */
+interface IRedisReadableOptions extends ReadableOptions {
+  redis: any;
+
+  key: string;
+
+  /**
+   * The minimum ttl of the key.
+   *
+   * RedisReadable will increase the ttl if the current ttl of the key is
+   * lower than the given value.
+   *
+   * @default 900
+   */
+  minimumReadTTL?: number;
+}
+
+/**
+ * Convenient class to use Redis Streams introduced by Redis 5.0.0
+ *
+ * @see https://redis.io/topics/streams-intro
+ *
+ * @export
+ * @class RedisReadable
+ * @extends {Readable}
+ */
+export default class RedisReadable extends Readable {
+  private chunkSize: number;
+
+  private next: string;
+
+  constructor(private opts = ({} as unknown) as IRedisReadableOptions) {
+    super(opts);
+
+    if (!this.opts.redis) {
+      throw new Error(
+        "Failed to instantiate RedisReadable. The field 'redis' was not provided as option."
+      );
+    }
+
+    if (!this.opts.key) {
+      throw new Error(
+        "Failed to instantiate RedisReadable. The field 'key' was not provided as option."
+      );
+    }
+
+    if (this.opts.objectMode) {
+      throw new Error("RedisReadable does not support objectMode.");
+    }
+
+    this.next = "-";
+
+    this.ensureTTL(this.opts.minimumReadTTL).catch((reason) =>
+      this.emit("error", reason)
+    );
+  }
+
+  _read(size: number): void {
+    const xrangeCount = Math.max(1, Math.ceil(size / this.chunkSize)) || 1;
+
+    const xrangeBufferArguments = this.chunkSize
+      ? [this.opts.key, this.next, "+", "COUNT", xrangeCount]
+      : [this.opts.key, "-", "+", "COUNT", 1];
+
+    this.opts.redis.xrangeBuffer
+      .apply(this.opts.redis, xrangeBufferArguments)
+      .then((chunks: [Buffer, [Buffer, Buffer]][]) => {
+        if (chunks.length === 0) {
+          this.push(null);
+          return;
+        }
+
+        if (!this.chunkSize) {
+          this.chunkSize = chunks[0][1][1].length;
+        }
+
+        this.next = this.getNext(chunks);
+
+        this.push(Buffer.concat(chunks.map((res) => res[1][1])));
+      });
+  }
+
+  _destroy(err, callback: (error?: Error | null) => void): void {
+    this.opts.autoDestroy
+      ? this.opts.redis
+          .unlink(this.opts.key)
+          .catch((err) => callback(err))
+          .then(() => callback(err))
+      : callback(err);
+  }
+
+  async ensureTTL(minimumTTL = 15 * 60): Promise<void> {
+    const ttl = await this.opts.redis.ttl(this.opts.key);
+
+    if (ttl !== -1 && ttl < minimumTTL) {
+      await this.opts.redis.expire(this.opts.key, minimumTTL);
+    }
+  }
+
+  getNext(chunks: [Buffer, [Buffer, Buffer]][]): string {
+    const [id, iterator] = chunks[chunks.length - 1][0]
+      .toString("binary")
+      .split("-") as [string, string];
+    return `${id}-${Number(iterator) + 1}`;
+  }
+}

--- a/lib/streams/RedisWritable.ts
+++ b/lib/streams/RedisWritable.ts
@@ -1,0 +1,141 @@
+import { Writable, WritableOptions } from "stream";
+
+/**
+ * Options for RedisWritable
+ *
+ * @export
+ * @interface IRedisWritableOptions
+ * @extends {WritableOptions}
+ */
+interface IRedisWritableOptions extends WritableOptions {
+  redis: any;
+
+  key: string;
+
+  /**
+   * The ttl of the entry in Redis in seconds.
+   * @default 900
+   */
+  ttl?: number;
+
+  /**
+   * The ttl of the temp Key in seconds.
+   * @default 900
+   */
+  ttlTempKey?: number;
+}
+
+/**
+ * Convenient class to use Redis Streams introduced by Redis 5.0.0
+ *
+ * @see https://redis.io/topics/streams-intro
+ *
+ * @export
+ * @class RedisWritable
+ * @extends {Writable}
+ */
+export default class RedisWritable extends Writable {
+  private hasData: boolean;
+
+  constructor(private opts = ({} as unknown) as IRedisWritableOptions) {
+    super(opts);
+
+    if (!this.opts.redis) {
+      throw new Error(
+        "Failed to instantiate RedisWritable. The field 'redis' was not provided as option."
+      );
+    }
+
+    if (!this.opts.key) {
+      throw new Error(
+        "Failed to instantiate RedisWritable. The field 'key' was not provided as option."
+      );
+    }
+
+    if (this.opts.objectMode) {
+      throw new Error("RedisWritable does not support objectMode.");
+    }
+
+    this.opts.ttl = this.opts.ttl ?? 15 * 60; // default is 15 minutes
+    this.opts.ttlTempKey = this.opts.ttlTempKey ?? 15 * 60; // default is 15 minutes
+  }
+
+  public async ensureWriteLock(): Promise<void> {
+    if (!this.hasData) {
+      const tempKeyExists = await this.opts.redis.exists(
+        `${this.opts.key}_temp`,
+        this.opts.key
+      );
+
+      if (tempKeyExists !== 0) {
+        throw new Error(
+          `Error while writing to Redis Stream. Key: '${this.opts.key}' is already in use.`
+        );
+      }
+    }
+  }
+
+  _write(
+    chunk: any,
+    encoding: string,
+    callback: (error?: Error | null) => void
+  ): void {
+    this.ensureWriteLock()
+      .then(() => {
+        const tmpKey = `${this.opts.key}_temp`;
+
+        const xaddBufferArguments =
+          typeof this.opts.highWaterMark === "number"
+            ? [tmpKey, "MAXLEN", this.opts.highWaterMark, "*", null, chunk]
+            : [tmpKey, "*", null, chunk];
+
+        this.opts.redis.xaddBuffer
+          .apply(this.opts.redis, xaddBufferArguments)
+          .catch((err) => callback(err))
+          .then(() => {
+            if (!this.hasData) {
+              this.opts.redis
+                .expire(tmpKey, this.opts.ttlTempKey)
+                .then(() => {
+                  this.hasData = true;
+                  callback(null);
+                })
+                .catch((err) => callback(err));
+            } else {
+              callback(null);
+            }
+          });
+      })
+      .catch((err) => callback(err));
+  }
+
+  _final(callback: (error?: Error | null) => void): void {
+    if (!this.hasData) {
+      return callback();
+    }
+
+    const tmpKey = `${this.opts.key}_temp`;
+
+    this.opts.redis
+      .rename(tmpKey, this.opts.key)
+      .then(() => {
+        if (this.opts.ttl) {
+          this.opts.redis
+            .expire(this.opts.key, this.opts.ttl)
+            .then(() => callback(null))
+            .catch((err) => callback(err));
+        } else {
+          this.opts.redis
+            .persist(this.opts.key)
+            .then(() => callback(null))
+            .catch((err) => callback(err));
+        }
+      })
+      .catch((err) => callback(err));
+  }
+
+  _destroy(err, callback: (error?: Error | null) => void): void {
+    this.opts.redis.unlink(`${this.opts.key}_temp`).catch((err) => {});
+    callback(err);
+  }
+}


### PR DESCRIPTION
This PR adds RedisReadable and RedisWritable to ioredis

These are convenient classes, which bring Redis Streams to the Node ecosystem.