### PR TITLE
fix: make export interface compatible with jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3247,9 +3247,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "server-destroy": "^1.0.1",
     "sinon": "^9.0.1",
     "ts-node": "^8.8.1",
-    "typescript": "^3.8.3",
+    "typescript": "3.8.3",
     "uuid": "^8.3.0"
   },
   "engines": {


### PR DESCRIPTION
Closes #1442

TypeScript doesn't follow semantic versioning, and 3.9 introduced some breaking changes to the export interface.

This PR locks its version.

### Test Plan

Make sure tests pass should be enough.