### PR TITLE
More explicit control flow

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -737,8 +737,7 @@ class Redis extends Commander {
 
     let item;
     if (options.offlineQueue) {
-      while (this.offlineQueue.length > 0) {
-        item = this.offlineQueue.shift();
+      while ((item = this.offlineQueue.shift())) {
         item.command.reject(error);
       }
     }
@@ -748,8 +747,8 @@ class Redis extends Commander {
         if (this.stream) {
           this.stream.removeAllListeners("data");
         }
-        while (this.commandQueue.length > 0) {
-          item = this.commandQueue.shift();
+
+        while ((item = this.commandQueue.shift())) {
           item.command.reject(error);
         }
       }

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -757,8 +757,7 @@ class Cluster extends Commander {
    */
   private flushQueue(error: Error) {
     let item;
-    while (this.offlineQueue.length > 0) {
-      item = this.offlineQueue.shift();
+    while ((item = this.offlineQueue.shift())) {
       item.command.reject(error);
     }
   }
@@ -768,8 +767,8 @@ class Cluster extends Commander {
       debug("send %d commands in offline queue", this.offlineQueue.length);
       const offlineQueue = this.offlineQueue;
       this.resetOfflineQueue();
-      while (offlineQueue.length > 0) {
-        const item = offlineQueue.shift();
+      let item;
+      while ((item = offlineQueue.shift())) {
         this.sendCommand(item.command, item.stream, item.node);
       }
     }

--- a/test/functional/pub_sub.ts
+++ b/test/functional/pub_sub.ts
@@ -22,7 +22,7 @@ describe("pub/sub", function () {
     redis.subscribe("foo", function () {
       redis.set("foo", "bar", function (err) {
         expect(err instanceof Error);
-        expect(err.toString()).to.match(/subscriber mode/);
+        expect(err.message).to.match(/subscriber mode/);
         redis.disconnect();
         done();
       });

--- a/test/functional/scripting.ts
+++ b/test/functional/scripting.ts
@@ -121,7 +121,7 @@ describe("scripting", () => {
       .exec(function (err, results) {
         expect(err).to.eql(null);
         expect(results[1][0]).to.be.instanceof(Error);
-        expect(results[1][0].toString()).to.match(/value is not an integer/);
+        expect(results[1][0].message).to.match(/value is not an integer/);
         redis.disconnect();
         done();
       });


### PR DESCRIPTION
@luin here are some micro-optimizations we can take in v5. Just close it if you don't like it 😉 

### Changelog
- Prevent unnecessary buffer allocations when using string and buffer commands in one pipeline.
  The performance is almost negligible, but I think the code is also a bit more explicit as it strictly separates buffer and string operations.
- Use `error.message` instead of `error.toString()`. Not sure whether it was there for legacy reasons
- Remove unnecessary `queue.length` checks, as `queue.shift()` basically does the same
- Use a more explicit control flow in Redis#sendCommand to improve readability