### PR TITLE
fix unhandled promise rejection in cluster

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -730,7 +730,7 @@ class Cluster extends EventEmitter {
         }
       }
       if (redis) {
-        redis.sendCommand(command, stream);
+        redis.sendCommand(command, stream).catch(function(e) {command.reject(e);});
       } else if (_this.options.enableOfflineQueue) {
         _this.offlineQueue.push({
           command: command,


### PR DESCRIPTION
The reproduction code  as follows, I want to perform unified processing when Redis executing, such as prohibiting some commands, so I rewrite the `sendCommand` method so that some commands can be intercepted [by reject or throw Errors], but the single Redis mode and Cluster mode have inconsistent responses: 

```javascript
var Redis = require("ioredis");
const { sendCommand } = Redis.prototype;

Redis.prototype.sendCommand = function(...options) {
  return new Promise((resolve, reject) => {
    // record command log
    console.log('command name', options[0].name);

    // if I want to prohibit command like 'set' in blockList
    // if blockList.includes(options[0].name) {
    if (options[0].name == 'set') {
        return reject(new Error("You can not exec 'set' command!"));
    }

    sendCommand.call(this, ...options)
      .then(r => {resolve(r)})
      .catch(e => {reject(e)})
  })
}

// cluster mode
var redis = new Redis.Cluster([{ port: 7000, host: '127.0.0.1' }], {
  redisOptions: {password: 'xxx'},
});
// single Redis mode
// var redis = new Redis(6379, '127.0.0.1');


redis.on('ready', r => {
  var key = 'test_key_' + Math.random();

  redis.set(key, Math.random()).then(r => {
    console.log('set result', r);
  }).catch(e => {
    console.log('fail to set===', e.message);
  })
})
```
If I `reject` in sendCommand, the single Redis mode can catch the error when executing `set` and logs `fail to set`, 
but when in Cluster mode,  I got ` UnhandledPromiseRejectionWarning: Unhandled promise rejection. ` and I cannot handle the promise rejection anywhere.

This PR is to solve the problem and make them have the consistent responses