### PR TITLE
Fix undefined property Error in executeAutoPipeline

### DIFF
--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -27,6 +27,16 @@ function executeAutoPipeline(client, slotKey: string) {
   if (client._runningAutoPipelines.has(slotKey)) {
     return;
   }
+  if (!client._autoPipelines.has(slotKey)) {
+    /* 
+      Rare edge case. Somehow, something has deleted this running autopipeline in an immediate 
+      call to executeAutoPipeline. 
+     
+      Maybe the callback in the pipeline.exec is sometimes called in the same tick,
+      e.g. if redis is disconnected?
+    */
+    return;
+  }
 
   client._runningAutoPipelines.add(slotKey);
 


### PR DESCRIPTION
Seen in an uncaughtException handler with ioredis 4.27.7

The application having this issue has a constant&high volume of redis calls, and is using both Redis and Redis.Cluster clients to connect to different redis servers. So it might be related to redis cluster. Or newrelic, but I doubt it, processImmediate is something I'd guess would be from the setImmediate call?

This is happening throughout the day

```
err_type=uncaughtException, exiting cause=TypeError: Cannot read property 'Symbol(callbacks)' of undefined
    at Immediate.executeAutoPipeline (.../node_modules/ioredis/built/autoPipelining.js:34:31)
    at Shim.applySegment (.../node_modules/newrelic/lib/shim/shim.js:1430:20)
    at Immediate.wrapper (.../node_modules/newrelic/lib/shim/shim.js:2097:17)
    at processImmediate (internal/timers.js:463:21)
```

A similar error was among the errors reported in
https://github.com/luin/ioredis/issues/1248

I suspect the process.exec might call the callback synchronously in the
same tick in some cases, immediately deleting the autopipeline from
running pipelines?

i.e. my guess is that

1. Something calls setImmediate for executeAutoPipeline
2. Something else calls setImmediate
3. The next tick starts
4. immediateHandler calls executeAutoPipeline the first time, and the `.exec` somehow synchronously happens(same tick) and deletes the key from the Map
5. immediateHandler calls executeAutoPipeline the second time for the same shard key, but because the shardKey was deleted, the fetched value was undefined