### PR TITLE
use null prototype instead of additional check

### DIFF
--- a/lib/command.ts
+++ b/lib/command.ts
@@ -425,22 +425,9 @@ Command.setArgumentTransformer("hmset", hsetArgumentTransformer);
 
 Command.setReplyTransformer("hgetall", function (result) {
   if (Array.isArray(result)) {
-    const obj = {};
+    const obj = Object.create(null);
     for (let i = 0; i < result.length; i += 2) {
-      const key = result[i];
-      const value = result[i + 1];
-      if (key in obj) {
-        // can only be truthy if the property is special somehow, like '__proto__' or 'constructor'
-        // https://github.com/luin/ioredis/issues/1267
-        Object.defineProperty(obj, key, {
-          value,
-          configurable: true,
-          enumerable: true,
-          writable: true,
-        });
-      } else {
-        obj[key] = value;
-      }
+      obj[result[i]] = result[i + 1];
     }
     return obj;
   }

--- a/test/functional/hgetall.ts
+++ b/test/functional/hgetall.ts
@@ -32,6 +32,6 @@ describe("hgetall", function () {
     expect(Object.keys(ret).sort()).to.eql(
       ["__proto__", CUSTOM_PROPERTY].sort()
     );
-    expect(Object.getPrototypeOf(ret)).to.eql(Object.prototype);
+    expect(Object.getPrototypeOf(ret)).to.eql(null);
   });
 });


### PR DESCRIPTION
Followup on https://github.com/luin/ioredis/pull/1416, this is a more efficient way of fixing the issue by creating a object that does not inherit anything.