### PR TITLE
fix: remove unused Command#isCustomCommand

### DIFF
--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -140,7 +140,6 @@ export default class Command implements Respondable {
   isReadOnly?: boolean;
 
   args: CommandParameter[];
-  isCustomCommand = false;
   inTransaction = false;
   pipelineIndex?: number;
 

--- a/lib/Script.ts
+++ b/lib/Script.ts
@@ -17,8 +17,6 @@ export default class Script {
     const sha = this.sha;
     const socketHasScriptLoaded = new WeakSet();
     this.Command = class CustomScriptCommand extends Command {
-      isCustomCommand = true;
-
       toWritable(socket: object): string | Buffer {
         const origReject = this.reject;
         this.reject = (err) => {
@@ -52,11 +50,7 @@ export default class Script {
       options.readOnly = true;
     }
 
-    const evalsha = new this.Command(
-      "evalsha",
-      [this.sha, ...args],
-      options
-    );
+    const evalsha = new this.Command("evalsha", [this.sha, ...args], options);
 
     evalsha.promise = evalsha.promise.catch((err: Error) => {
       if (err.message.indexOf("NOSCRIPT") === -1) {
@@ -65,11 +59,7 @@ export default class Script {
 
       // Resend the same custom evalsha command that gets transformed
       // to an eval in case it's not loaded yet on the connection.
-      const resend = new this.Command(
-        "evalsha",
-        [this.sha, ...args],
-        options
-      );
+      const resend = new this.Command("evalsha", [this.sha, ...args], options);
 
       const client = container.isPipeline ? container.redis : container;
       return client.sendCommand(resend);


### PR DESCRIPTION
It was introduced to prevent sending custom commands in cluster+pipeline: https://github.com/luin/ioredis/blob/80f4a454fb0d24392e4fa27fbd3f6f22b0bf938e/lib/pipeline.js#L250, and it's not used anymore.

### Test plan
Make sure the property is not used anymore.