### PR TITLE
fix: make sure other command wait for auth response.

### DIFF
--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -19,9 +19,14 @@ export function connectHandler(self) {
     // AUTH command should be processed before any other commands
     let flushed = false;
     const { connectionEpoch } = self;
+    let authResolve;
+    const authPro = new Promise((resolve) => {
+      authResolve = resolve;
+    });
     if (self.condition.auth) {
       self.auth(self.condition.auth, function (err) {
         if (connectionEpoch !== self.connectionEpoch) {
+          authResolve();
           return;
         }
         if (err) {
@@ -50,7 +55,11 @@ export function connectHandler(self) {
             self.recoverFromFatalError(err, err);
           }
         }
+        
+        authResolve();
       });
+    } else {
+      authResolve();
     }
 
     if (self.condition.select) {
@@ -76,25 +85,27 @@ export function connectHandler(self) {
     });
 
     if (self.options.enableReadyCheck) {
-      self._readyCheck(function (err, info) {
-        if (connectionEpoch !== self.connectionEpoch) {
-          return;
-        }
-        if (err) {
-          if (!flushed) {
-            self.recoverFromFatalError(
-              new Error("Ready check failed: " + err.message),
-              err
-            );
+      authPro.then(() => {
+        self._readyCheck(function (err, info) {
+          if (connectionEpoch !== self.connectionEpoch) {
+            return;
           }
-        } else {
-          self.serverInfo = info;
-          if (self.connector.check(info)) {
-            exports.readyHandler(self)();
+          if (err) {
+            if (!flushed) {
+              self.recoverFromFatalError(
+                new Error("Ready check failed: " + err.message),
+                err
+              );
+            }
           } else {
-            self.disconnect(true);
+            self.serverInfo = info;
+            if (self.connector.check(info)) {
+              exports.readyHandler(self)();
+            } else {
+              self.disconnect(true);
+            }
           }
-        }
+        });
       });
     }
   };

--- a/test/functional/connection.ts
+++ b/test/functional/connection.ts
@@ -32,6 +32,7 @@ describe("connection", function () {
       times += 1;
       if (times === 1) {
         expect(command.name).to.eql("auth");
+        return command.resolve("OK");
       } else if (times === 2) {
         expect(command.name).to.eql("info");
         redis.disconnect();
@@ -549,15 +550,15 @@ describe("disconnection", function () {
       }
     });
   });
-  
+
   it("should clear the added script hashes interval even when no connection succeeded", function (done) {
     let attempt = 0;
-    const redis = new Redis(0, 'localhost');
-    
+    const redis = new Redis(0, "localhost");
+
     redis.on("error", function () {
-      if(attempt < 5) {
-        attempt ++;
-        return
+      if (attempt < 5) {
+        attempt++;
+        return;
       }
 
       redis.quit();


### PR DESCRIPTION
When network transmission lag,`_readyCheck` not wait for auth response,that make redis client throw error and reconnection.

![image](https://user-images.githubusercontent.com/9568094/129180614-11d45e5d-4605-4b1a-8228-becd541a4ec5.png)
