### PR TITLE
Fix more edge cases in autopipelining when using redis cluster

### DIFF
--- a/lib/commander.ts
+++ b/lib/commander.ts
@@ -173,7 +173,7 @@ function generateFunction(
     }
 
     // No auto pipeline, use regular command sending
-    if (!shouldUseAutoPipelining(this, functionName, commandName)) {
+    if (!shouldUseAutoPipelining(this, functionName, commandName, args)) {
       return this.sendCommand(
         new Command(commandName, args, options, callback)
       );
@@ -228,7 +228,7 @@ function generateScriptingFunction(
     }
 
     // No auto pipeline, use regular command sending
-    if (!shouldUseAutoPipelining(this, functionName, commandName)) {
+    if (!shouldUseAutoPipelining(this, functionName, commandName, args)) {
       return script.execute(this, args, options, callback);
     }
 


### PR DESCRIPTION
Fixes #1392

This is a superset of the fixes in https://github.com/luin/ioredis/pull/1391

The other issue this PR fixes was that this was passing an array instead of a string to
cluster-key-slot when `args[0]` was an array

Handle pathological cases such as redis.get([], ['key1', 'key2'])
by flattening the entire args array.

Prior to this PR, in the below example, the array was hashed instead of the first string in the array,
meaning that 'v{profile}1' and 'b' were incorrectly put in the same pipeline

```js
const IORedis = require('./built');
const process = require('process');
async function main() {
    // Using instructions from https://redis.io/topics/cluster-tutorial
    // redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 --cluster-replicas 0
    const redis = new IORedis.Cluster([{ host: '127.0.0.1', port:7000 }], { enableAutoPipelining: true });
    const results = await Promise.all([
      redis.mget(['v{profile}1', 'v{profile}2', 'v{profile}3', 'v{profile}4']),
      redis.get('b'),
    ]);
    console.log(results);
    process.exit(0);
}
main();
```