### PR TITLE
Handle possible unhandled promise rejection with autopipelining+cluster

### DIFF
--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -121,22 +121,25 @@ export function executeWithAutoPipelining(
   // On cluster mode let's wait for slots to be available
   if (client.isCluster && !client.slots.length) {
     if (client.status === "wait") client.connect().catch(noop);
-    return new CustomPromise(function (resolve, reject) {
-      client.delayUntilReady((err) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+    return asCallback(
+      new CustomPromise(function (resolve, reject) {
+        client.delayUntilReady((err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
 
-        executeWithAutoPipelining(
-          client,
-          functionName,
-          commandName,
-          args,
-          callback
-        ).then(resolve, reject);
-      });
-    });
+          executeWithAutoPipelining(
+            client,
+            functionName,
+            commandName,
+            args,
+            null
+          ).then(resolve, reject);
+        });
+      }),
+      callback
+    );
   }
 
   // If we have slot information, we can improve routing by grouping slots served by the same subset of nodes


### PR DESCRIPTION
Deliberately add `asCallback` on the **same** Promise instance being returned,
not on a different Promise instance that resolves to the same thing.

Avoid this category of unhandledRejection errors:

```javascript
process.on('unhandledRejection', (reason) => console.log('unhandledRejection', reason));
const x = Promise.reject(new Error());
x.catch((e) => console.log('caught x', e));

const causesUnhandledRejection = Promise.resolve().then(() => x);
```

Related to #1466