### PR TITLE
fixbug[cluster/index.ts] GetInfoFromNode slotRangeStart and slotRangeEnd WrongType

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -861,7 +861,7 @@ class Cluster extends EventEmitter {
             keys
           );
 
-          for (let slot = slotRangeStart; slot <= slotRangeEnd; slot++) {
+          for (let slot = Number(slotRangeStart); slot <= Number(slotRangeEnd); slot++) {
             this.slots[slot] = keys;
           }
         }


### PR DESCRIPTION
GetInfoFromNode slotRangeStart and slotRangeEnd WrongType