### PR TITLE
feat: skip ready check on NOPERM error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,7 +60,7 @@
   },
   "overrides": [
     {
-      "files": ["test/**/*"],
+      "files": ["test/**/*", "test-cluster/**/*"],
       "env": {
         "mocha": true
       },

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -766,6 +766,12 @@ class Redis extends Commander {
     const _this = this;
     this.info(function (err, res) {
       if (err) {
+        if (err.message && err.message.includes("NOPERM")) {
+          console.warn(
+            `Skipping the ready check because INFO command fails: "${err.message}". You can disable ready check with "enableReadyCheck". More: https://github.com/luin/ioredis/wiki/Disable-ready-check.`
+          );
+          return callback(null, {});
+        }
         return callback(err);
       }
       if (typeof res !== "string") {
@@ -799,7 +805,7 @@ class Redis extends Commander {
           _this._readyCheck(callback);
         }, retryTime);
       }
-    });
+    }).catch(noop);
   }
 }
 

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -88,7 +88,6 @@ export function connectHandler(self) {
             );
           }
         } else {
-          self.serverInfo = info;
           if (self.connector.check(info)) {
             exports.readyHandler(self)();
           } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,6 +230,12 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/chai": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
+      "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
+      "dev": true
+    },
     "@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "standard-as-callback": "^2.1.0"
   },
   "devDependencies": {
+    "@types/chai": "^4.3.0",
     "@types/debug": "^4.1.5",
     "@types/lodash.defaults": "^4.2.6",
     "@types/lodash.isarguments": "^3.1.6",

--- a/test/functional/connection.ts
+++ b/test/functional/connection.ts
@@ -37,7 +37,7 @@ describe("connection", function () {
         redis.disconnect();
         setImmediate(() => done());
       }
-      command.resolve("fake");
+      return command.resolve("fake");
     });
   });
 

--- a/test/functional/monitor.ts
+++ b/test/functional/monitor.ts
@@ -64,10 +64,10 @@ describe("monitor", () => {
   it("should wait for the ready event before monitoring", (done) => {
     const redis = new Redis();
     redis.on("ready", () => {
+      // @ts-expect-error
       const readyCheck = sinon.spy(Redis.prototype, "_readyCheck");
-      redis.monitor(function (err, monitor) {
+      redis.monitor((err, monitor) => {
         expect(readyCheck.callCount).to.eql(1);
-        Redis.prototype._readyCheck.restore();
         redis.disconnect();
         monitor.disconnect();
         done();

--- a/test/functional/pipeline.ts
+++ b/test/functional/pipeline.ts
@@ -144,7 +144,7 @@ describe("pipeline", () => {
     const redis = new Redis({ keyPrefix: "foo:" });
     redis.addBuiltinCommand("someCommand");
     sinon.stub(redis, "sendCommand").callsFake((command) => {
-      command.resolve(Buffer.from("OK"));
+      return command.resolve(Buffer.from("OK"));
     });
     const result = await redis.pipeline().someCommand().exec();
     expect(result).to.eql([[null, "OK"]]);


### PR DESCRIPTION
Closes #1293
Closes #1211

BREAKING CHANGE: `Redis#serverInfo` is removed. This field is never documented so
you very likely have never used it.