### PR TITLE
Fix script loading behavior on script flush with pipelines

### DIFF
--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -316,6 +316,10 @@ Redis.prototype.connect = function (callback) {
     // Make sure only one timer is active at a time
     clearInterval(this._addedScriptHashesCleanInterval);
 
+    // Scripts need to get reset on reconnect as redis
+    // might have been restarted or some failover happened
+    this._addedScriptHashes = {};
+
     // Start the script cache cleaning
     this._addedScriptHashesCleanInterval = setInterval(() => {
       this._addedScriptHashes = {};


### PR DESCRIPTION
Lua scripts get loaded once and not retried unless a client side interval expires: https://github.com/luin/ioredis/blob/master/lib/pipeline.ts#L376

This causes issues with redis instances restarting or failing over.
There's no way of knowing whether a script is still present in the new instance.
We should reset the local state and just load them again when a reconnect happens and rely on the existing code that checks whether the scripts are present on the server.

~I ran into that issue while testing the reliability of a service, but it might also fix https://github.com/luin/ioredis/issues/1405~ See #1499 for the cluster fixes.

There's still a small time window where `NOSCRIPT` errors occur as messages are already queued for execution. ~Previously the script handler only executed `EVAL` in the non-pipeline mode. This now changed and always gets executed.~

### Changelog
- 🐛 Reset loaded script hashes to force a reload of scripts after reconnect of redis