### PR TITLE
#1500 Make sure the _addedScriptHashesCleanInterval is cleared on end.

### DIFF
--- a/lib/redis/index.ts
+++ b/lib/redis/index.ts
@@ -321,6 +321,12 @@ Redis.prototype.connect = function (callback) {
       this._addedScriptHashes = {};
     }, this.options.maxScriptsCachingTime);
 
+    this.on("end", () => {
+      console.log("On end, going to clear interval.");
+      clearInterval(this._addedScriptHashesCleanInterval);
+      this._addedScriptHashesCleanInterval = null;
+    });
+
     this.connectionEpoch += 1;
     this.setStatus("connecting");
 


### PR DESCRIPTION
This PR makes sure that intervals are cleared on `end`. 

In Issue #1500 I describe a case affecting ioredis clients Node event loop not being able to exit because of left over `Intervals`. 

Running the scenario described in #1500 with this branch lets Node exit.