### PR TITLE
fix reply[2] is null issue

### DIFF
--- a/lib/DataHandler.ts
+++ b/lib/DataHandler.ts
@@ -119,7 +119,7 @@ export default class DataHandler {
       case "message":
         if (this.redis.listeners("message").length > 0) {
           // Check if there're listeners to avoid unnecessary `toString()`.
-          this.redis.emit("message", reply[1].toString(), reply[2].toString());
+          this.redis.emit("message", reply[1].toString(), reply[2] ? reply[2].toString() : '');
         }
         this.redis.emit("messageBuffer", reply[1], reply[2]);
         break;


### PR DESCRIPTION
when works with the new server assist client side cache feature, redis sends single string "\_\_redis\_\_:invalidate" from server.
so reply[2] is null, the update fixes the issue