### PR TITLE
scanStream TYPE test requires redis 6

### DIFF
--- a/test/helpers/util.ts
+++ b/test/helpers/util.ts
@@ -1,0 +1,12 @@
+const VERSION_REGEX = /\bredis_version:(\d+)\.(\d+)\.(\d+)/;
+
+export async function getRedisVersion(redis: Redis) {
+  const raw = await redis.info("server");
+  const match = VERSION_REGEX.exec(raw);
+  if (match) {
+    return [match[1], match[2], match[3]];
+  }
+  throw new Error(
+    "Could not determine redis version from: " + JSON.stringify(raw)
+  );
+}


### PR DESCRIPTION
See https://redis.io/commands/scan

When this test fails in local development
it stops the rest of the tests from running.
Some OSes (versions) have redis 5 or older installed.