### PR TITLE
Document enableTLSForSentinelMode Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,7 @@ The arguments passed to the constructor are different from the ones you use to c
 - `sentinels` are a list of sentinels to connect to. The list does not need to enumerate all your sentinel instances, but a few so that if one is down the client will try the next one.
 - `role` (optional) with a value of `slave` will return a random slave from the Sentinel group.
 - `preferredSlaves` (optional) can be used to prefer a particular slave or set of slaves based on priority. It accepts a function or array.
+- `enableTLSForSentinelMode` (optional) set to true if connecting to sentinel instances that are encrypted
 
 ioredis **guarantees** that the node you connected to is always a master even after a failover. When a failover happens, instead of trying to reconnect to the failed node (which will be demoted to slave when it's available again), ioredis will ask sentinels for the new master node and connect to it. All commands sent during the failover are queued and will be executed when the new connection is established so that none of the commands will be lost.
 


### PR DESCRIPTION
Add to the sentinel section of the readme.  Without this option, encrypted versions of redis sentinel fail with obscure errors