### PR TITLE
fix: fix a memory leak with autopipelining.

### DIFF
--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -45,6 +45,10 @@ function executeAutoPipeline(client, slotKey: string) {
   client._autoPipelines.delete(slotKey);
 
   const callbacks = pipeline[kCallbacks];
+  // Stop keeping a reference to callbacks immediately after the callbacks stop being used.
+  // This allows the GC to reclaim objects referenced by callbacks, especially with 16384 slots
+  // in Redis.Cluster
+  pipeline[kCallbacks] = null;
 
   // Perform the call
   pipeline.exec(function (err, results) {


### PR DESCRIPTION
Set kCallbacks field to null instead of the empty array because nothing
should append to it until a new pipeline starts.
If anything did, that is a bug.

With Redis.Cluster, there could be 16384 different arrays pointing to
callbacks that aren't needed.

Memory impact probably isn't significant if those all point to Promises to resolve/reject,
though I guess the resolved data could itself be large in some cases