### PR TITLE
feat: improve typings for smismember

### DIFF
--- a/bin/generateRedisCommander/index.js
+++ b/bin/generateRedisCommander/index.js
@@ -5,9 +5,9 @@ const overrides = require("./overrides");
 const { getCommanderInterface } = require("@ioredis/interface-generator");
 
 const ignoredCommands = ["monitor", "multi"];
-const commands = require("@ioredis/commands").list.filter(
-  (name) => !ignoredCommands.includes(name)
-);
+const commands = require("@ioredis/commands")
+  .list.filter((name) => !ignoredCommands.includes(name))
+  .sort();
 
 const fs = require("fs");
 const path = require("path");
@@ -33,6 +33,7 @@ async function main() {
       "lolwut",
       "memory",
       "cluster",
+      "geopos",
     ],
   });
 

--- a/bin/generateRedisCommander/returnTypes.js
+++ b/bin/generateRedisCommander/returnTypes.js
@@ -331,12 +331,7 @@ module.exports = {
   xrange: "[id: string, fields: string[]][]",
   xrevrange: "[id: string, fields: string[]][]",
   xlen: "number",
-  xread: (types) => {
-    if (types.find((type) => type.includes("BLOCK"))) {
-      return "unknown[] | null";
-    }
-    return "unknown[]";
-  },
+  xread: "[key: string, items: [id: string, fields: string[]][]][] | null",
   xreadgroup: "unknown[]",
   xack: "number",
   xclaim: "unknown[]",

--- a/bin/generateRedisCommander/returnTypes.js
+++ b/bin/generateRedisCommander/returnTypes.js
@@ -106,10 +106,10 @@ module.exports = {
   brpop: "[string, string] | null",
   brpoplpush: "string | null",
   blmove: "string | null",
-  lmpop: "unknown[] | null",
-  blmpop: "unknown[] | null",
-  bzpopmin: "unknown[] | null",
-  bzpopmax: "unknown[] | null",
+  lmpop: "[key: string, members: string[]] | null",
+  blmpop: "[key: string, members: string[]] | null",
+  bzpopmin: "[key: string, member: string, score: string] | null",
+  bzpopmax: "[key: string, member: string, score: string] | null",
   command: "unknown[]",
   copy: "number",
   dbsize: "number",
@@ -129,7 +129,7 @@ module.exports = {
   flushdb: "'OK'",
   geoadd: "number",
   geohash: "string[]",
-  geopos: "unknown[] | null",
+  geopos: "([longitude: string, latitude: string] | null)[]",
   geodist: "string | null",
   georadius: "unknown[]",
   geosearch: "unknown[]",
@@ -196,7 +196,9 @@ module.exports = {
   linsert: "number",
   llen: "number",
   lpop: (types) => {
-    return types.includes("number") ? "string[] | null" : "string | null";
+    return types.some((type) => type.includes("number"))
+      ? "string[] | null"
+      : "string | null";
   },
   lpos: (types) => {
     return hasToken(types, "COUNT") ? "number[]" : "number | null";
@@ -232,7 +234,9 @@ module.exports = {
   restore: "'OK'",
   role: "unknown[]",
   rpop: (types) => {
-    return types.includes("number") ? "string[] | null" : "string | null";
+    return types.some((type) => type.includes("number"))
+      ? "string[] | null"
+      : "string | null";
   },
   rpoplpush: "string",
   lmove: "string",
@@ -253,7 +257,7 @@ module.exports = {
   sintercard: "number",
   sinterstore: "number",
   sismember: "number",
-  smismember: "unknown[]",
+  smismember: "number[]",
   slaveof: "'OK'",
   replicaof: "'OK'",
   smembers: "string[]",
@@ -296,7 +300,9 @@ module.exports = {
   zpopmax: "string[]",
   zpopmin: "string[]",
   zrandmember: (types) => {
-    return types.includes("number") ? "string | null" : "string[]";
+    return types.some((type) => type.includes("number"))
+      ? "string[]"
+      : "string | null";
   },
   zrangestore: "number",
   zrange: "string[]",

--- a/bin/generateRedisCommander/typeMaps.js
+++ b/bin/generateRedisCommander/typeMaps.js
@@ -17,10 +17,5 @@ module.exports = {
       ? "string | Buffer | number"
       : "string | Buffer",
   pattern: "string",
-  number: (name) =>
-    ["seconds", "count", "start", "stop", "end", "index"].some((pattern) =>
-      name.toLowerCase().includes(pattern)
-    )
-      ? "number"
-      : "number | string",
+  number: () => "number | string",
 };

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -53,30 +53,13 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
 
   
   /**
-   * Show helpful text about the different subcommands
+   * List the ACL categories or the commands inside a category
    * - _group_: server
-   * - _complexity_: O(1)
+   * - _complexity_: O(1) since the categories and commands are a fixed set.
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * Return the name of the user associated to the current connection
-   * - _group_: server
-   * - _complexity_: O(1)
-   * - _since_: 6.0.0
-   */
-  acl(subcommand: 'WHOAMI', callback?: Callback<string>): Result<string, Context>;
-  aclBuffer(subcommand: 'WHOAMI', callback?: Callback<Buffer>): Result<Buffer, Context>;
-
-  /**
-   * Get the rules for a specific ACL user
-   * - _group_: server
-   * - _complexity_: O(N). Where N is the number of password, command and pattern rules that the user has.
-   * - _since_: 6.0.0
-   */
-  acl(subcommand: 'GETUSER', username: string | Buffer, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
-  aclBuffer(subcommand: 'GETUSER', username: string | Buffer, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  acl(subcommand: 'CAT', callback?: Callback<unknown>): Result<unknown, Context>;
+  acl(subcommand: 'CAT', categoryname: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Remove the specified ACL users and the associated rules
@@ -88,40 +71,17 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   acl(...args: [subcommand: 'DELUSER', ...usernames: (string | Buffer)[]]): Result<number, Context>;
 
   /**
-   * List the ACL categories or the commands inside a category
+   * Returns whether the user can execute the given command without executing the command.
    * - _group_: server
-   * - _complexity_: O(1) since the categories and commands are a fixed set.
-   * - _since_: 6.0.0
+   * - _complexity_: O(1).
+   * - _since_: 7.0.0
    */
-  acl(subcommand: 'CAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  acl(subcommand: 'CAT', categoryname: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * List the username of all the configured ACL rules
-   * - _group_: server
-   * - _complexity_: O(N). Where N is the number of configured users.
-   * - _since_: 6.0.0
-   */
-  acl(subcommand: 'USERS', callback?: Callback<string[]>): Result<string[], Context>;
-  aclBuffer(subcommand: 'USERS', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-
-  /**
-   * Modify or create the rules for a specific ACL user
-   * - _group_: server
-   * - _complexity_: O(N). Where N is the number of rules provided.
-   * - _since_: 6.0.0
-   */
-  acl(subcommand: 'SETUSER', username: string | Buffer, callback?: Callback<"OK">): Result<"OK", Context>;
-  acl(...args: [subcommand: 'SETUSER', username: string | Buffer, ...rules: (string | Buffer)[], callback: Callback<"OK">]): Result<"OK", Context>;
-  acl(...args: [subcommand: 'SETUSER', username: string | Buffer, ...rules: (string | Buffer)[]]): Result<"OK", Context>;
-
-  /**
-   * Save the current ACL rules in the configured ACL file
-   * - _group_: server
-   * - _complexity_: O(N). Where N is the number of configured users.
-   * - _since_: 6.0.0
-   */
-  acl(subcommand: 'SAVE', callback?: Callback<"OK">): Result<"OK", Context>;
+  acl(subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, callback?: Callback<string>): Result<string, Context>;
+  aclBuffer(subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  acl(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[], callback: Callback<string>]): Result<string, Context>;
+  aclBuffer(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[], callback: Callback<Buffer>]): Result<Buffer, Context>;
+  acl(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[]]): Result<string, Context>;
+  aclBuffer(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[]]): Result<Buffer, Context>;
 
   /**
    * Generate a pseudorandom secure password to use for ACL users
@@ -133,6 +93,23 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   aclBuffer(subcommand: 'GENPASS', callback?: Callback<Buffer>): Result<Buffer, Context>;
   acl(subcommand: 'GENPASS', bits: number | string, callback?: Callback<string>): Result<string, Context>;
   aclBuffer(subcommand: 'GENPASS', bits: number | string, callback?: Callback<Buffer>): Result<Buffer, Context>;
+
+  /**
+   * Get the rules for a specific ACL user
+   * - _group_: server
+   * - _complexity_: O(N). Where N is the number of password, command and pattern rules that the user has.
+   * - _since_: 6.0.0
+   */
+  acl(subcommand: 'GETUSER', username: string | Buffer, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  aclBuffer(subcommand: 'GETUSER', username: string | Buffer, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+
+  /**
+   * Show helpful text about the different subcommands
+   * - _group_: server
+   * - _complexity_: O(1)
+   * - _since_: 6.0.0
+   */
+  acl(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * List the current ACL rules in ACL config file format
@@ -158,21 +135,44 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 6.0.0
    */
   acl(subcommand: 'LOG', callback?: Callback<unknown>): Result<unknown, Context>;
-  acl(subcommand: 'LOG', count: number, callback?: Callback<unknown>): Result<unknown, Context>;
+  acl(subcommand: 'LOG', count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
   acl(subcommand: 'LOG', reset: 'RESET', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Returns whether the user can execute the given command without executing the command.
+   * Save the current ACL rules in the configured ACL file
    * - _group_: server
-   * - _complexity_: O(1).
-   * - _since_: 7.0.0
+   * - _complexity_: O(N). Where N is the number of configured users.
+   * - _since_: 6.0.0
    */
-  acl(subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  aclBuffer(subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
-  acl(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[], callback: Callback<string>]): Result<string, Context>;
-  aclBuffer(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[], callback: Callback<Buffer>]): Result<Buffer, Context>;
-  acl(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[]]): Result<string, Context>;
-  aclBuffer(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[]]): Result<Buffer, Context>;
+  acl(subcommand: 'SAVE', callback?: Callback<"OK">): Result<"OK", Context>;
+
+  /**
+   * Modify or create the rules for a specific ACL user
+   * - _group_: server
+   * - _complexity_: O(N). Where N is the number of rules provided.
+   * - _since_: 6.0.0
+   */
+  acl(subcommand: 'SETUSER', username: string | Buffer, callback?: Callback<"OK">): Result<"OK", Context>;
+  acl(...args: [subcommand: 'SETUSER', username: string | Buffer, ...rules: (string | Buffer)[], callback: Callback<"OK">]): Result<"OK", Context>;
+  acl(...args: [subcommand: 'SETUSER', username: string | Buffer, ...rules: (string | Buffer)[]]): Result<"OK", Context>;
+
+  /**
+   * List the username of all the configured ACL rules
+   * - _group_: server
+   * - _complexity_: O(N). Where N is the number of configured users.
+   * - _since_: 6.0.0
+   */
+  acl(subcommand: 'USERS', callback?: Callback<string[]>): Result<string[], Context>;
+  aclBuffer(subcommand: 'USERS', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+
+  /**
+   * Return the name of the user associated to the current connection
+   * - _group_: server
+   * - _complexity_: O(1)
+   * - _since_: 6.0.0
+   */
+  acl(subcommand: 'WHOAMI', callback?: Callback<string>): Result<string, Context>;
+  aclBuffer(subcommand: 'WHOAMI', callback?: Callback<Buffer>): Result<Buffer, Context>;
 
   /**
    * Append a value to a key
@@ -224,9 +224,9 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 2.6.0
    */
   bitcount(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
-  bitcount(key: RedisKey, start: number, end: number, callback?: Callback<number>): Result<number, Context>;
-  bitcount(key: RedisKey, start: number, end: number, byte: 'BYTE', callback?: Callback<number>): Result<number, Context>;
-  bitcount(key: RedisKey, start: number, end: number, bit: 'BIT', callback?: Callback<number>): Result<number, Context>;
+  bitcount(key: RedisKey, start: number | string, end: number | string, callback?: Callback<number>): Result<number, Context>;
+  bitcount(key: RedisKey, start: number | string, end: number | string, byte: 'BYTE', callback?: Callback<number>): Result<number, Context>;
+  bitcount(key: RedisKey, start: number | string, end: number | string, bit: 'BIT', callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Perform arbitrary bitfield integer operations on strings
@@ -293,10 +293,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 2.8.7
    */
   bitpos(key: RedisKey, bit: number | string, callback?: Callback<number>): Result<number, Context>;
-  bitpos(key: RedisKey, bit: number | string, start: number, callback?: Callback<number>): Result<number, Context>;
-  bitpos(key: RedisKey, bit: number | string, start: number, end: number, callback?: Callback<number>): Result<number, Context>;
-  bitpos(key: RedisKey, bit: number | string, start: number, end: number, byte: 'BYTE', callback?: Callback<number>): Result<number, Context>;
-  bitpos(key: RedisKey, bit: number | string, start: number, end: number, bit1: 'BIT', callback?: Callback<number>): Result<number, Context>;
+  bitpos(key: RedisKey, bit: number | string, start: number | string, callback?: Callback<number>): Result<number, Context>;
+  bitpos(key: RedisKey, bit: number | string, start: number | string, end: number | string, callback?: Callback<number>): Result<number, Context>;
+  bitpos(key: RedisKey, bit: number | string, start: number | string, end: number | string, byte: 'BYTE', callback?: Callback<number>): Result<number, Context>;
+  bitpos(key: RedisKey, bit: number | string, start: number | string, end: number | string, bit1: 'BIT', callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Pop an element from a list, push it to another list and return it; or block until one is available
@@ -319,22 +319,38 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+M) where N is the number of provided keys and M is the number of elements returned.
    * - _since_: 7.0.0
    */
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number]): Result<unknown[] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number]): Result<unknown[] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
 
   /**
    * Remove and get the first element in a list, or block until one is available
@@ -385,18 +401,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN', callback: Callback<unknown>]): Result<unknown, Context>;
   bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN']): Result<unknown, Context>;
   bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN']): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number, callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number, callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number]): Result<unknown, Context>;
+  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
+  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
+  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
+  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
   bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', callback: Callback<unknown>]): Result<unknown, Context>;
   bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX', callback: Callback<unknown>]): Result<unknown, Context>;
   bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX']): Result<unknown, Context>;
   bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX']): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number, callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number, callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number]): Result<unknown, Context>;
+  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
+  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
+  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
+  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
 
   /**
    * Remove and return the member with the highest score from one or more sorted sets, or block until one is available
@@ -404,10 +420,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) with N being the number of elements in the sorted set.
    * - _since_: 5.0.0
    */
-  bzpopmax(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  bzpopmax(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  bzpopmax(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<unknown[] | null, Context>;
-  bzpopmax(...args: [keys: (RedisKey)[], timeout: number | string]): Result<unknown[] | null, Context>;
+  bzpopmax(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: string, member: string, score: string] | null>]): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopmaxBuffer(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmax(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: string, member: string, score: string] | null>]): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopmaxBuffer(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmax(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopmaxBuffer(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmax(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopmaxBuffer(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
 
   /**
    * Remove and return the member with the lowest score from one or more sorted sets, or block until one is available
@@ -415,54 +435,32 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) with N being the number of elements in the sorted set.
    * - _since_: 5.0.0
    */
-  bzpopmin(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  bzpopmin(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  bzpopmin(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<unknown[] | null, Context>;
-  bzpopmin(...args: [keys: (RedisKey)[], timeout: number | string]): Result<unknown[] | null, Context>;
+  bzpopmin(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: string, member: string, score: string] | null>]): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopminBuffer(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmin(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: string, member: string, score: string] | null>]): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopminBuffer(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmin(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopminBuffer(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmin(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopminBuffer(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
 
   /**
-   * Enable or disable server assisted client side caching support
+   * Instruct the server about tracking or not keys in the next request
    * - _group_: connection
-   * - _complexity_: O(1). Some options may introduce additional complexity.
+   * - _complexity_: O(1)
    * - _since_: 6.0.0
    */
-  client(...args: [subcommand: 'TRACKING', ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  client(...args: [subcommand: 'TRACKING', ...args: (RedisValue)[]]): Result<unknown, Context>;
+  client(subcommand: 'CACHING', yes: 'YES', callback?: Callback<"OK">): Result<"OK", Context>;
+  client(subcommand: 'CACHING', no: 'NO', callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
-   * Return information about server assisted client side caching for the current connection
+   * Get the current connection name
    * - _group_: connection
    * - _complexity_: O(1)
-   * - _since_: 6.2.0
+   * - _since_: 2.6.9
    */
-  client(subcommand: 'TRACKINGINFO', callback?: Callback<string>): Result<string, Context>;
-  clientBuffer(subcommand: 'TRACKINGINFO', callback?: Callback<Buffer>): Result<Buffer, Context>;
-
-  /**
-   * Returns information about the current client connection.
-   * - _group_: connection
-   * - _complexity_: O(1)
-   * - _since_: 6.2.0
-   */
-  client(subcommand: 'INFO', callback?: Callback<string>): Result<string, Context>;
-  clientBuffer(subcommand: 'INFO', callback?: Callback<Buffer>): Result<Buffer, Context>;
-
-  /**
-   * Kill the connection of a client
-   * - _group_: connection
-   * - _complexity_: O(N) where N is the number of client connections
-   * - _since_: 2.4.0
-   */
-  client(...args: [subcommand: 'KILL', ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  client(...args: [subcommand: 'KILL', ...args: (RedisValue)[]]): Result<unknown, Context>;
-
-  /**
-   * Resume processing of clients that were paused
-   * - _group_: connection
-   * - _complexity_: O(N) Where N is the number of paused clients
-   * - _since_: 6.2.0
-   */
-  client(subcommand: 'UNPAUSE', callback?: Callback<"OK">): Result<"OK", Context>;
+  client(subcommand: 'GETNAME', callback?: Callback<string | null>): Result<string | null, Context>;
+  clientBuffer(subcommand: 'GETNAME', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
 
   /**
    * Get tracking notifications redirection client ID if any
@@ -481,33 +479,6 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   client(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Set the current connection name
-   * - _group_: connection
-   * - _complexity_: O(1)
-   * - _since_: 2.6.9
-   */
-  client(subcommand: 'SETNAME', connectionName: string | Buffer, callback?: Callback<"OK">): Result<"OK", Context>;
-
-  /**
-   * Get the current connection name
-   * - _group_: connection
-   * - _complexity_: O(1)
-   * - _since_: 2.6.9
-   */
-  client(subcommand: 'GETNAME', callback?: Callback<string | null>): Result<string | null, Context>;
-  clientBuffer(subcommand: 'GETNAME', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-
-  /**
-   * Stop processing commands from clients for some time
-   * - _group_: connection
-   * - _complexity_: O(1)
-   * - _since_: 2.9.50
-   */
-  client(subcommand: 'PAUSE', timeout: number | string, callback?: Callback<"OK">): Result<"OK", Context>;
-  client(subcommand: 'PAUSE', timeout: number | string, write: 'WRITE', callback?: Callback<"OK">): Result<"OK", Context>;
-  client(subcommand: 'PAUSE', timeout: number | string, all: 'ALL', callback?: Callback<"OK">): Result<"OK", Context>;
-
-  /**
    * Returns the client ID for the current connection
    * - _group_: connection
    * - _complexity_: O(1)
@@ -516,14 +487,22 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   client(subcommand: 'ID', callback?: Callback<number>): Result<number, Context>;
 
   /**
-   * Instruct the server whether to reply to commands
+   * Returns information about the current client connection.
    * - _group_: connection
    * - _complexity_: O(1)
-   * - _since_: 3.2.0
+   * - _since_: 6.2.0
    */
-  client(subcommand: 'REPLY', on: 'ON', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(subcommand: 'REPLY', off: 'OFF', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(subcommand: 'REPLY', skip: 'SKIP', callback?: Callback<unknown>): Result<unknown, Context>;
+  client(subcommand: 'INFO', callback?: Callback<string>): Result<string, Context>;
+  clientBuffer(subcommand: 'INFO', callback?: Callback<Buffer>): Result<Buffer, Context>;
+
+  /**
+   * Kill the connection of a client
+   * - _group_: connection
+   * - _complexity_: O(N) where N is the number of client connections
+   * - _since_: 2.4.0
+   */
+  client(...args: [subcommand: 'KILL', ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
+  client(...args: [subcommand: 'KILL', ...args: (RedisValue)[]]): Result<unknown, Context>;
 
   /**
    * Get the list of client connections
@@ -548,6 +527,61 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   client(...args: [subcommand: 'LIST', type: 'TYPE', pubsub: 'PUBSUB', idToken: 'ID', ...clientIds: (number | string)[]]): Result<unknown, Context>;
 
   /**
+   * Set client eviction mode for the current connection
+   * - _group_: connection
+   * - _complexity_: O(1)
+   * - _since_: 7.0.0
+   */
+  client(subcommand: 'NO-EVICT', on: 'ON', callback?: Callback<unknown>): Result<unknown, Context>;
+  client(subcommand: 'NO-EVICT', off: 'OFF', callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
+   * Stop processing commands from clients for some time
+   * - _group_: connection
+   * - _complexity_: O(1)
+   * - _since_: 2.9.50
+   */
+  client(subcommand: 'PAUSE', timeout: number | string, callback?: Callback<"OK">): Result<"OK", Context>;
+  client(subcommand: 'PAUSE', timeout: number | string, write: 'WRITE', callback?: Callback<"OK">): Result<"OK", Context>;
+  client(subcommand: 'PAUSE', timeout: number | string, all: 'ALL', callback?: Callback<"OK">): Result<"OK", Context>;
+
+  /**
+   * Instruct the server whether to reply to commands
+   * - _group_: connection
+   * - _complexity_: O(1)
+   * - _since_: 3.2.0
+   */
+  client(subcommand: 'REPLY', on: 'ON', callback?: Callback<unknown>): Result<unknown, Context>;
+  client(subcommand: 'REPLY', off: 'OFF', callback?: Callback<unknown>): Result<unknown, Context>;
+  client(subcommand: 'REPLY', skip: 'SKIP', callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
+   * Set the current connection name
+   * - _group_: connection
+   * - _complexity_: O(1)
+   * - _since_: 2.6.9
+   */
+  client(subcommand: 'SETNAME', connectionName: string | Buffer, callback?: Callback<"OK">): Result<"OK", Context>;
+
+  /**
+   * Enable or disable server assisted client side caching support
+   * - _group_: connection
+   * - _complexity_: O(1). Some options may introduce additional complexity.
+   * - _since_: 6.0.0
+   */
+  client(...args: [subcommand: 'TRACKING', ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
+  client(...args: [subcommand: 'TRACKING', ...args: (RedisValue)[]]): Result<unknown, Context>;
+
+  /**
+   * Return information about server assisted client side caching for the current connection
+   * - _group_: connection
+   * - _complexity_: O(1)
+   * - _since_: 6.2.0
+   */
+  client(subcommand: 'TRACKINGINFO', callback?: Callback<string>): Result<string, Context>;
+  clientBuffer(subcommand: 'TRACKINGINFO', callback?: Callback<Buffer>): Result<Buffer, Context>;
+
+  /**
    * Unblock a client blocked in a blocking command from a different connection
    * - _group_: connection
    * - _complexity_: O(log N) where N is the number of client connections
@@ -558,22 +592,23 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   client(subcommand: 'UNBLOCK', clientId: number | string, error: 'ERROR', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Set client eviction mode for the current connection
+   * Resume processing of clients that were paused
    * - _group_: connection
-   * - _complexity_: O(1)
-   * - _since_: 7.0.0
+   * - _complexity_: O(N) Where N is the number of paused clients
+   * - _since_: 6.2.0
    */
-  client(subcommand: 'NO-EVICT', on: 'ON', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(subcommand: 'NO-EVICT', off: 'OFF', callback?: Callback<unknown>): Result<unknown, Context>;
+  client(subcommand: 'UNPAUSE', callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
-   * Instruct the server about tracking or not keys in the next request
-   * - _group_: connection
-   * - _complexity_: O(1)
-   * - _since_: 6.0.0
+   * Assign new hash slots to receiving node
+   * - _group_: cluster
+   * - _complexity_: O(N) where N is the total number of hash slot arguments
+   * - _since_: 3.0.0
    */
-  client(subcommand: 'CACHING', yes: 'YES', callback?: Callback<"OK">): Result<"OK", Context>;
-  client(subcommand: 'CACHING', no: 'NO', callback?: Callback<"OK">): Result<"OK", Context>;
+  cluster(...args: [subcommand: 'ADDSLOTS', ...slots: (number | string)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(...args: [subcommand: 'ADDSLOTS', slots: (number | string)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(...args: [subcommand: 'ADDSLOTS', ...slots: (number | string)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(...args: [subcommand: 'ADDSLOTS', slots: (number | string)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
 
   /**
    * Assign new hash slots to receiving node
@@ -581,16 +616,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of the slots between the start slot and end slot arguments.
    * - _since_: 7.0.0
    */
-  cluster(...args: [subcommand: 'ADDSLOTSRANGE', ...startSlotEndSlots: (number)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'ADDSLOTSRANGE', ...startSlotEndSlots: (number)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(...args: [subcommand: 'ADDSLOTSRANGE', ...startSlotEndSlots: (string | number)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(...args: [subcommand: 'ADDSLOTSRANGE', ...startSlotEndSlots: (string | number)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
 
   /**
-   * Returns a list of all TCP links to and from peer nodes in cluster
+   * Advance the cluster config epoch
    * - _group_: cluster
-   * - _complexity_: O(N) where N is the total number of Cluster nodes
-   * - _since_: 7.0.0
+   * - _complexity_: O(1)
+   * - _since_: 3.0.0
    */
-  cluster(subcommand: 'LINKS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  cluster(subcommand: 'BUMPEPOCH', callback?: Callback<'BUMPED' | 'STILL'>): Result<'BUMPED' | 'STILL', Context>;
 
   /**
    * Return the number of failure reports active for a given node
@@ -601,54 +636,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   cluster(subcommand: 'COUNT-FAILURE-REPORTS', nodeId: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
 
   /**
-   * List replica nodes of the specified master node
+   * Return the number of local keys in the specified hash slot
    * - _group_: cluster
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'SLAVES', nodeId: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * Remove a node from the nodes table
-   * - _group_: cluster
-   * - _complexity_: O(1)
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'FORGET', nodeId: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
-
-  /**
-   * Returns the hash slot of the specified key
-   * - _group_: cluster
-   * - _complexity_: O(N) where N is the number of bytes in the key
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'KEYSLOT', key: string | Buffer, callback?: Callback<number>): Result<number, Context>;
-
-  /**
-   * Show helpful text about the different subcommands
-   * - _group_: cluster
-   * - _complexity_: O(1)
-   * - _since_: 5.0.0
-   */
-  cluster(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * Get Cluster config for the node
-   * - _group_: cluster
-   * - _complexity_: O(N) where N is the total number of Cluster nodes
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'NODES', callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * Reset a Redis Cluster node
-   * - _group_: cluster
-   * - _complexity_: O(N) where N is the number of known nodes. The command may execute a FLUSHALL as a side effect.
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'RESET', callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'RESET', hard: 'HARD', callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'RESET', soft: 'SOFT', callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(subcommand: 'COUNTKEYSINSLOT', slot: number | string, callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Set hash slots as unbound in receiving node
@@ -662,20 +655,79 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   cluster(...args: [subcommand: 'DELSLOTS', slots: (number | string)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
 
   /**
-   * Get array of Cluster slot to node mappings
+   * Set hash slots as unbound in receiving node
    * - _group_: cluster
-   * - _complexity_: O(N) where N is the total number of Cluster nodes
-   * - _since_: 3.0.0
+   * - _complexity_: O(N) where N is the total number of the slots between the start slot and end slot arguments.
+   * - _since_: 7.0.0
    */
-  cluster(subcommand: 'SLOTS', callback?: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(...args: [subcommand: 'DELSLOTSRANGE', ...startSlotEndSlots: (string | number)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(...args: [subcommand: 'DELSLOTSRANGE', ...startSlotEndSlots: (string | number)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
 
   /**
-   * Advance the cluster config epoch
+   * Forces a replica to perform a manual failover of its master.
    * - _group_: cluster
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'BUMPEPOCH', callback?: Callback<'BUMPED' | 'STILL'>): Result<'BUMPED' | 'STILL', Context>;
+  cluster(subcommand: 'FAILOVER', callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(subcommand: 'FAILOVER', force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(subcommand: 'FAILOVER', takeover: 'TAKEOVER', callback?: Callback<'OK'>): Result<'OK', Context>;
+
+  /**
+   * Delete a node's own slots information
+   * - _group_: cluster
+   * - _complexity_: O(1)
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'FLUSHSLOTS', callback?: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+
+  /**
+   * Remove a node from the nodes table
+   * - _group_: cluster
+   * - _complexity_: O(1)
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'FORGET', nodeId: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
+
+  /**
+   * Return local key names in the specified hash slot
+   * - _group_: cluster
+   * - _complexity_: O(log(N)) where N is the number of requested keys
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'GETKEYSINSLOT', slot: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+
+  /**
+   * Show helpful text about the different subcommands
+   * - _group_: cluster
+   * - _complexity_: O(1)
+   * - _since_: 5.0.0
+   */
+  cluster(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
+   * Provides info about Redis Cluster node state
+   * - _group_: cluster
+   * - _complexity_: O(1)
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'INFO', callback?: Callback<string>): Result<string, Context>;
+
+  /**
+   * Returns the hash slot of the specified key
+   * - _group_: cluster
+   * - _complexity_: O(N) where N is the number of bytes in the key
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'KEYSLOT', key: string | Buffer, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Returns a list of all TCP links to and from peer nodes in cluster
+   * - _group_: cluster
+   * - _complexity_: O(N) where N is the total number of Cluster nodes
+   * - _since_: 7.0.0
+   */
+  cluster(subcommand: 'LINKS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
 
   /**
    * Force a node cluster to handshake with another node
@@ -694,6 +746,56 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   cluster(subcommand: 'MYID', callback?: Callback<string>): Result<string, Context>;
 
   /**
+   * Get Cluster config for the node
+   * - _group_: cluster
+   * - _complexity_: O(N) where N is the total number of Cluster nodes
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'NODES', callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
+   * List replica nodes of the specified master node
+   * - _group_: cluster
+   * - _complexity_: O(1)
+   * - _since_: 5.0.0
+   */
+  cluster(subcommand: 'REPLICAS', nodeId: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
+   * Reconfigure a node as a replica of the specified master node
+   * - _group_: cluster
+   * - _complexity_: O(1)
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'REPLICATE', nodeId: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
+
+  /**
+   * Reset a Redis Cluster node
+   * - _group_: cluster
+   * - _complexity_: O(N) where N is the number of known nodes. The command may execute a FLUSHALL as a side effect.
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'RESET', callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(subcommand: 'RESET', hard: 'HARD', callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(subcommand: 'RESET', soft: 'SOFT', callback?: Callback<'OK'>): Result<'OK', Context>;
+
+  /**
+   * Forces the node to save cluster state on disk
+   * - _group_: cluster
+   * - _complexity_: O(1)
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'SAVECONFIG', callback?: Callback<'OK'>): Result<'OK', Context>;
+
+  /**
+   * Set the configuration epoch in a new node
+   * - _group_: cluster
+   * - _complexity_: O(1)
+   * - _since_: 3.0.0
+   */
+  cluster(subcommand: 'SET-CONFIG-EPOCH', configEpoch: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+
+  /**
    * Bind a hash slot to a specific node
    * - _group_: cluster
    * - _complexity_: O(1)
@@ -708,116 +810,25 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * List replica nodes of the specified master node
    * - _group_: cluster
    * - _complexity_: O(1)
-   * - _since_: 5.0.0
-   */
-  cluster(subcommand: 'REPLICAS', nodeId: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * Assign new hash slots to receiving node
-   * - _group_: cluster
-   * - _complexity_: O(N) where N is the total number of hash slot arguments
    * - _since_: 3.0.0
    */
-  cluster(...args: [subcommand: 'ADDSLOTS', ...slots: (number | string)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'ADDSLOTS', slots: (number | string)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'ADDSLOTS', ...slots: (number | string)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'ADDSLOTS', slots: (number | string)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(subcommand: 'SLAVES', nodeId: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Return local key names in the specified hash slot
+   * Get array of Cluster slot to node mappings
    * - _group_: cluster
-   * - _complexity_: O(log(N)) where N is the number of requested keys
+   * - _complexity_: O(N) where N is the total number of Cluster nodes
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'GETKEYSINSLOT', slot: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
+  cluster(subcommand: 'SLOTS', callback?: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
 
   /**
-   * Provides info about Redis Cluster node state
-   * - _group_: cluster
-   * - _complexity_: O(1)
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'INFO', callback?: Callback<string>): Result<string, Context>;
-
-  /**
-   * Return the number of local keys in the specified hash slot
-   * - _group_: cluster
-   * - _complexity_: O(1)
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'COUNTKEYSINSLOT', slot: number | string, callback?: Callback<number>): Result<number, Context>;
-
-  /**
-   * Forces a replica to perform a manual failover of its master.
-   * - _group_: cluster
-   * - _complexity_: O(1)
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'FAILOVER', callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'FAILOVER', force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'FAILOVER', takeover: 'TAKEOVER', callback?: Callback<'OK'>): Result<'OK', Context>;
-
-  /**
-   * Set the configuration epoch in a new node
-   * - _group_: cluster
-   * - _complexity_: O(1)
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'SET-CONFIG-EPOCH', configEpoch: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-
-  /**
-   * Forces the node to save cluster state on disk
-   * - _group_: cluster
-   * - _complexity_: O(1)
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'SAVECONFIG', callback?: Callback<'OK'>): Result<'OK', Context>;
-
-  /**
-   * Delete a node's own slots information
-   * - _group_: cluster
-   * - _complexity_: O(1)
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'FLUSHSLOTS', callback?: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-
-  /**
-   * Set hash slots as unbound in receiving node
-   * - _group_: cluster
-   * - _complexity_: O(N) where N is the total number of the slots between the start slot and end slot arguments.
-   * - _since_: 7.0.0
-   */
-  cluster(...args: [subcommand: 'DELSLOTSRANGE', ...startSlotEndSlots: (number)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'DELSLOTSRANGE', ...startSlotEndSlots: (number)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-
-  /**
-   * Reconfigure a node as a replica of the specified master node
-   * - _group_: cluster
-   * - _complexity_: O(1)
-   * - _since_: 3.0.0
-   */
-  cluster(subcommand: 'REPLICATE', nodeId: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
-
-  /**
-   * Get an array of Redis command names
+   * Get total number of Redis commands
    * - _group_: server
-   * - _complexity_: O(N) where N is the total number of Redis commands
-   * - _since_: 7.0.0
-   */
-  command(subcommand: 'LIST', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  command(subcommand: 'LIST', filterby: 'FILTERBY', moduleNameToken: 'MODULE', moduleName: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  command(subcommand: 'LIST', filterby: 'FILTERBY', categoryToken: 'ACLCAT', category: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  command(subcommand: 'LIST', filterby: 'FILTERBY', patternToken: 'PATTERN', pattern: string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-
-  /**
-   * Get array of specific Redis command details, or all when no argument is given.
-   * - _group_: server
-   * - _complexity_: O(N) where N is the number of commands to look up
+   * - _complexity_: O(1)
    * - _since_: 2.8.13
    */
-  command(subcommand: 'INFO', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  command(...args: [subcommand: 'INFO', ...commandNames: (string | Buffer)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  command(...args: [subcommand: 'INFO', ...commandNames: (string | Buffer)[]]): Result<unknown[], Context>;
+  command(subcommand: 'COUNT', callback?: Callback<unknown[]>): Result<unknown[], Context>;
 
   /**
    * Get array of specific Redis command documentation
@@ -838,22 +849,6 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   command(subcommand: 'GETKEYS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
 
   /**
-   * Show helpful text about the different subcommands
-   * - _group_: server
-   * - _complexity_: O(1)
-   * - _since_: 5.0.0
-   */
-  command(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-
-  /**
-   * Get total number of Redis commands
-   * - _group_: server
-   * - _complexity_: O(1)
-   * - _since_: 2.8.13
-   */
-  command(subcommand: 'COUNT', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-
-  /**
    * Extract keys given a full Redis command
    * - _group_: server
    * - _complexity_: O(N) where N is the number of arguments to the command
@@ -862,12 +857,42 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   command(subcommand: 'GETKEYSANDFLAGS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
 
   /**
-   * Reset the stats returned by INFO
+   * Show helpful text about the different subcommands
    * - _group_: server
    * - _complexity_: O(1)
+   * - _since_: 5.0.0
+   */
+  command(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+
+  /**
+   * Get array of specific Redis command details, or all when no argument is given.
+   * - _group_: server
+   * - _complexity_: O(N) where N is the number of commands to look up
+   * - _since_: 2.8.13
+   */
+  command(subcommand: 'INFO', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  command(...args: [subcommand: 'INFO', ...commandNames: (string | Buffer)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  command(...args: [subcommand: 'INFO', ...commandNames: (string | Buffer)[]]): Result<unknown[], Context>;
+
+  /**
+   * Get an array of Redis command names
+   * - _group_: server
+   * - _complexity_: O(N) where N is the total number of Redis commands
+   * - _since_: 7.0.0
+   */
+  command(subcommand: 'LIST', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  command(subcommand: 'LIST', filterby: 'FILTERBY', moduleNameToken: 'MODULE', moduleName: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  command(subcommand: 'LIST', filterby: 'FILTERBY', categoryToken: 'ACLCAT', category: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  command(subcommand: 'LIST', filterby: 'FILTERBY', patternToken: 'PATTERN', pattern: string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+
+  /**
+   * Get the values of configuration parameters
+   * - _group_: server
+   * - _complexity_: O(N) when N is the number of configuration parameters provided
    * - _since_: 2.0.0
    */
-  config(subcommand: 'RESETSTAT', callback?: Callback<unknown>): Result<unknown, Context>;
+  config(...args: [subcommand: 'GET', ...parameters: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
+  config(...args: [subcommand: 'GET', ...parameters: (string | Buffer)[]]): Result<unknown, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -878,13 +903,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   config(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Get the values of configuration parameters
+   * Reset the stats returned by INFO
    * - _group_: server
-   * - _complexity_: O(N) when N is the number of configuration parameters provided
+   * - _complexity_: O(1)
    * - _since_: 2.0.0
    */
-  config(...args: [subcommand: 'GET', ...parameters: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  config(...args: [subcommand: 'GET', ...parameters: (string | Buffer)[]]): Result<unknown, Context>;
+  config(subcommand: 'RESETSTAT', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Rewrite the configuration file with the in memory configuration
@@ -1060,11 +1084,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  expire(key: RedisKey, seconds: number, callback?: Callback<number>): Result<number, Context>;
-  expire(key: RedisKey, seconds: number, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
-  expire(key: RedisKey, seconds: number, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
-  expire(key: RedisKey, seconds: number, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
-  expire(key: RedisKey, seconds: number, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
+  expire(key: RedisKey, seconds: number | string, callback?: Callback<number>): Result<number, Context>;
+  expire(key: RedisKey, seconds: number | string, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
+  expire(key: RedisKey, seconds: number | string, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
+  expire(key: RedisKey, seconds: number | string, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
+  expire(key: RedisKey, seconds: number | string, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Set the expiration for a key as a UNIX timestamp
@@ -1072,11 +1096,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.2.0
    */
-  expireat(key: RedisKey, unixTimeSeconds: number, callback?: Callback<number>): Result<number, Context>;
-  expireat(key: RedisKey, unixTimeSeconds: number, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
-  expireat(key: RedisKey, unixTimeSeconds: number, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
-  expireat(key: RedisKey, unixTimeSeconds: number, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
-  expireat(key: RedisKey, unixTimeSeconds: number, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
+  expireat(key: RedisKey, unixTimeSeconds: number | string, callback?: Callback<number>): Result<number, Context>;
+  expireat(key: RedisKey, unixTimeSeconds: number | string, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
+  expireat(key: RedisKey, unixTimeSeconds: number | string, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
+  expireat(key: RedisKey, unixTimeSeconds: number | string, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
+  expireat(key: RedisKey, unixTimeSeconds: number | string, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Get the expiration Unix timestamp for a key
@@ -1093,17 +1117,17 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 6.2.0
    */
   failover(callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(millisecondsToken: 'TIMEOUT', milliseconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  failover(millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
   failover(abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(abort: 'ABORT', millisecondsToken: 'TIMEOUT', milliseconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  failover(abort: 'ABORT', millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
   failover(targetToken: 'TO', host: string | Buffer, port: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, millisecondsToken: 'TIMEOUT', milliseconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  failover(targetToken: 'TO', host: string | Buffer, port: number | string, millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
   failover(targetToken: 'TO', host: string | Buffer, port: number | string, abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, abort: 'ABORT', millisecondsToken: 'TIMEOUT', milliseconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  failover(targetToken: 'TO', host: string | Buffer, port: number | string, abort: 'ABORT', millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
   failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', millisecondsToken: 'TIMEOUT', milliseconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
   failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', abort: 'ABORT', millisecondsToken: 'TIMEOUT', milliseconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', abort: 'ABORT', millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
 
   /**
    * Invoke a function
@@ -1144,6 +1168,15 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   flushdb(sync: 'SYNC', callback?: Callback<'OK'>): Result<'OK', Context>;
 
   /**
+   * Delete a function by name
+   * - _group_: scripting
+   * - _complexity_: O(1)
+   * - _since_: 7.0.0
+   */
+  function(subcommand: 'DELETE', libraryName: string | Buffer, callback?: Callback<string>): Result<string, Context>;
+  functionBuffer(subcommand: 'DELETE', libraryName: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
+
+  /**
    * Dump all functions into a serialized binary payload
    * - _group_: scripting
    * - _complexity_: O(N) where N is the number of functions
@@ -1151,14 +1184,6 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   function(subcommand: 'DUMP', callback?: Callback<string>): Result<string, Context>;
   functionBuffer(subcommand: 'DUMP', callback?: Callback<Buffer>): Result<Buffer, Context>;
-
-  /**
-   * Show helpful text about the different subcommands
-   * - _group_: scripting
-   * - _complexity_: O(1)
-   * - _since_: 7.0.0
-   */
-  function(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Deleting all functions
@@ -1174,6 +1199,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   functionBuffer(subcommand: 'FLUSH', sync: 'SYNC', callback?: Callback<Buffer>): Result<Buffer, Context>;
 
   /**
+   * Show helpful text about the different subcommands
+   * - _group_: scripting
+   * - _complexity_: O(1)
+   * - _since_: 7.0.0
+   */
+  function(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
    * Kill the function currently in execution.
    * - _group_: scripting
    * - _complexity_: O(1)
@@ -1181,30 +1214,6 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   function(subcommand: 'KILL', callback?: Callback<string>): Result<string, Context>;
   functionBuffer(subcommand: 'KILL', callback?: Callback<Buffer>): Result<Buffer, Context>;
-
-  /**
-   * Delete a function by name
-   * - _group_: scripting
-   * - _complexity_: O(1)
-   * - _since_: 7.0.0
-   */
-  function(subcommand: 'DELETE', libraryName: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'DELETE', libraryName: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
-
-  /**
-   * Restore all the functions on the given payload
-   * - _group_: scripting
-   * - _complexity_: O(N) where N is the number of functions on the payload
-   * - _since_: 7.0.0
-   */
-  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, flush: 'FLUSH', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, flush: 'FLUSH', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, append: 'APPEND', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, append: 'APPEND', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, replace: 'REPLACE', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, replace: 'REPLACE', callback?: Callback<Buffer>): Result<Buffer, Context>;
 
   /**
    * List information about all the functions
@@ -1231,6 +1240,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   functionBuffer(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, replace: 'REPLACE', functionCode: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
   function(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, replace: 'REPLACE', libraryDescriptionToken: 'DESCRIPTION', libraryDescription: string | Buffer, functionCode: string | Buffer, callback?: Callback<string>): Result<string, Context>;
   functionBuffer(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, replace: 'REPLACE', libraryDescriptionToken: 'DESCRIPTION', libraryDescription: string | Buffer, functionCode: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
+
+  /**
+   * Restore all the functions on the given payload
+   * - _group_: scripting
+   * - _complexity_: O(N) where N is the number of functions on the payload
+   * - _since_: 7.0.0
+   */
+  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, callback?: Callback<string>): Result<string, Context>;
+  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, flush: 'FLUSH', callback?: Callback<string>): Result<string, Context>;
+  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, flush: 'FLUSH', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, append: 'APPEND', callback?: Callback<string>): Result<string, Context>;
+  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, append: 'APPEND', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, replace: 'REPLACE', callback?: Callback<string>): Result<string, Context>;
+  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, replace: 'REPLACE', callback?: Callback<Buffer>): Result<Buffer, Context>;
 
   /**
    * Return information about the function currently running (name, description, duration)
@@ -1297,10 +1321,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of members requested.
    * - _since_: 3.2.0
    */
-  geopos(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  geopos(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  geopos(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<unknown[] | null, Context>;
-  geopos(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<unknown[] | null, Context>;
+  geopos(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<([longitude: string, latitude: string] | null)[]>]): Result<([longitude: string, latitude: string] | null)[], Context>;
+  geopos(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<([longitude: string, latitude: string] | null)[]>]): Result<([longitude: string, latitude: string] | null)[], Context>;
+  geopos(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<([longitude: string, latitude: string] | null)[], Context>;
+  geopos(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<([longitude: string, latitude: string] | null)[], Context>;
 
   /**
    * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
@@ -1390,14 +1414,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   getex(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
   getexBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  getex(key: RedisKey, secondsToken: 'EX', seconds: number, callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, secondsToken: 'EX', seconds: number, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  getex(key: RedisKey, millisecondsToken: 'PX', milliseconds: number, callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, millisecondsToken: 'PX', milliseconds: number, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  getex(key: RedisKey, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  getex(key: RedisKey, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  getex(key: RedisKey, secondsToken: 'EX', seconds: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
+  getexBuffer(key: RedisKey, secondsToken: 'EX', seconds: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  getex(key: RedisKey, millisecondsToken: 'PX', milliseconds: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
+  getexBuffer(key: RedisKey, millisecondsToken: 'PX', milliseconds: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  getex(key: RedisKey, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
+  getexBuffer(key: RedisKey, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  getex(key: RedisKey, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
+  getexBuffer(key: RedisKey, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
   getex(key: RedisKey, persist: 'PERSIST', callback?: Callback<string | null>): Result<string | null, Context>;
   getexBuffer(key: RedisKey, persist: 'PERSIST', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
 
@@ -1407,8 +1431,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.
    * - _since_: 2.4.0
    */
-  getrange(key: RedisKey, start: number, end: number, callback?: Callback<string>): Result<string, Context>;
-  getrangeBuffer(key: RedisKey, start: number, end: number, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  getrange(key: RedisKey, start: number | string, end: number | string, callback?: Callback<string>): Result<string, Context>;
+  getrangeBuffer(key: RedisKey, start: number | string, end: number | string, callback?: Callback<Buffer>): Result<Buffer, Context>;
 
   /**
    * Set the string value of a key and return its old value
@@ -1530,10 +1554,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   hrandfield(key: RedisKey, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
   hrandfieldBuffer(key: RedisKey, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
-  hrandfield(key: RedisKey, count: number, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
-  hrandfieldBuffer(key: RedisKey, count: number, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
-  hrandfield(key: RedisKey, count: number, withvalues: 'WITHVALUES', callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
-  hrandfieldBuffer(key: RedisKey, count: number, withvalues: 'WITHVALUES', callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
+  hrandfield(key: RedisKey, count: number | string, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
+  hrandfieldBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
+  hrandfield(key: RedisKey, count: number | string, withvalues: 'WITHVALUES', callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
+  hrandfieldBuffer(key: RedisKey, count: number | string, withvalues: 'WITHVALUES', callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
 
   /**
    * Incrementally iterate hash fields and associated values
@@ -1543,12 +1567,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   hscan(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
   hscanBuffer(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  hscan(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  hscanBuffer(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  hscan(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  hscanBuffer(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
   hscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
   hscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  hscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  hscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  hscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  hscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
 
   /**
    * Set the string value of a hash field
@@ -1646,6 +1670,22 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   latency(subcommand: 'DOCTOR', callback?: Callback<string>): Result<string, Context>;
 
   /**
+   * Return a latency graph for the event.
+   * - _group_: server
+   * - _complexity_: O(1)
+   * - _since_: 2.8.13
+   */
+  latency(subcommand: 'GRAPH', event: string | Buffer, callback?: Callback<string>): Result<string, Context>;
+
+  /**
+   * Show helpful text about the different subcommands.
+   * - _group_: server
+   * - _complexity_: O(1)
+   * - _since_: 2.8.13
+   */
+  latency(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+
+  /**
    * Return the cumulative distribution of latencies of a subset of commands or all.
    * - _group_: server
    * - _complexity_: O(N) where N is the number of commands with latency information being retrieved.
@@ -1656,28 +1696,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   latency(...args: [subcommand: 'HISTOGRAM', ...commands: (string | Buffer)[]]): Result<unknown, Context>;
 
   /**
-   * Return a latency graph for the event.
-   * - _group_: server
-   * - _complexity_: O(1)
-   * - _since_: 2.8.13
-   */
-  latency(subcommand: 'GRAPH', event: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-
-  /**
    * Return timestamp-latency samples for the event.
    * - _group_: server
    * - _complexity_: O(1)
    * - _since_: 2.8.13
    */
   latency(subcommand: 'HISTORY', event: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-
-  /**
-   * Show helpful text about the different subcommands.
-   * - _group_: server
-   * - _complexity_: O(1)
-   * - _since_: 2.8.13
-   */
-  latency(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
 
   /**
    * Return the latest latency samples for all events.
@@ -1726,8 +1750,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements to traverse to get to the element at index. This makes asking for the first or the last element of the list O(1).
    * - _since_: 1.0.0
    */
-  lindex(key: RedisKey, index: number, callback?: Callback<string | null>): Result<string | null, Context>;
-  lindexBuffer(key: RedisKey, index: number, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  lindex(key: RedisKey, index: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
+  lindexBuffer(key: RedisKey, index: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
 
   /**
    * Insert an element before or after another element in a list
@@ -1767,22 +1791,38 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+M) where N is the number of provided keys and M is the number of elements returned.
    * - _since_: 7.0.0
    */
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number, callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number]): Result<unknown[] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number]): Result<unknown[] | null, Context>;
+  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
 
   /**
    * Display some computer art and the Redis version
@@ -1801,8 +1841,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   lpop(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
   lpopBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  lpop(key: RedisKey, count: number, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
-  lpopBuffer(key: RedisKey, count: number, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lpop(key: RedisKey, count: number | string, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lpopBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
 
   /**
    * Return the index of matching elements on a list
@@ -1843,8 +1883,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(S+N) where S is the distance of start offset from HEAD for small lists, from nearest end (HEAD or TAIL) for large lists; and N is the number of elements in the specified range.
    * - _since_: 1.0.0
    */
-  lrange(key: RedisKey, start: number, stop: number, callback?: Callback<string[]>): Result<string[], Context>;
-  lrangeBuffer(key: RedisKey, start: number, stop: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  lrange(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  lrangeBuffer(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Remove elements from a list
@@ -1852,7 +1892,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+M) where N is the length of the list and M is the number of elements removed.
    * - _since_: 1.0.0
    */
-  lrem(key: RedisKey, count: number, element: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  lrem(key: RedisKey, count: number | string, element: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Set the value of an element in a list by its index
@@ -1860,7 +1900,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the length of the list. Setting either the first or the last element of the list is O(1).
    * - _since_: 1.0.0
    */
-  lset(key: RedisKey, index: number, element: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  lset(key: RedisKey, index: number | string, element: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
 
   /**
    * Trim a list to the specified range
@@ -1868,15 +1908,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements to be removed by the operation.
    * - _since_: 1.0.0
    */
-  ltrim(key: RedisKey, start: number, stop: number, callback?: Callback<'OK'>): Result<'OK', Context>;
-
-  /**
-   * Ask the allocator to release memory
-   * - _group_: server
-   * - _complexity_: Depends on how much memory is allocated, could be slow
-   * - _since_: 4.0.0
-   */
-  memory(subcommand: 'PURGE', callback?: Callback<"OK">): Result<"OK", Context>;
+  ltrim(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
 
   /**
    * Outputs memory problems report
@@ -1887,12 +1919,28 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   memory(subcommand: 'DOCTOR', callback?: Callback<string>): Result<string, Context>;
 
   /**
+   * Show helpful text about the different subcommands
+   * - _group_: server
+   * - _complexity_: O(1)
+   * - _since_: 4.0.0
+   */
+  memory(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+
+  /**
    * Show allocator internal stats
    * - _group_: server
    * - _complexity_: Depends on how much memory is allocated, could be slow
    * - _since_: 4.0.0
    */
   memory(subcommand: 'MALLOC-STATS', callback?: Callback<string>): Result<string, Context>;
+
+  /**
+   * Ask the allocator to release memory
+   * - _group_: server
+   * - _complexity_: Depends on how much memory is allocated, could be slow
+   * - _since_: 4.0.0
+   */
+  memory(subcommand: 'PURGE', callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Show memory usage details
@@ -1903,21 +1951,13 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   memory(subcommand: 'STATS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
 
   /**
-   * Show helpful text about the different subcommands
-   * - _group_: server
-   * - _complexity_: O(1)
-   * - _since_: 4.0.0
-   */
-  memory(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-
-  /**
    * Estimate the memory usage of a key
    * - _group_: server
    * - _complexity_: O(N) where N is the number of samples.
    * - _since_: 4.0.0
    */
   memory(subcommand: 'USAGE', key: RedisKey, callback?: Callback<number | null>): Result<number | null, Context>;
-  memory(subcommand: 'USAGE', key: RedisKey, countToken: 'SAMPLES', count: number, callback?: Callback<number | null>): Result<number | null, Context>;
+  memory(subcommand: 'USAGE', key: RedisKey, countToken: 'SAMPLES', count: number | string, callback?: Callback<number | null>): Result<number | null, Context>;
 
   /**
    * Get the values of all the given keys
@@ -1944,14 +1984,6 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   migrate(...args: [host: string | Buffer, port: string | Buffer, ...args: (RedisValue)[]]): Result<'OK', Context>;
 
   /**
-   * Unload a module
-   * - _group_: server
-   * - _complexity_: O(1)
-   * - _since_: 4.0.0
-   */
-  module(subcommand: 'UNLOAD', name: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
    * Show helpful text about the different subcommands
    * - _group_: server
    * - _complexity_: O(1)
@@ -1976,6 +2008,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   module(subcommand: 'LOAD', path: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
   module(...args: [subcommand: 'LOAD', path: string | Buffer, ...args: (string | Buffer | number)[], callback: Callback<unknown>]): Result<unknown, Context>;
   module(...args: [subcommand: 'LOAD', path: string | Buffer, ...args: (string | Buffer | number)[]]): Result<unknown, Context>;
+
+  /**
+   * Unload a module
+   * - _group_: server
+   * - _complexity_: O(1)
+   * - _since_: 4.0.0
+   */
+  module(subcommand: 'UNLOAD', name: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Move a key to another database
@@ -2008,20 +2048,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   msetnx(...args: [...keyValues: (RedisKey | string | Buffer | number)[]]): Result<number, Context>;
 
   /**
+   * Inspect the internal encoding of a Redis object
+   * - _group_: generic
+   * - _complexity_: O(1)
+   * - _since_: 2.2.3
+   */
+  object(subcommand: 'ENCODING', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
    * Get the logarithmic access frequency counter of a Redis object
    * - _group_: generic
    * - _complexity_: O(1)
    * - _since_: 4.0.0
    */
   object(subcommand: 'FREQ', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * Get the time since a Redis object was last accessed
-   * - _group_: generic
-   * - _complexity_: O(1)
-   * - _since_: 2.2.3
-   */
-  object(subcommand: 'IDLETIME', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -2032,12 +2072,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   object(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Inspect the internal encoding of a Redis object
+   * Get the time since a Redis object was last accessed
    * - _group_: generic
    * - _complexity_: O(1)
    * - _since_: 2.2.3
    */
-  object(subcommand: 'ENCODING', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
+  object(subcommand: 'IDLETIME', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Get the number of references to the value of the key
@@ -2061,11 +2101,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.0
    */
-  pexpire(key: RedisKey, milliseconds: number, callback?: Callback<number>): Result<number, Context>;
-  pexpire(key: RedisKey, milliseconds: number, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
-  pexpire(key: RedisKey, milliseconds: number, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
-  pexpire(key: RedisKey, milliseconds: number, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
-  pexpire(key: RedisKey, milliseconds: number, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
+  pexpire(key: RedisKey, milliseconds: number | string, callback?: Callback<number>): Result<number, Context>;
+  pexpire(key: RedisKey, milliseconds: number | string, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
+  pexpire(key: RedisKey, milliseconds: number | string, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
+  pexpire(key: RedisKey, milliseconds: number | string, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
+  pexpire(key: RedisKey, milliseconds: number | string, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Set the expiration for a key as a UNIX timestamp specified in milliseconds
@@ -2073,11 +2113,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.0
    */
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number, callback?: Callback<number>): Result<number, Context>;
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
+  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, callback?: Callback<number>): Result<number, Context>;
+  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
+  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
+  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
+  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Get the expiration Unix timestamp for a key in milliseconds
@@ -2151,7 +2191,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.0
    */
-  psetex(key: RedisKey, milliseconds: number, value: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
+  psetex(key: RedisKey, milliseconds: number | string, value: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Listen for messages published to channels matching the given patterns
@@ -2187,22 +2227,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   publish(channel: string | Buffer, message: string | Buffer, callback?: Callback<number>): Result<number, Context>;
 
   /**
+   * List active channels
+   * - _group_: pubsub
+   * - _complexity_: O(N) where N is the number of active channels, and assuming constant time pattern matching (relatively short channels and patterns)
+   * - _since_: 2.8.0
+   */
+  pubsub(subcommand: 'CHANNELS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  pubsub(subcommand: 'CHANNELS', pattern: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+
+  /**
    * Show helpful text about the different subcommands
    * - _group_: pubsub
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
   pubsub(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-
-  /**
-   * Get the count of subscribers for channels
-   * - _group_: pubsub
-   * - _complexity_: O(N) for the NUMSUB subcommand, where N is the number of requested channels
-   * - _since_: 2.8.0
-   */
-  pubsub(subcommand: 'NUMSUB', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  pubsub(...args: [subcommand: 'NUMSUB', ...channels: (string | Buffer)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  pubsub(...args: [subcommand: 'NUMSUB', ...channels: (string | Buffer)[]]): Result<unknown[], Context>;
 
   /**
    * Get the count of unique patterns pattern subscriptions
@@ -2213,13 +2252,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   pubsub(subcommand: 'NUMPAT', callback?: Callback<unknown[]>): Result<unknown[], Context>;
 
   /**
-   * List active channels
+   * Get the count of subscribers for channels
    * - _group_: pubsub
-   * - _complexity_: O(N) where N is the number of active channels, and assuming constant time pattern matching (relatively short channels and patterns)
+   * - _complexity_: O(N) for the NUMSUB subcommand, where N is the number of requested channels
    * - _since_: 2.8.0
    */
-  pubsub(subcommand: 'CHANNELS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  pubsub(subcommand: 'CHANNELS', pattern: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  pubsub(subcommand: 'NUMSUB', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  pubsub(...args: [subcommand: 'NUMSUB', ...channels: (string | Buffer)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  pubsub(...args: [subcommand: 'NUMSUB', ...channels: (string | Buffer)[]]): Result<unknown[], Context>;
 
   /**
    * List active shard channels
@@ -2331,20 +2371,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
   restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, secondsToken: 'IDLETIME', seconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, secondsToken: 'IDLETIME', seconds: number, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, secondsToken: 'IDLETIME', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, secondsToken: 'IDLETIME', seconds: number | string, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
   restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', callback?: Callback<'OK'>): Result<'OK', Context>;
   restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number | string, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
   restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', callback?: Callback<'OK'>): Result<'OK', Context>;
   restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', secondsToken: 'IDLETIME', seconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', secondsToken: 'IDLETIME', seconds: number, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', secondsToken: 'IDLETIME', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', secondsToken: 'IDLETIME', seconds: number | string, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
   restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', callback?: Callback<'OK'>): Result<'OK', Context>;
   restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number | string, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
 
   /**
    * An internal command for migrating keys in a cluster
@@ -2370,8 +2410,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   rpop(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
   rpopBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  rpop(key: RedisKey, count: number, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
-  rpopBuffer(key: RedisKey, count: number, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  rpop(key: RedisKey, count: number | string, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  rpopBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
 
   /**
    * Remove the last element in a list, prepend it to another list and return it
@@ -2429,18 +2469,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   scanBuffer(cursor: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
   scan(cursor: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
   scanBuffer(cursor: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, countToken: 'COUNT', count: number, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, countToken: 'COUNT', count: number, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(cursor: number | string, countToken: 'COUNT', count: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(cursor: number | string, countToken: 'COUNT', count: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
   scan(cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
   scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
   scan(cursor: number | string, patternToken: 'MATCH', pattern: string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
   scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
 
   /**
    * Get the number of members in a set
@@ -2449,24 +2489,6 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 1.0.0
    */
   scard(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
-
-  /**
-   * Show helpful text about the different subcommands
-   * - _group_: scripting
-   * - _complexity_: O(1)
-   * - _since_: 5.0.0
-   */
-  script(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * Remove all the scripts from the script cache.
-   * - _group_: scripting
-   * - _complexity_: O(N) with N being the number of scripts in cache
-   * - _since_: 2.6.0
-   */
-  script(subcommand: 'FLUSH', callback?: Callback<unknown>): Result<unknown, Context>;
-  script(subcommand: 'FLUSH', async: 'ASYNC', callback?: Callback<unknown>): Result<unknown, Context>;
-  script(subcommand: 'FLUSH', sync: 'SYNC', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Set the debug mode for executed scripts.
@@ -2479,12 +2501,31 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   script(subcommand: 'DEBUG', no: 'NO', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Load the specified Lua script into the script cache.
+   * Check existence of scripts in the script cache.
    * - _group_: scripting
-   * - _complexity_: O(N) with N being the length in bytes of the script body.
+   * - _complexity_: O(N) with N being the number of scripts to check (so checking a single script is an O(1) operation).
    * - _since_: 2.6.0
    */
-  script(subcommand: 'LOAD', script: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  script(...args: [subcommand: 'EXISTS', ...sha1s: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
+  script(...args: [subcommand: 'EXISTS', ...sha1s: (string | Buffer)[]]): Result<unknown, Context>;
+
+  /**
+   * Remove all the scripts from the script cache.
+   * - _group_: scripting
+   * - _complexity_: O(N) with N being the number of scripts in cache
+   * - _since_: 2.6.0
+   */
+  script(subcommand: 'FLUSH', callback?: Callback<unknown>): Result<unknown, Context>;
+  script(subcommand: 'FLUSH', async: 'ASYNC', callback?: Callback<unknown>): Result<unknown, Context>;
+  script(subcommand: 'FLUSH', sync: 'SYNC', callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
+   * Show helpful text about the different subcommands
+   * - _group_: scripting
+   * - _complexity_: O(1)
+   * - _since_: 5.0.0
+   */
+  script(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Kill the script currently in execution.
@@ -2495,13 +2536,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   script(subcommand: 'KILL', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Check existence of scripts in the script cache.
+   * Load the specified Lua script into the script cache.
    * - _group_: scripting
-   * - _complexity_: O(N) with N being the number of scripts to check (so checking a single script is an O(1) operation).
+   * - _complexity_: O(N) with N being the length in bytes of the script body.
    * - _since_: 2.6.0
    */
-  script(...args: [subcommand: 'EXISTS', ...sha1s: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  script(...args: [subcommand: 'EXISTS', ...sha1s: (string | Buffer)[]]): Result<unknown, Context>;
+  script(subcommand: 'LOAD', script: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Subtract multiple sets
@@ -2535,7 +2575,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  select(index: number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  select(index: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
 
   /**
    * Set the string value of a key
@@ -2552,42 +2592,42 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   set(key: RedisKey, value: string | Buffer | number, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
   set(key: RedisKey, value: string | Buffer | number, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
   setBuffer(key: RedisKey, value: string | Buffer | number, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
+  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
+  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
   set(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', callback?: Callback<'OK'>): Result<'OK', Context>;
   set(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
   setBuffer(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
@@ -2612,7 +2652,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.0.0
    */
-  setex(key: RedisKey, seconds: number, value: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  setex(key: RedisKey, seconds: number | string, value: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
 
   /**
    * Set the value of a key, only if the key does not exist
@@ -2719,6 +2759,15 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   slaveof(host: string | Buffer, port: string | Buffer, callback?: Callback<'OK'>): Result<'OK', Context>;
 
   /**
+   * Get the slow log's entries
+   * - _group_: server
+   * - _complexity_: O(N) where N is the number of entries returned
+   * - _since_: 2.2.12
+   */
+  slowlog(subcommand: 'GET', callback?: Callback<unknown>): Result<unknown, Context>;
+  slowlog(subcommand: 'GET', count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
    * Show helpful text about the different subcommands
    * - _group_: server
    * - _complexity_: O(1)
@@ -2727,13 +2776,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   slowlog(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Get the slow log's entries
+   * Get the slow log's length
    * - _group_: server
-   * - _complexity_: O(N) where N is the number of entries returned
+   * - _complexity_: O(1)
    * - _since_: 2.2.12
    */
-  slowlog(subcommand: 'GET', callback?: Callback<unknown>): Result<unknown, Context>;
-  slowlog(subcommand: 'GET', count: number, callback?: Callback<unknown>): Result<unknown, Context>;
+  slowlog(subcommand: 'LEN', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Clear all entries from the slow log
@@ -2742,14 +2790,6 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 2.2.12
    */
   slowlog(subcommand: 'RESET', callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * Get the slow log's length
-   * - _group_: server
-   * - _complexity_: O(1)
-   * - _since_: 2.2.12
-   */
-  slowlog(subcommand: 'LEN', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Get all the members in a set
@@ -2766,10 +2806,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements being checked for membership
    * - _since_: 6.2.0
    */
-  smismember(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  smismember(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  smismember(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<unknown[], Context>;
-  smismember(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<unknown[], Context>;
+  smismember(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<number[]>]): Result<number[], Context>;
+  smismember(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<number[]>]): Result<number[], Context>;
+  smismember(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<number[], Context>;
+  smismember(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<number[], Context>;
 
   /**
    * Move a member from one set to another
@@ -2812,24 +2852,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
   sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
   sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, asc: 'ASC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, asc: 'ASC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, desc: 'DESC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, desc: 'DESC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[]]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
+  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, asc: 'ASC', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, asc: 'ASC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, desc: 'DESC', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, desc: 'DESC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[]]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], alpha: 'ALPHA']): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC']): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA']): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
   sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, callback?: Callback<unknown>): Result<unknown, Context>;
   sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
   sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, asc: 'ASC', callback?: Callback<unknown>): Result<unknown, Context>;
@@ -2848,24 +2888,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
   sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
   sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, asc: 'ASC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, asc: 'ASC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, desc: 'DESC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, desc: 'DESC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[]]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
+  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, asc: 'ASC', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, asc: 'ASC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, desc: 'DESC', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, desc: 'DESC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[]]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], alpha: 'ALPHA']): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC']): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA']): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
+  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
 
   /**
    * Remove and return one or multiple random members from a set
@@ -2875,8 +2915,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   spop(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
   spopBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  spop(key: RedisKey, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  spopBuffer(key: RedisKey, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  spop(key: RedisKey, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  spopBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Post a message to a shard channel
@@ -2894,8 +2934,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   srandmember(key: RedisKey, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
   srandmemberBuffer(key: RedisKey, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
-  srandmember(key: RedisKey, count: number, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
-  srandmemberBuffer(key: RedisKey, count: number, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
+  srandmember(key: RedisKey, count: number | string, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
+  srandmemberBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
 
   /**
    * Remove one or more members from a set
@@ -2916,12 +2956,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   sscan(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
   sscanBuffer(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  sscan(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  sscanBuffer(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  sscan(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  sscanBuffer(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
   sscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
   sscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  sscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  sscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  sscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  sscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
 
   /**
    * Listen for messages published to the given shard channels
@@ -2955,7 +2995,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.
    * - _since_: 1.0.0
    */
-  substr(key: RedisKey, start: number, end: number, callback?: Callback<unknown>): Result<unknown, Context>;
+  substr(key: RedisKey, start: number | string, end: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Add multiple sets
@@ -2999,7 +3039,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the count of clients watching or blocking on keys from both databases.
    * - _since_: 4.0.0
    */
-  swapdb(index1: number, index2: number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  swapdb(index1: number | string, index2: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
 
   /**
    * Internal command used for replication
@@ -3120,8 +3160,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, callback?: Callback<unknown[]>): Result<unknown[], Context>;
   xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, justid: 'JUSTID', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number, justid: 'JUSTID', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number | string, justid: 'JUSTID', callback?: Callback<unknown[]>): Result<unknown[], Context>;
 
   /**
    * Changes (or acquires) ownership of a message in a consumer group, as if the message was delivered to the specified consumer.
@@ -3137,30 +3177,30 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], force: 'FORCE']): Result<unknown[], Context>;
   xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
   xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
   xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
   xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string]): Result<unknown[], Context>;
   xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
@@ -3169,30 +3209,30 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, force: 'FORCE']): Result<unknown[], Context>;
   xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
   xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number, countToken: 'RETRYCOUNT', count: number, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE']): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
 
   /**
    * Removes the specified entries from the stream. Returns the number of items actually deleted, that may be different from the number of IDs passed in case certain IDs do not exist.
@@ -3219,14 +3259,6 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   xgroup(subcommand: 'CREATE', key: RedisKey, groupname: string | Buffer, newId: '$', mkstream: 'MKSTREAM', entriesReadToken: 'ENTRIESREAD', entriesRead: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Delete a consumer from a consumer group.
-   * - _group_: stream
-   * - _complexity_: O(1)
-   * - _since_: 5.0.0
-   */
-  xgroup(subcommand: 'DELCONSUMER', key: RedisKey, groupname: string | Buffer, consumername: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
    * Create a consumer in a consumer group.
    * - _group_: stream
    * - _complexity_: O(1)
@@ -3235,12 +3267,28 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   xgroup(subcommand: 'CREATECONSUMER', key: RedisKey, groupname: string | Buffer, consumername: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
+   * Delete a consumer from a consumer group.
+   * - _group_: stream
+   * - _complexity_: O(1)
+   * - _since_: 5.0.0
+   */
+  xgroup(subcommand: 'DELCONSUMER', key: RedisKey, groupname: string | Buffer, consumername: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
    * Destroy a consumer group.
    * - _group_: stream
    * - _complexity_: O(N) where N is the number of entries in the group's pending entries list (PEL).
    * - _since_: 5.0.0
    */
   xgroup(subcommand: 'DESTROY', key: RedisKey, groupname: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+
+  /**
+   * Show helpful text about the different subcommands
+   * - _group_: stream
+   * - _complexity_: O(1)
+   * - _since_: 5.0.0
+   */
+  xgroup(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Set a consumer group to an arbitrary last delivered ID value.
@@ -3254,20 +3302,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   xgroup(subcommand: 'SETID', key: RedisKey, groupname: string | Buffer, newId: '$', entriesReadToken: 'ENTRIESREAD', entriesRead: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * Show helpful text about the different subcommands
+   * List the consumers in a consumer group
    * - _group_: stream
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xgroup(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
-
-  /**
-   * Show helpful text about the different subcommands
-   * - _group_: stream
-   * - _complexity_: O(1)
-   * - _since_: 5.0.0
-   */
-  xinfo(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  xinfo(subcommand: 'CONSUMERS', key: RedisKey, groupname: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * List the consumer groups of a stream
@@ -3278,12 +3318,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   xinfo(subcommand: 'GROUPS', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
-   * List the consumers in a consumer group
+   * Show helpful text about the different subcommands
    * - _group_: stream
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xinfo(subcommand: 'CONSUMERS', key: RedisKey, groupname: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  xinfo(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Get information about a stream
@@ -3293,7 +3333,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   xinfo(subcommand: 'STREAM', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
   xinfo(subcommand: 'STREAM', key: RedisKey, fullToken: 'FULL', callback?: Callback<unknown>): Result<unknown, Context>;
-  xinfo(subcommand: 'STREAM', key: RedisKey, fullToken: 'FULL', countToken: 'COUNT', count: number, callback?: Callback<unknown>): Result<unknown, Context>;
+  xinfo(subcommand: 'STREAM', key: RedisKey, fullToken: 'FULL', countToken: 'COUNT', count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Return the number of entries in a stream
@@ -3310,10 +3350,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 5.0.0
    */
   xpending(key: RedisKey, group: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xpending(key: RedisKey, group: string | Buffer, start: string | Buffer | number, end: string | Buffer | number, count: number, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xpending(key: RedisKey, group: string | Buffer, start: string | Buffer | number, end: string | Buffer | number, count: number, consumer: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xpending(key: RedisKey, group: string | Buffer, minIdleTimeToken: 'IDLE', minIdleTime: number | string, start: string | Buffer | number, end: string | Buffer | number, count: number, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xpending(key: RedisKey, group: string | Buffer, minIdleTimeToken: 'IDLE', minIdleTime: number | string, start: string | Buffer | number, end: string | Buffer | number, count: number, consumer: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  xpending(key: RedisKey, group: string | Buffer, start: string | Buffer | number, end: string | Buffer | number, count: number | string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  xpending(key: RedisKey, group: string | Buffer, start: string | Buffer | number, end: string | Buffer | number, count: number | string, consumer: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  xpending(key: RedisKey, group: string | Buffer, minIdleTimeToken: 'IDLE', minIdleTime: number | string, start: string | Buffer | number, end: string | Buffer | number, count: number | string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  xpending(key: RedisKey, group: string | Buffer, minIdleTimeToken: 'IDLE', minIdleTime: number | string, start: string | Buffer | number, end: string | Buffer | number, count: number | string, consumer: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
 
   /**
    * Return a range of elements in a stream, with IDs matching the specified IDs interval
@@ -3323,8 +3363,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   xrange(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
   xrangeBuffer(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
-  xrange(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, countToken: 'COUNT', count: number, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
-  xrangeBuffer(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, countToken: 'COUNT', count: number, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
+  xrange(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
+  xrangeBuffer(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
 
   /**
    * Return never seen elements in multiple streams, with IDs greater than the ones reported by the caller for each stream. Can block.
@@ -3334,12 +3374,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   xread(...args: [streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
   xread(...args: [streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xread(...args: [millisecondsToken: 'BLOCK', milliseconds: number, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  xread(...args: [millisecondsToken: 'BLOCK', milliseconds: number, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[] | null, Context>;
-  xread(...args: [countToken: 'COUNT', count: number, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xread(...args: [countToken: 'COUNT', count: number, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xread(...args: [countToken: 'COUNT', count: number, millisecondsToken: 'BLOCK', milliseconds: number, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  xread(...args: [countToken: 'COUNT', count: number, millisecondsToken: 'BLOCK', milliseconds: number, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[] | null, Context>;
+  xread(...args: [millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
+  xread(...args: [millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[] | null, Context>;
+  xread(...args: [countToken: 'COUNT', count: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xread(...args: [countToken: 'COUNT', count: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  xread(...args: [countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
+  xread(...args: [countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[] | null, Context>;
 
   /**
    * Return new entries from a stream using a consumer group, or access the history of the pending entries for a given consumer. Can block.
@@ -3351,18 +3391,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
   xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
   xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number, millisecondsToken: 'BLOCK', milliseconds: number, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number, millisecondsToken: 'BLOCK', milliseconds: number, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number, millisecondsToken: 'BLOCK', milliseconds: number, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number, millisecondsToken: 'BLOCK', milliseconds: number, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
+  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
 
   /**
    * Return a range of elements in a stream, with IDs matching the specified IDs interval, in reverse order (from greater to smaller IDs) compared to XRANGE
@@ -3372,8 +3412,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   xrevrange(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
   xrevrangeBuffer(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
-  xrevrange(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
-  xrevrangeBuffer(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
+  xrevrange(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
+  xrevrangeBuffer(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
 
   /**
    * An internal command for replicating stream values
@@ -3393,17 +3433,17 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 5.0.0
    */
   xtrim(key: RedisKey, maxlen: 'MAXLEN', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, maxlen: 'MAXLEN', threshold: string | Buffer | number, countToken: 'LIMIT', count: number, callback?: Callback<number>): Result<number, Context>;
+  xtrim(key: RedisKey, maxlen: 'MAXLEN', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
   xtrim(key: RedisKey, maxlen: 'MAXLEN', equal: '=', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, maxlen: 'MAXLEN', equal: '=', threshold: string | Buffer | number, countToken: 'LIMIT', count: number, callback?: Callback<number>): Result<number, Context>;
+  xtrim(key: RedisKey, maxlen: 'MAXLEN', equal: '=', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
   xtrim(key: RedisKey, maxlen: 'MAXLEN', approximately: '~', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, maxlen: 'MAXLEN', approximately: '~', threshold: string | Buffer | number, countToken: 'LIMIT', count: number, callback?: Callback<number>): Result<number, Context>;
+  xtrim(key: RedisKey, maxlen: 'MAXLEN', approximately: '~', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
   xtrim(key: RedisKey, minid: 'MINID', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, minid: 'MINID', threshold: string | Buffer | number, countToken: 'LIMIT', count: number, callback?: Callback<number>): Result<number, Context>;
+  xtrim(key: RedisKey, minid: 'MINID', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
   xtrim(key: RedisKey, minid: 'MINID', equal: '=', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, minid: 'MINID', equal: '=', threshold: string | Buffer | number, countToken: 'LIMIT', count: number, callback?: Callback<number>): Result<number, Context>;
+  xtrim(key: RedisKey, minid: 'MINID', equal: '=', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
   xtrim(key: RedisKey, minid: 'MINID', approximately: '~', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, minid: 'MINID', approximately: '~', threshold: string | Buffer | number, countToken: 'LIMIT', count: number, callback?: Callback<number>): Result<number, Context>;
+  xtrim(key: RedisKey, minid: 'MINID', approximately: '~', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Add one or more members to a sorted set, or update its score if it already exists
@@ -3746,18 +3786,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN', callback: Callback<unknown>]): Result<unknown, Context>;
   zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN']): Result<unknown, Context>;
   zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN']): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number, callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number, callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number]): Result<unknown, Context>;
+  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
+  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
+  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
+  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
   zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', callback: Callback<unknown>]): Result<unknown, Context>;
   zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX', callback: Callback<unknown>]): Result<unknown, Context>;
   zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX']): Result<unknown, Context>;
   zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX']): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number, callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number, callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number]): Result<unknown, Context>;
+  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
+  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
+  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
+  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
 
   /**
    * Get the score associated with the given members in a sorted set
@@ -3782,8 +3822,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   zpopmax(key: RedisKey, callback?: Callback<string[]>): Result<string[], Context>;
   zpopmaxBuffer(key: RedisKey, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zpopmax(key: RedisKey, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zpopmaxBuffer(key: RedisKey, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zpopmax(key: RedisKey, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zpopmaxBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Remove and return members with the lowest scores in a sorted set
@@ -3793,8 +3833,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   zpopmin(key: RedisKey, callback?: Callback<string[]>): Result<string[], Context>;
   zpopminBuffer(key: RedisKey, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zpopmin(key: RedisKey, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zpopminBuffer(key: RedisKey, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zpopmin(key: RedisKey, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zpopminBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Get one or multiple random elements from a sorted set
@@ -3802,12 +3842,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements returned
    * - _since_: 6.2.0
    */
-  zrandmember(key: RedisKey, callback?: Callback<string[]>): Result<string[], Context>;
-  zrandmemberBuffer(key: RedisKey, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrandmember(key: RedisKey, count: number, callback?: Callback<string | null>): Result<string | null, Context>;
-  zrandmemberBuffer(key: RedisKey, count: number, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  zrandmember(key: RedisKey, count: number, withscores: 'WITHSCORES', callback?: Callback<string | null>): Result<string | null, Context>;
-  zrandmemberBuffer(key: RedisKey, count: number, withscores: 'WITHSCORES', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  zrandmember(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
+  zrandmemberBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  zrandmember(key: RedisKey, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrandmemberBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrandmember(key: RedisKey, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
+  zrandmemberBuffer(key: RedisKey, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set
@@ -3819,50 +3859,50 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
   zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
+  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set, by lexicographical range
@@ -3872,8 +3912,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   zrangebylex(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<string[]>): Result<string[], Context>;
   zrangebylexBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrangebylex(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangebylexBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrangebylex(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrangebylexBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set, by score
@@ -3883,12 +3923,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   zrangebyscore(key: RedisKey, min: number | string, max: number | string, callback?: Callback<string[]>): Result<string[], Context>;
   zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrangebyscore(key: RedisKey, min: number | string, max: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrangebyscore(key: RedisKey, min: number | string, max: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrangebyscore(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
   zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrangebyscore(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrangebyscore(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Store a range of members from sorted set into another key
@@ -3897,17 +3937,17 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 6.2.0
    */
   zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<number>): Result<number, Context>;
+  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
   zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<number>): Result<number, Context>;
+  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
   zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<number>): Result<number, Context>;
+  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
   zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<number>): Result<number, Context>;
+  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
   zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<number>): Result<number, Context>;
+  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
   zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<number>): Result<number, Context>;
+  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Determine the index of a member in a sorted set
@@ -3942,7 +3982,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.
    * - _since_: 2.0.0
    */
-  zremrangebyrank(key: RedisKey, start: number, stop: number, callback?: Callback<number>): Result<number, Context>;
+  zremrangebyrank(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<number>): Result<number, Context>;
 
   /**
    * Remove all members in a sorted set within the given scores
@@ -3958,10 +3998,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.
    * - _since_: 1.2.0
    */
-  zrevrange(key: RedisKey, start: number, stop: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangeBuffer(key: RedisKey, start: number, stop: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrevrange(key: RedisKey, start: number, stop: number, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangeBuffer(key: RedisKey, start: number, stop: number, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrevrange(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrevrangeBuffer(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrevrange(key: RedisKey, start: number | string, stop: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
+  zrevrangeBuffer(key: RedisKey, start: number | string, stop: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set, by lexicographical range, ordered from higher to lower strings.
@@ -3971,8 +4011,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   zrevrangebylex(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, callback?: Callback<string[]>): Result<string[], Context>;
   zrevrangebylexBuffer(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrevrangebylex(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangebylexBuffer(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrevrangebylex(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrevrangebylexBuffer(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set, by score, with scores ordered from high to low
@@ -3982,12 +4022,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, callback?: Callback<string[]>): Result<string[], Context>;
   zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
   zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
   zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
 
   /**
    * Determine the index of a member in a sorted set, with scores ordered from high to low
@@ -4005,12 +4045,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   zscan(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
   zscanBuffer(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  zscan(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  zscanBuffer(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
   zscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
   zscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  zscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  zscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
 
   /**
    * Get the score associated with the given member in a sorted set

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -51,15 +51,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
     ...args: [command: string, ...args: (string | Buffer | number)[]]
   ): Result<unknown, Context>;
 
-  
   /**
    * List the ACL categories or the commands inside a category
    * - _group_: server
    * - _complexity_: O(1) since the categories and commands are a fixed set.
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'CAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  acl(subcommand: 'CAT', categoryname: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  acl(
+    subcommand: "CAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  acl(
+    subcommand: "CAT",
+    categoryname: string | Buffer,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Remove the specified ACL users and the associated rules
@@ -67,8 +73,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) amortized time considering the typical user.
    * - _since_: 6.0.0
    */
-  acl(...args: [subcommand: 'DELUSER', ...usernames: (string | Buffer)[], callback: Callback<number>]): Result<number, Context>;
-  acl(...args: [subcommand: 'DELUSER', ...usernames: (string | Buffer)[]]): Result<number, Context>;
+  acl(
+    ...args: [
+      subcommand: "DELUSER",
+      ...usernames: (string | Buffer)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  acl(
+    ...args: [subcommand: "DELUSER", ...usernames: (string | Buffer)[]]
+  ): Result<number, Context>;
 
   /**
    * Returns whether the user can execute the given command without executing the command.
@@ -76,12 +90,52 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1).
    * - _since_: 7.0.0
    */
-  acl(subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  aclBuffer(subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
-  acl(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[], callback: Callback<string>]): Result<string, Context>;
-  aclBuffer(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[], callback: Callback<Buffer>]): Result<Buffer, Context>;
-  acl(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[]]): Result<string, Context>;
-  aclBuffer(...args: [subcommand: 'DRYRUN', username: string | Buffer, command: string | Buffer, ...args: (string | Buffer | number)[]]): Result<Buffer, Context>;
+  acl(
+    subcommand: "DRYRUN",
+    username: string | Buffer,
+    command: string | Buffer,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  aclBuffer(
+    subcommand: "DRYRUN",
+    username: string | Buffer,
+    command: string | Buffer,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  acl(
+    ...args: [
+      subcommand: "DRYRUN",
+      username: string | Buffer,
+      command: string | Buffer,
+      ...args: (string | Buffer | number)[],
+      callback: Callback<string>
+    ]
+  ): Result<string, Context>;
+  aclBuffer(
+    ...args: [
+      subcommand: "DRYRUN",
+      username: string | Buffer,
+      command: string | Buffer,
+      ...args: (string | Buffer | number)[],
+      callback: Callback<Buffer>
+    ]
+  ): Result<Buffer, Context>;
+  acl(
+    ...args: [
+      subcommand: "DRYRUN",
+      username: string | Buffer,
+      command: string | Buffer,
+      ...args: (string | Buffer | number)[]
+    ]
+  ): Result<string, Context>;
+  aclBuffer(
+    ...args: [
+      subcommand: "DRYRUN",
+      username: string | Buffer,
+      command: string | Buffer,
+      ...args: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer, Context>;
 
   /**
    * Generate a pseudorandom secure password to use for ACL users
@@ -89,10 +143,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'GENPASS', callback?: Callback<string>): Result<string, Context>;
-  aclBuffer(subcommand: 'GENPASS', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  acl(subcommand: 'GENPASS', bits: number | string, callback?: Callback<string>): Result<string, Context>;
-  aclBuffer(subcommand: 'GENPASS', bits: number | string, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  acl(
+    subcommand: "GENPASS",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  aclBuffer(
+    subcommand: "GENPASS",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  acl(
+    subcommand: "GENPASS",
+    bits: number | string,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  aclBuffer(
+    subcommand: "GENPASS",
+    bits: number | string,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Get the rules for a specific ACL user
@@ -100,8 +168,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N). Where N is the number of password, command and pattern rules that the user has.
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'GETUSER', username: string | Buffer, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
-  aclBuffer(subcommand: 'GETUSER', username: string | Buffer, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  acl(
+    subcommand: "GETUSER",
+    username: string | Buffer,
+    callback?: Callback<string[] | null>
+  ): Result<string[] | null, Context>;
+  aclBuffer(
+    subcommand: "GETUSER",
+    username: string | Buffer,
+    callback?: Callback<Buffer[] | null>
+  ): Result<Buffer[] | null, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -109,7 +185,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  acl(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * List the current ACL rules in ACL config file format
@@ -117,8 +196,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N). Where N is the number of configured users.
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'LIST', callback?: Callback<string[]>): Result<string[], Context>;
-  aclBuffer(subcommand: 'LIST', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  acl(
+    subcommand: "LIST",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  aclBuffer(
+    subcommand: "LIST",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Reload the ACLs from the configured ACL file
@@ -126,7 +211,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N). Where N is the number of configured users.
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'LOAD', callback?: Callback<"OK">): Result<"OK", Context>;
+  acl(subcommand: "LOAD", callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * List latest events denied because of ACLs in place
@@ -134,9 +219,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) with N being the number of entries shown.
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'LOG', callback?: Callback<unknown>): Result<unknown, Context>;
-  acl(subcommand: 'LOG', count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  acl(subcommand: 'LOG', reset: 'RESET', callback?: Callback<unknown>): Result<unknown, Context>;
+  acl(
+    subcommand: "LOG",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  acl(
+    subcommand: "LOG",
+    count: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  acl(
+    subcommand: "LOG",
+    reset: "RESET",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Save the current ACL rules in the configured ACL file
@@ -144,7 +240,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N). Where N is the number of configured users.
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'SAVE', callback?: Callback<"OK">): Result<"OK", Context>;
+  acl(subcommand: "SAVE", callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Modify or create the rules for a specific ACL user
@@ -152,9 +248,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N). Where N is the number of rules provided.
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'SETUSER', username: string | Buffer, callback?: Callback<"OK">): Result<"OK", Context>;
-  acl(...args: [subcommand: 'SETUSER', username: string | Buffer, ...rules: (string | Buffer)[], callback: Callback<"OK">]): Result<"OK", Context>;
-  acl(...args: [subcommand: 'SETUSER', username: string | Buffer, ...rules: (string | Buffer)[]]): Result<"OK", Context>;
+  acl(
+    subcommand: "SETUSER",
+    username: string | Buffer,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  acl(
+    ...args: [
+      subcommand: "SETUSER",
+      username: string | Buffer,
+      ...rules: (string | Buffer)[],
+      callback: Callback<"OK">
+    ]
+  ): Result<"OK", Context>;
+  acl(
+    ...args: [
+      subcommand: "SETUSER",
+      username: string | Buffer,
+      ...rules: (string | Buffer)[]
+    ]
+  ): Result<"OK", Context>;
 
   /**
    * List the username of all the configured ACL rules
@@ -162,8 +275,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N). Where N is the number of configured users.
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'USERS', callback?: Callback<string[]>): Result<string[], Context>;
-  aclBuffer(subcommand: 'USERS', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  acl(
+    subcommand: "USERS",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  aclBuffer(
+    subcommand: "USERS",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Return the name of the user associated to the current connection
@@ -171,8 +290,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.0.0
    */
-  acl(subcommand: 'WHOAMI', callback?: Callback<string>): Result<string, Context>;
-  aclBuffer(subcommand: 'WHOAMI', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  acl(
+    subcommand: "WHOAMI",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  aclBuffer(
+    subcommand: "WHOAMI",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Append a value to a key
@@ -180,7 +305,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1). The amortized time complexity is O(1) assuming the appended value is small and the already present value is of any size, since the dynamic string library used by Redis will double the free space available on every reallocation.
    * - _since_: 2.0.0
    */
-  append(key: RedisKey, value: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  append(
+    key: RedisKey,
+    value: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Sent by cluster clients after an -ASK redirect
@@ -188,7 +317,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  asking(callback?: Callback<'OK'>): Result<'OK', Context>;
+  asking(callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Authenticate to the server
@@ -196,8 +325,15 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of passwords defined for the user
    * - _since_: 1.0.0
    */
-  auth(password: string | Buffer, callback?: Callback<'OK'>): Result<'OK', Context>;
-  auth(username: string | Buffer, password: string | Buffer, callback?: Callback<'OK'>): Result<'OK', Context>;
+  auth(
+    password: string | Buffer,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  auth(
+    username: string | Buffer,
+    password: string | Buffer,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Asynchronously rewrite the append-only file
@@ -214,8 +350,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  bgsave(callback?: Callback<'OK'>): Result<'OK', Context>;
-  bgsave(schedule: 'SCHEDULE', callback?: Callback<'OK'>): Result<'OK', Context>;
+  bgsave(callback?: Callback<"OK">): Result<"OK", Context>;
+  bgsave(
+    schedule: "SCHEDULE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Count set bits in a string
@@ -224,9 +363,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 2.6.0
    */
   bitcount(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
-  bitcount(key: RedisKey, start: number | string, end: number | string, callback?: Callback<number>): Result<number, Context>;
-  bitcount(key: RedisKey, start: number | string, end: number | string, byte: 'BYTE', callback?: Callback<number>): Result<number, Context>;
-  bitcount(key: RedisKey, start: number | string, end: number | string, bit: 'BIT', callback?: Callback<number>): Result<number, Context>;
+  bitcount(
+    key: RedisKey,
+    start: number | string,
+    end: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  bitcount(
+    key: RedisKey,
+    start: number | string,
+    end: number | string,
+    byte: "BYTE",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  bitcount(
+    key: RedisKey,
+    start: number | string,
+    end: number | string,
+    bit: "BIT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Perform arbitrary bitfield integer operations on strings
@@ -234,38 +390,358 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each subcommand specified
    * - _since_: 3.2.0
    */
-  bitfield(key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, overflow: 'OVERFLOW', wrap: 'WRAP', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, overflow: 'OVERFLOW', sat: 'SAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, overflow: 'OVERFLOW', fail: 'FAIL', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetIncrementToken: 'INCRBY', encoding: string | Buffer, offset: number | string, increment: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetIncrementToken: 'INCRBY', encoding: string | Buffer, offset: number | string, increment: number | string, overflow: 'OVERFLOW', wrap: 'WRAP', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetIncrementToken: 'INCRBY', encoding: string | Buffer, offset: number | string, increment: number | string, overflow: 'OVERFLOW', sat: 'SAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetIncrementToken: 'INCRBY', encoding: string | Buffer, offset: number | string, increment: number | string, overflow: 'OVERFLOW', fail: 'FAIL', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetValueToken: 'SET', encoding: string | Buffer, offset: number | string, value: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetValueToken: 'SET', encoding: string | Buffer, offset: number | string, value: number | string, overflow: 'OVERFLOW', wrap: 'WRAP', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetValueToken: 'SET', encoding: string | Buffer, offset: number | string, value: number | string, overflow: 'OVERFLOW', sat: 'SAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetValueToken: 'SET', encoding: string | Buffer, offset: number | string, value: number | string, overflow: 'OVERFLOW', fail: 'FAIL', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetValueToken: 'SET', encoding: string | Buffer, offset: number | string, value: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding1: string | Buffer, offset1: number | string, increment: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetValueToken: 'SET', encoding: string | Buffer, offset: number | string, value: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding1: string | Buffer, offset1: number | string, increment: number | string, overflow: 'OVERFLOW', wrap: 'WRAP', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetValueToken: 'SET', encoding: string | Buffer, offset: number | string, value: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding1: string | Buffer, offset1: number | string, increment: number | string, overflow: 'OVERFLOW', sat: 'SAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetValueToken: 'SET', encoding: string | Buffer, offset: number | string, value: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding1: string | Buffer, offset1: number | string, increment: number | string, overflow: 'OVERFLOW', fail: 'FAIL', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, overflow: 'OVERFLOW', wrap: 'WRAP', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, overflow: 'OVERFLOW', sat: 'SAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, overflow: 'OVERFLOW', fail: 'FAIL', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding1: string | Buffer, offset1: number | string, increment: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding1: string | Buffer, offset1: number | string, increment: number | string, overflow: 'OVERFLOW', wrap: 'WRAP', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding1: string | Buffer, offset1: number | string, increment: number | string, overflow: 'OVERFLOW', sat: 'SAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding1: string | Buffer, offset1: number | string, increment: number | string, overflow: 'OVERFLOW', fail: 'FAIL', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetValueToken: 'SET', encoding1: string | Buffer, offset1: number | string, value: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetValueToken: 'SET', encoding1: string | Buffer, offset1: number | string, value: number | string, overflow: 'OVERFLOW', wrap: 'WRAP', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetValueToken: 'SET', encoding1: string | Buffer, offset1: number | string, value: number | string, overflow: 'OVERFLOW', sat: 'SAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetValueToken: 'SET', encoding1: string | Buffer, offset1: number | string, value: number | string, overflow: 'OVERFLOW', fail: 'FAIL', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetValueToken: 'SET', encoding1: string | Buffer, offset1: number | string, value: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding2: string | Buffer, offset2: number | string, increment: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetValueToken: 'SET', encoding1: string | Buffer, offset1: number | string, value: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding2: string | Buffer, offset2: number | string, increment: number | string, overflow: 'OVERFLOW', wrap: 'WRAP', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetValueToken: 'SET', encoding1: string | Buffer, offset1: number | string, value: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding2: string | Buffer, offset2: number | string, increment: number | string, overflow: 'OVERFLOW', sat: 'SAT', callback?: Callback<unknown>): Result<unknown, Context>;
-  bitfield(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, encodingOffsetValueToken: 'SET', encoding1: string | Buffer, offset1: number | string, value: number | string, encodingOffsetIncrementToken: 'INCRBY', encoding2: string | Buffer, offset2: number | string, increment: number | string, overflow: 'OVERFLOW', fail: 'FAIL', callback?: Callback<unknown>): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    overflow: "OVERFLOW",
+    wrap: "WRAP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    overflow: "OVERFLOW",
+    sat: "SAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    overflow: "OVERFLOW",
+    fail: "FAIL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding: string | Buffer,
+    offset: number | string,
+    increment: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding: string | Buffer,
+    offset: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    wrap: "WRAP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding: string | Buffer,
+    offset: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    sat: "SAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding: string | Buffer,
+    offset: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    fail: "FAIL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetValueToken: "SET",
+    encoding: string | Buffer,
+    offset: number | string,
+    value: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetValueToken: "SET",
+    encoding: string | Buffer,
+    offset: number | string,
+    value: number | string,
+    overflow: "OVERFLOW",
+    wrap: "WRAP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetValueToken: "SET",
+    encoding: string | Buffer,
+    offset: number | string,
+    value: number | string,
+    overflow: "OVERFLOW",
+    sat: "SAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetValueToken: "SET",
+    encoding: string | Buffer,
+    offset: number | string,
+    value: number | string,
+    overflow: "OVERFLOW",
+    fail: "FAIL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetValueToken: "SET",
+    encoding: string | Buffer,
+    offset: number | string,
+    value: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    increment: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetValueToken: "SET",
+    encoding: string | Buffer,
+    offset: number | string,
+    value: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    wrap: "WRAP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetValueToken: "SET",
+    encoding: string | Buffer,
+    offset: number | string,
+    value: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    sat: "SAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetValueToken: "SET",
+    encoding: string | Buffer,
+    offset: number | string,
+    value: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    fail: "FAIL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    overflow: "OVERFLOW",
+    wrap: "WRAP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    overflow: "OVERFLOW",
+    sat: "SAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    overflow: "OVERFLOW",
+    fail: "FAIL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    increment: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    wrap: "WRAP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    sat: "SAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    fail: "FAIL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetValueToken: "SET",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    value: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetValueToken: "SET",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    value: number | string,
+    overflow: "OVERFLOW",
+    wrap: "WRAP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetValueToken: "SET",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    value: number | string,
+    overflow: "OVERFLOW",
+    sat: "SAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetValueToken: "SET",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    value: number | string,
+    overflow: "OVERFLOW",
+    fail: "FAIL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetValueToken: "SET",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    value: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding2: string | Buffer,
+    offset2: number | string,
+    increment: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetValueToken: "SET",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    value: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding2: string | Buffer,
+    offset2: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    wrap: "WRAP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetValueToken: "SET",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    value: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding2: string | Buffer,
+    offset2: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    sat: "SAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  bitfield(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    encodingOffsetValueToken: "SET",
+    encoding1: string | Buffer,
+    offset1: number | string,
+    value: number | string,
+    encodingOffsetIncrementToken: "INCRBY",
+    encoding2: string | Buffer,
+    offset2: number | string,
+    increment: number | string,
+    overflow: "OVERFLOW",
+    fail: "FAIL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Perform arbitrary bitfield integer operations on strings. Read-only variant of BITFIELD
@@ -273,7 +749,13 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each subcommand specified
    * - _since_: 6.2.0
    */
-  bitfield_ro(key: RedisKey, encodingOffsetToken: 'GET', encoding: string | Buffer, offset: number | string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  bitfield_ro(
+    key: RedisKey,
+    encodingOffsetToken: "GET",
+    encoding: string | Buffer,
+    offset: number | string,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Perform bitwise operations between strings
@@ -281,10 +763,32 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N)
    * - _since_: 2.6.0
    */
-  bitop(...args: [operation: string | Buffer, destkey: RedisKey, ...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  bitop(...args: [operation: string | Buffer, destkey: RedisKey, keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  bitop(...args: [operation: string | Buffer, destkey: RedisKey, ...keys: (RedisKey)[]]): Result<number, Context>;
-  bitop(...args: [operation: string | Buffer, destkey: RedisKey, keys: (RedisKey)[]]): Result<number, Context>;
+  bitop(
+    ...args: [
+      operation: string | Buffer,
+      destkey: RedisKey,
+      ...keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  bitop(
+    ...args: [
+      operation: string | Buffer,
+      destkey: RedisKey,
+      keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  bitop(
+    ...args: [
+      operation: string | Buffer,
+      destkey: RedisKey,
+      ...keys: RedisKey[]
+    ]
+  ): Result<number, Context>;
+  bitop(
+    ...args: [operation: string | Buffer, destkey: RedisKey, keys: RedisKey[]]
+  ): Result<number, Context>;
 
   /**
    * Find first bit set or clear in a string
@@ -292,11 +796,40 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N)
    * - _since_: 2.8.7
    */
-  bitpos(key: RedisKey, bit: number | string, callback?: Callback<number>): Result<number, Context>;
-  bitpos(key: RedisKey, bit: number | string, start: number | string, callback?: Callback<number>): Result<number, Context>;
-  bitpos(key: RedisKey, bit: number | string, start: number | string, end: number | string, callback?: Callback<number>): Result<number, Context>;
-  bitpos(key: RedisKey, bit: number | string, start: number | string, end: number | string, byte: 'BYTE', callback?: Callback<number>): Result<number, Context>;
-  bitpos(key: RedisKey, bit: number | string, start: number | string, end: number | string, bit1: 'BIT', callback?: Callback<number>): Result<number, Context>;
+  bitpos(
+    key: RedisKey,
+    bit: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  bitpos(
+    key: RedisKey,
+    bit: number | string,
+    start: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  bitpos(
+    key: RedisKey,
+    bit: number | string,
+    start: number | string,
+    end: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  bitpos(
+    key: RedisKey,
+    bit: number | string,
+    start: number | string,
+    end: number | string,
+    byte: "BYTE",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  bitpos(
+    key: RedisKey,
+    bit: number | string,
+    start: number | string,
+    end: number | string,
+    bit1: "BIT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Pop an element from a list, push it to another list and return it; or block until one is available
@@ -304,14 +837,70 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  blmove(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  blmoveBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  blmove(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  blmoveBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  blmove(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  blmoveBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  blmove(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  blmoveBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  blmove(
+    source: RedisKey,
+    destination: RedisKey,
+    left: "LEFT",
+    left1: "LEFT",
+    timeout: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  blmoveBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    left: "LEFT",
+    left1: "LEFT",
+    timeout: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  blmove(
+    source: RedisKey,
+    destination: RedisKey,
+    left: "LEFT",
+    right: "RIGHT",
+    timeout: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  blmoveBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    left: "LEFT",
+    right: "RIGHT",
+    timeout: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  blmove(
+    source: RedisKey,
+    destination: RedisKey,
+    right: "RIGHT",
+    left: "LEFT",
+    timeout: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  blmoveBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    right: "RIGHT",
+    left: "LEFT",
+    timeout: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  blmove(
+    source: RedisKey,
+    destination: RedisKey,
+    right: "RIGHT",
+    right1: "RIGHT",
+    timeout: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  blmoveBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    right: "RIGHT",
+    right1: "RIGHT",
+    timeout: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Pop elements from a list, or block until one is available
@@ -319,38 +908,310 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+M) where N is the number of provided keys and M is the number of elements returned.
    * - _since_: 7.0.0
    */
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  blmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
-  blmpopBuffer(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT"
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT"
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT"
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT"
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT"
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT"
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT"
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT"
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  blmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  blmpopBuffer(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
 
   /**
    * Remove and get the first element in a list, or block until one is available
@@ -358,14 +1219,46 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of provided keys.
    * - _since_: 2.0.0
    */
-  blpop(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[string, string] | null>]): Result<[string, string] | null, Context>;
-  blpopBuffer(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[Buffer, Buffer] | null>]): Result<[Buffer, Buffer] | null, Context>;
-  blpop(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[string, string] | null>]): Result<[string, string] | null, Context>;
-  blpopBuffer(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[Buffer, Buffer] | null>]): Result<[Buffer, Buffer] | null, Context>;
-  blpop(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[string, string] | null, Context>;
-  blpopBuffer(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[Buffer, Buffer] | null, Context>;
-  blpop(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[string, string] | null, Context>;
-  blpopBuffer(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[Buffer, Buffer] | null, Context>;
+  blpop(
+    ...args: [
+      ...keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[string, string] | null>
+    ]
+  ): Result<[string, string] | null, Context>;
+  blpopBuffer(
+    ...args: [
+      ...keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[Buffer, Buffer] | null>
+    ]
+  ): Result<[Buffer, Buffer] | null, Context>;
+  blpop(
+    ...args: [
+      keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[string, string] | null>
+    ]
+  ): Result<[string, string] | null, Context>;
+  blpopBuffer(
+    ...args: [
+      keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[Buffer, Buffer] | null>
+    ]
+  ): Result<[Buffer, Buffer] | null, Context>;
+  blpop(
+    ...args: [...keys: RedisKey[], timeout: number | string]
+  ): Result<[string, string] | null, Context>;
+  blpopBuffer(
+    ...args: [...keys: RedisKey[], timeout: number | string]
+  ): Result<[Buffer, Buffer] | null, Context>;
+  blpop(
+    ...args: [keys: RedisKey[], timeout: number | string]
+  ): Result<[string, string] | null, Context>;
+  blpopBuffer(
+    ...args: [keys: RedisKey[], timeout: number | string]
+  ): Result<[Buffer, Buffer] | null, Context>;
 
   /**
    * Remove and get the last element in a list, or block until one is available
@@ -373,14 +1266,46 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of provided keys.
    * - _since_: 2.0.0
    */
-  brpop(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[string, string] | null>]): Result<[string, string] | null, Context>;
-  brpopBuffer(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[Buffer, Buffer] | null>]): Result<[Buffer, Buffer] | null, Context>;
-  brpop(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[string, string] | null>]): Result<[string, string] | null, Context>;
-  brpopBuffer(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[Buffer, Buffer] | null>]): Result<[Buffer, Buffer] | null, Context>;
-  brpop(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[string, string] | null, Context>;
-  brpopBuffer(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[Buffer, Buffer] | null, Context>;
-  brpop(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[string, string] | null, Context>;
-  brpopBuffer(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[Buffer, Buffer] | null, Context>;
+  brpop(
+    ...args: [
+      ...keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[string, string] | null>
+    ]
+  ): Result<[string, string] | null, Context>;
+  brpopBuffer(
+    ...args: [
+      ...keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[Buffer, Buffer] | null>
+    ]
+  ): Result<[Buffer, Buffer] | null, Context>;
+  brpop(
+    ...args: [
+      keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[string, string] | null>
+    ]
+  ): Result<[string, string] | null, Context>;
+  brpopBuffer(
+    ...args: [
+      keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[Buffer, Buffer] | null>
+    ]
+  ): Result<[Buffer, Buffer] | null, Context>;
+  brpop(
+    ...args: [...keys: RedisKey[], timeout: number | string]
+  ): Result<[string, string] | null, Context>;
+  brpopBuffer(
+    ...args: [...keys: RedisKey[], timeout: number | string]
+  ): Result<[Buffer, Buffer] | null, Context>;
+  brpop(
+    ...args: [keys: RedisKey[], timeout: number | string]
+  ): Result<[string, string] | null, Context>;
+  brpopBuffer(
+    ...args: [keys: RedisKey[], timeout: number | string]
+  ): Result<[Buffer, Buffer] | null, Context>;
 
   /**
    * Pop an element from a list, push it to another list and return it; or block until one is available
@@ -388,8 +1313,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.2.0
    */
-  brpoplpush(source: RedisKey, destination: RedisKey, timeout: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  brpoplpushBuffer(source: RedisKey, destination: RedisKey, timeout: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  brpoplpush(
+    source: RedisKey,
+    destination: RedisKey,
+    timeout: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  brpoplpushBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    timeout: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Remove and return members with scores in a sorted set or block until one is available
@@ -397,22 +1332,158 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(K) + O(N*log(M)) where K is the number of provided keys, N being the number of elements in the sorted set, and M being the number of elements popped.
    * - _since_: 7.0.0
    */
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN', callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN']): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN']): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX', callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX']): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX']): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
-  bzmpop(...args: [timeout: number | string, numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      min: "MIN",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      min: "MIN",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      min: "MIN"
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      min: "MIN"
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      min: "MIN",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      min: "MIN",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      min: "MIN",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      min: "MIN",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      max: "MAX",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      max: "MAX",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      max: "MAX"
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      max: "MAX"
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      max: "MAX",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      max: "MAX",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      max: "MAX",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<unknown, Context>;
+  bzmpop(
+    ...args: [
+      timeout: number | string,
+      numkeys: number | string,
+      keys: RedisKey[],
+      max: "MAX",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Remove and return the member with the highest score from one or more sorted sets, or block until one is available
@@ -420,14 +1491,46 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) with N being the number of elements in the sorted set.
    * - _since_: 5.0.0
    */
-  bzpopmax(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: string, member: string, score: string] | null>]): Result<[key: string, member: string, score: string] | null, Context>;
-  bzpopmaxBuffer(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
-  bzpopmax(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: string, member: string, score: string] | null>]): Result<[key: string, member: string, score: string] | null, Context>;
-  bzpopmaxBuffer(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
-  bzpopmax(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[key: string, member: string, score: string] | null, Context>;
-  bzpopmaxBuffer(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
-  bzpopmax(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[key: string, member: string, score: string] | null, Context>;
-  bzpopmaxBuffer(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmax(
+    ...args: [
+      ...keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[key: string, member: string, score: string] | null>
+    ]
+  ): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopmaxBuffer(
+    ...args: [
+      ...keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>
+    ]
+  ): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmax(
+    ...args: [
+      keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[key: string, member: string, score: string] | null>
+    ]
+  ): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopmaxBuffer(
+    ...args: [
+      keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>
+    ]
+  ): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmax(
+    ...args: [...keys: RedisKey[], timeout: number | string]
+  ): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopmaxBuffer(
+    ...args: [...keys: RedisKey[], timeout: number | string]
+  ): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmax(
+    ...args: [keys: RedisKey[], timeout: number | string]
+  ): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopmaxBuffer(
+    ...args: [keys: RedisKey[], timeout: number | string]
+  ): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
 
   /**
    * Remove and return the member with the lowest score from one or more sorted sets, or block until one is available
@@ -435,14 +1538,46 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) with N being the number of elements in the sorted set.
    * - _since_: 5.0.0
    */
-  bzpopmin(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: string, member: string, score: string] | null>]): Result<[key: string, member: string, score: string] | null, Context>;
-  bzpopminBuffer(...args: [...keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
-  bzpopmin(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: string, member: string, score: string] | null>]): Result<[key: string, member: string, score: string] | null, Context>;
-  bzpopminBuffer(...args: [keys: (RedisKey)[], timeout: number | string, callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
-  bzpopmin(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[key: string, member: string, score: string] | null, Context>;
-  bzpopminBuffer(...args: [...keys: (RedisKey)[], timeout: number | string]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
-  bzpopmin(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[key: string, member: string, score: string] | null, Context>;
-  bzpopminBuffer(...args: [keys: (RedisKey)[], timeout: number | string]): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmin(
+    ...args: [
+      ...keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[key: string, member: string, score: string] | null>
+    ]
+  ): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopminBuffer(
+    ...args: [
+      ...keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>
+    ]
+  ): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmin(
+    ...args: [
+      keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[key: string, member: string, score: string] | null>
+    ]
+  ): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopminBuffer(
+    ...args: [
+      keys: RedisKey[],
+      timeout: number | string,
+      callback: Callback<[key: Buffer, member: Buffer, score: Buffer] | null>
+    ]
+  ): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmin(
+    ...args: [...keys: RedisKey[], timeout: number | string]
+  ): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopminBuffer(
+    ...args: [...keys: RedisKey[], timeout: number | string]
+  ): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
+  bzpopmin(
+    ...args: [keys: RedisKey[], timeout: number | string]
+  ): Result<[key: string, member: string, score: string] | null, Context>;
+  bzpopminBuffer(
+    ...args: [keys: RedisKey[], timeout: number | string]
+  ): Result<[key: Buffer, member: Buffer, score: Buffer] | null, Context>;
 
   /**
    * Instruct the server about tracking or not keys in the next request
@@ -450,8 +1585,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.0.0
    */
-  client(subcommand: 'CACHING', yes: 'YES', callback?: Callback<"OK">): Result<"OK", Context>;
-  client(subcommand: 'CACHING', no: 'NO', callback?: Callback<"OK">): Result<"OK", Context>;
+  client(
+    subcommand: "CACHING",
+    yes: "YES",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  client(
+    subcommand: "CACHING",
+    no: "NO",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Get the current connection name
@@ -459,8 +1602,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.9
    */
-  client(subcommand: 'GETNAME', callback?: Callback<string | null>): Result<string | null, Context>;
-  clientBuffer(subcommand: 'GETNAME', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  client(
+    subcommand: "GETNAME",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  clientBuffer(
+    subcommand: "GETNAME",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Get tracking notifications redirection client ID if any
@@ -468,7 +1617,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.0.0
    */
-  client(subcommand: 'GETREDIR', callback?: Callback<number>): Result<number, Context>;
+  client(
+    subcommand: "GETREDIR",
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -476,7 +1628,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  client(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  client(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Returns the client ID for the current connection
@@ -484,7 +1639,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  client(subcommand: 'ID', callback?: Callback<number>): Result<number, Context>;
+  client(
+    subcommand: "ID",
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Returns information about the current client connection.
@@ -492,8 +1650,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  client(subcommand: 'INFO', callback?: Callback<string>): Result<string, Context>;
-  clientBuffer(subcommand: 'INFO', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  client(
+    subcommand: "INFO",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  clientBuffer(
+    subcommand: "INFO",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Kill the connection of a client
@@ -501,8 +1665,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of client connections
    * - _since_: 2.4.0
    */
-  client(...args: [subcommand: 'KILL', ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  client(...args: [subcommand: 'KILL', ...args: (RedisValue)[]]): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "KILL",
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  client(
+    ...args: [subcommand: "KILL", ...args: RedisValue[]]
+  ): Result<unknown, Context>;
 
   /**
    * Get the list of client connections
@@ -510,21 +1682,125 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of client connections
    * - _since_: 2.4.0
    */
-  client(subcommand: 'LIST', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', idToken: 'ID', ...clientIds: (number | string)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', idToken: 'ID', ...clientIds: (number | string)[]]): Result<unknown, Context>;
-  client(subcommand: 'LIST', type: 'TYPE', normal: 'NORMAL', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', type: 'TYPE', normal: 'NORMAL', idToken: 'ID', ...clientIds: (number | string)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', type: 'TYPE', normal: 'NORMAL', idToken: 'ID', ...clientIds: (number | string)[]]): Result<unknown, Context>;
-  client(subcommand: 'LIST', type: 'TYPE', master: 'MASTER', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', type: 'TYPE', master: 'MASTER', idToken: 'ID', ...clientIds: (number | string)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', type: 'TYPE', master: 'MASTER', idToken: 'ID', ...clientIds: (number | string)[]]): Result<unknown, Context>;
-  client(subcommand: 'LIST', type: 'TYPE', replica: 'REPLICA', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', type: 'TYPE', replica: 'REPLICA', idToken: 'ID', ...clientIds: (number | string)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', type: 'TYPE', replica: 'REPLICA', idToken: 'ID', ...clientIds: (number | string)[]]): Result<unknown, Context>;
-  client(subcommand: 'LIST', type: 'TYPE', pubsub: 'PUBSUB', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', type: 'TYPE', pubsub: 'PUBSUB', idToken: 'ID', ...clientIds: (number | string)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  client(...args: [subcommand: 'LIST', type: 'TYPE', pubsub: 'PUBSUB', idToken: 'ID', ...clientIds: (number | string)[]]): Result<unknown, Context>;
+  client(
+    subcommand: "LIST",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      idToken: "ID",
+      ...clientIds: (number | string)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      idToken: "ID",
+      ...clientIds: (number | string)[]
+    ]
+  ): Result<unknown, Context>;
+  client(
+    subcommand: "LIST",
+    type: "TYPE",
+    normal: "NORMAL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      type: "TYPE",
+      normal: "NORMAL",
+      idToken: "ID",
+      ...clientIds: (number | string)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      type: "TYPE",
+      normal: "NORMAL",
+      idToken: "ID",
+      ...clientIds: (number | string)[]
+    ]
+  ): Result<unknown, Context>;
+  client(
+    subcommand: "LIST",
+    type: "TYPE",
+    master: "MASTER",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      type: "TYPE",
+      master: "MASTER",
+      idToken: "ID",
+      ...clientIds: (number | string)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      type: "TYPE",
+      master: "MASTER",
+      idToken: "ID",
+      ...clientIds: (number | string)[]
+    ]
+  ): Result<unknown, Context>;
+  client(
+    subcommand: "LIST",
+    type: "TYPE",
+    replica: "REPLICA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      type: "TYPE",
+      replica: "REPLICA",
+      idToken: "ID",
+      ...clientIds: (number | string)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      type: "TYPE",
+      replica: "REPLICA",
+      idToken: "ID",
+      ...clientIds: (number | string)[]
+    ]
+  ): Result<unknown, Context>;
+  client(
+    subcommand: "LIST",
+    type: "TYPE",
+    pubsub: "PUBSUB",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      type: "TYPE",
+      pubsub: "PUBSUB",
+      idToken: "ID",
+      ...clientIds: (number | string)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "LIST",
+      type: "TYPE",
+      pubsub: "PUBSUB",
+      idToken: "ID",
+      ...clientIds: (number | string)[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Set client eviction mode for the current connection
@@ -532,8 +1808,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 7.0.0
    */
-  client(subcommand: 'NO-EVICT', on: 'ON', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(subcommand: 'NO-EVICT', off: 'OFF', callback?: Callback<unknown>): Result<unknown, Context>;
+  client(
+    subcommand: "NO-EVICT",
+    on: "ON",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    subcommand: "NO-EVICT",
+    off: "OFF",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Stop processing commands from clients for some time
@@ -541,9 +1825,23 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.9.50
    */
-  client(subcommand: 'PAUSE', timeout: number | string, callback?: Callback<"OK">): Result<"OK", Context>;
-  client(subcommand: 'PAUSE', timeout: number | string, write: 'WRITE', callback?: Callback<"OK">): Result<"OK", Context>;
-  client(subcommand: 'PAUSE', timeout: number | string, all: 'ALL', callback?: Callback<"OK">): Result<"OK", Context>;
+  client(
+    subcommand: "PAUSE",
+    timeout: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  client(
+    subcommand: "PAUSE",
+    timeout: number | string,
+    write: "WRITE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  client(
+    subcommand: "PAUSE",
+    timeout: number | string,
+    all: "ALL",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Instruct the server whether to reply to commands
@@ -551,9 +1849,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.2.0
    */
-  client(subcommand: 'REPLY', on: 'ON', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(subcommand: 'REPLY', off: 'OFF', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(subcommand: 'REPLY', skip: 'SKIP', callback?: Callback<unknown>): Result<unknown, Context>;
+  client(
+    subcommand: "REPLY",
+    on: "ON",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    subcommand: "REPLY",
+    off: "OFF",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    subcommand: "REPLY",
+    skip: "SKIP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Set the current connection name
@@ -561,7 +1871,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.9
    */
-  client(subcommand: 'SETNAME', connectionName: string | Buffer, callback?: Callback<"OK">): Result<"OK", Context>;
+  client(
+    subcommand: "SETNAME",
+    connectionName: string | Buffer,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Enable or disable server assisted client side caching support
@@ -569,8 +1883,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1). Some options may introduce additional complexity.
    * - _since_: 6.0.0
    */
-  client(...args: [subcommand: 'TRACKING', ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  client(...args: [subcommand: 'TRACKING', ...args: (RedisValue)[]]): Result<unknown, Context>;
+  client(
+    ...args: [
+      subcommand: "TRACKING",
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  client(
+    ...args: [subcommand: "TRACKING", ...args: RedisValue[]]
+  ): Result<unknown, Context>;
 
   /**
    * Return information about server assisted client side caching for the current connection
@@ -578,8 +1900,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  client(subcommand: 'TRACKINGINFO', callback?: Callback<string>): Result<string, Context>;
-  clientBuffer(subcommand: 'TRACKINGINFO', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  client(
+    subcommand: "TRACKINGINFO",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  clientBuffer(
+    subcommand: "TRACKINGINFO",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Unblock a client blocked in a blocking command from a different connection
@@ -587,9 +1915,23 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log N) where N is the number of client connections
    * - _since_: 5.0.0
    */
-  client(subcommand: 'UNBLOCK', clientId: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  client(subcommand: 'UNBLOCK', clientId: number | string, timeout: 'TIMEOUT', callback?: Callback<unknown>): Result<unknown, Context>;
-  client(subcommand: 'UNBLOCK', clientId: number | string, error: 'ERROR', callback?: Callback<unknown>): Result<unknown, Context>;
+  client(
+    subcommand: "UNBLOCK",
+    clientId: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    subcommand: "UNBLOCK",
+    clientId: number | string,
+    timeout: "TIMEOUT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  client(
+    subcommand: "UNBLOCK",
+    clientId: number | string,
+    error: "ERROR",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Resume processing of clients that were paused
@@ -597,7 +1939,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) Where N is the number of paused clients
    * - _since_: 6.2.0
    */
-  client(subcommand: 'UNPAUSE', callback?: Callback<"OK">): Result<"OK", Context>;
+  client(
+    subcommand: "UNPAUSE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Assign new hash slots to receiving node
@@ -605,10 +1950,76 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of hash slot arguments
    * - _since_: 3.0.0
    */
-  cluster(...args: [subcommand: 'ADDSLOTS', ...slots: (number | string)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'ADDSLOTS', slots: (number | string)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'ADDSLOTS', ...slots: (number | string)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'ADDSLOTS', slots: (number | string)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(
+    ...args: [
+      subcommand: "ADDSLOTS",
+      ...slots: (number | string)[],
+      callback: Callback<
+        [
+          startSlotRange: number,
+          endSlotRange: number,
+          ...nodes: [
+            host: string,
+            port: number,
+            nodeId: string,
+            info: unknown[]
+          ][]
+        ][]
+      >
+    ]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
+  cluster(
+    ...args: [
+      subcommand: "ADDSLOTS",
+      slots: (number | string)[],
+      callback: Callback<
+        [
+          startSlotRange: number,
+          endSlotRange: number,
+          ...nodes: [
+            host: string,
+            port: number,
+            nodeId: string,
+            info: unknown[]
+          ][]
+        ][]
+      >
+    ]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
+  cluster(
+    ...args: [subcommand: "ADDSLOTS", ...slots: (number | string)[]]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
+  cluster(
+    ...args: [subcommand: "ADDSLOTS", slots: (number | string)[]]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
 
   /**
    * Assign new hash slots to receiving node
@@ -616,8 +2027,44 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of the slots between the start slot and end slot arguments.
    * - _since_: 7.0.0
    */
-  cluster(...args: [subcommand: 'ADDSLOTSRANGE', ...startSlotEndSlots: (string | number)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'ADDSLOTSRANGE', ...startSlotEndSlots: (string | number)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(
+    ...args: [
+      subcommand: "ADDSLOTSRANGE",
+      ...startSlotEndSlots: (string | number)[],
+      callback: Callback<
+        [
+          startSlotRange: number,
+          endSlotRange: number,
+          ...nodes: [
+            host: string,
+            port: number,
+            nodeId: string,
+            info: unknown[]
+          ][]
+        ][]
+      >
+    ]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
+  cluster(
+    ...args: [
+      subcommand: "ADDSLOTSRANGE",
+      ...startSlotEndSlots: (string | number)[]
+    ]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
 
   /**
    * Advance the cluster config epoch
@@ -625,7 +2072,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'BUMPEPOCH', callback?: Callback<'BUMPED' | 'STILL'>): Result<'BUMPED' | 'STILL', Context>;
+  cluster(
+    subcommand: "BUMPEPOCH",
+    callback?: Callback<"BUMPED" | "STILL">
+  ): Result<"BUMPED" | "STILL", Context>;
 
   /**
    * Return the number of failure reports active for a given node
@@ -633,7 +2083,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of failure reports
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'COUNT-FAILURE-REPORTS', nodeId: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  cluster(
+    subcommand: "COUNT-FAILURE-REPORTS",
+    nodeId: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Return the number of local keys in the specified hash slot
@@ -641,7 +2095,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'COUNTKEYSINSLOT', slot: number | string, callback?: Callback<number>): Result<number, Context>;
+  cluster(
+    subcommand: "COUNTKEYSINSLOT",
+    slot: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Set hash slots as unbound in receiving node
@@ -649,10 +2107,76 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of hash slot arguments
    * - _since_: 3.0.0
    */
-  cluster(...args: [subcommand: 'DELSLOTS', ...slots: (number | string)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'DELSLOTS', slots: (number | string)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'DELSLOTS', ...slots: (number | string)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'DELSLOTS', slots: (number | string)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(
+    ...args: [
+      subcommand: "DELSLOTS",
+      ...slots: (number | string)[],
+      callback: Callback<
+        [
+          startSlotRange: number,
+          endSlotRange: number,
+          ...nodes: [
+            host: string,
+            port: number,
+            nodeId: string,
+            info: unknown[]
+          ][]
+        ][]
+      >
+    ]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
+  cluster(
+    ...args: [
+      subcommand: "DELSLOTS",
+      slots: (number | string)[],
+      callback: Callback<
+        [
+          startSlotRange: number,
+          endSlotRange: number,
+          ...nodes: [
+            host: string,
+            port: number,
+            nodeId: string,
+            info: unknown[]
+          ][]
+        ][]
+      >
+    ]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
+  cluster(
+    ...args: [subcommand: "DELSLOTS", ...slots: (number | string)[]]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
+  cluster(
+    ...args: [subcommand: "DELSLOTS", slots: (number | string)[]]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
 
   /**
    * Set hash slots as unbound in receiving node
@@ -660,8 +2184,44 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of the slots between the start slot and end slot arguments.
    * - _since_: 7.0.0
    */
-  cluster(...args: [subcommand: 'DELSLOTSRANGE', ...startSlotEndSlots: (string | number)[], callback: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
-  cluster(...args: [subcommand: 'DELSLOTSRANGE', ...startSlotEndSlots: (string | number)[]]): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(
+    ...args: [
+      subcommand: "DELSLOTSRANGE",
+      ...startSlotEndSlots: (string | number)[],
+      callback: Callback<
+        [
+          startSlotRange: number,
+          endSlotRange: number,
+          ...nodes: [
+            host: string,
+            port: number,
+            nodeId: string,
+            info: unknown[]
+          ][]
+        ][]
+      >
+    ]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
+  cluster(
+    ...args: [
+      subcommand: "DELSLOTSRANGE",
+      ...startSlotEndSlots: (string | number)[]
+    ]
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
 
   /**
    * Forces a replica to perform a manual failover of its master.
@@ -669,9 +2229,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'FAILOVER', callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'FAILOVER', force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'FAILOVER', takeover: 'TAKEOVER', callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(
+    subcommand: "FAILOVER",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  cluster(
+    subcommand: "FAILOVER",
+    force: "FORCE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  cluster(
+    subcommand: "FAILOVER",
+    takeover: "TAKEOVER",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Delete a node's own slots information
@@ -679,7 +2250,28 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'FLUSHSLOTS', callback?: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(
+    subcommand: "FLUSHSLOTS",
+    callback?: Callback<
+      [
+        startSlotRange: number,
+        endSlotRange: number,
+        ...nodes: [
+          host: string,
+          port: number,
+          nodeId: string,
+          info: unknown[]
+        ][]
+      ][]
+    >
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
 
   /**
    * Remove a node from the nodes table
@@ -687,7 +2279,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'FORGET', nodeId: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(
+    subcommand: "FORGET",
+    nodeId: string | Buffer | number,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Return local key names in the specified hash slot
@@ -695,7 +2291,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) where N is the number of requested keys
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'GETKEYSINSLOT', slot: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  cluster(
+    subcommand: "GETKEYSINSLOT",
+    slot: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -703,7 +2304,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  cluster(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  cluster(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Provides info about Redis Cluster node state
@@ -711,7 +2315,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'INFO', callback?: Callback<string>): Result<string, Context>;
+  cluster(
+    subcommand: "INFO",
+    callback?: Callback<string>
+  ): Result<string, Context>;
 
   /**
    * Returns the hash slot of the specified key
@@ -719,7 +2326,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of bytes in the key
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'KEYSLOT', key: string | Buffer, callback?: Callback<number>): Result<number, Context>;
+  cluster(
+    subcommand: "KEYSLOT",
+    key: string | Buffer,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Returns a list of all TCP links to and from peer nodes in cluster
@@ -727,7 +2338,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of Cluster nodes
    * - _since_: 7.0.0
    */
-  cluster(subcommand: 'LINKS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  cluster(
+    subcommand: "LINKS",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Force a node cluster to handshake with another node
@@ -735,7 +2349,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'MEET', ip: string | Buffer, port: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(
+    subcommand: "MEET",
+    ip: string | Buffer,
+    port: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Return the node id
@@ -743,7 +2362,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'MYID', callback?: Callback<string>): Result<string, Context>;
+  cluster(
+    subcommand: "MYID",
+    callback?: Callback<string>
+  ): Result<string, Context>;
 
   /**
    * Get Cluster config for the node
@@ -751,7 +2373,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of Cluster nodes
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'NODES', callback?: Callback<unknown>): Result<unknown, Context>;
+  cluster(
+    subcommand: "NODES",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * List replica nodes of the specified master node
@@ -759,7 +2384,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  cluster(subcommand: 'REPLICAS', nodeId: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
+  cluster(
+    subcommand: "REPLICAS",
+    nodeId: string | Buffer | number,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Reconfigure a node as a replica of the specified master node
@@ -767,7 +2396,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'REPLICATE', nodeId: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(
+    subcommand: "REPLICATE",
+    nodeId: string | Buffer | number,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Reset a Redis Cluster node
@@ -775,9 +2408,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of known nodes. The command may execute a FLUSHALL as a side effect.
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'RESET', callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'RESET', hard: 'HARD', callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'RESET', soft: 'SOFT', callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(
+    subcommand: "RESET",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  cluster(
+    subcommand: "RESET",
+    hard: "HARD",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  cluster(
+    subcommand: "RESET",
+    soft: "SOFT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Forces the node to save cluster state on disk
@@ -785,7 +2429,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'SAVECONFIG', callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(
+    subcommand: "SAVECONFIG",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Set the configuration epoch in a new node
@@ -793,7 +2440,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'SET-CONFIG-EPOCH', configEpoch: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(
+    subcommand: "SET-CONFIG-EPOCH",
+    configEpoch: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Bind a hash slot to a specific node
@@ -801,10 +2452,33 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'SETSLOT', slot: number | string, nodeIdToken: 'IMPORTING', nodeId: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'SETSLOT', slot: number | string, nodeIdToken: 'MIGRATING', nodeId: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'SETSLOT', slot: number | string, nodeIdToken: 'NODE', nodeId: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  cluster(subcommand: 'SETSLOT', slot: number | string, stable: 'STABLE', callback?: Callback<'OK'>): Result<'OK', Context>;
+  cluster(
+    subcommand: "SETSLOT",
+    slot: number | string,
+    nodeIdToken: "IMPORTING",
+    nodeId: string | Buffer | number,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  cluster(
+    subcommand: "SETSLOT",
+    slot: number | string,
+    nodeIdToken: "MIGRATING",
+    nodeId: string | Buffer | number,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  cluster(
+    subcommand: "SETSLOT",
+    slot: number | string,
+    nodeIdToken: "NODE",
+    nodeId: string | Buffer | number,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  cluster(
+    subcommand: "SETSLOT",
+    slot: number | string,
+    stable: "STABLE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * List replica nodes of the specified master node
@@ -812,7 +2486,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'SLAVES', nodeId: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
+  cluster(
+    subcommand: "SLAVES",
+    nodeId: string | Buffer | number,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get array of Cluster slot to node mappings
@@ -820,7 +2498,28 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of Cluster nodes
    * - _since_: 3.0.0
    */
-  cluster(subcommand: 'SLOTS', callback?: Callback<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][]>): Result<[startSlotRange: number, endSlotRange: number, ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]][], Context>;
+  cluster(
+    subcommand: "SLOTS",
+    callback?: Callback<
+      [
+        startSlotRange: number,
+        endSlotRange: number,
+        ...nodes: [
+          host: string,
+          port: number,
+          nodeId: string,
+          info: unknown[]
+        ][]
+      ][]
+    >
+  ): Result<
+    [
+      startSlotRange: number,
+      endSlotRange: number,
+      ...nodes: [host: string, port: number, nodeId: string, info: unknown[]][]
+    ][],
+    Context
+  >;
 
   /**
    * Get total number of Redis commands
@@ -828,7 +2527,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.8.13
    */
-  command(subcommand: 'COUNT', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  command(
+    subcommand: "COUNT",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Get array of specific Redis command documentation
@@ -836,9 +2538,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of commands to look up
    * - _since_: 7.0.0
    */
-  command(subcommand: 'DOCS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  command(...args: [subcommand: 'DOCS', ...commandNames: (string | Buffer)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  command(...args: [subcommand: 'DOCS', ...commandNames: (string | Buffer)[]]): Result<unknown[], Context>;
+  command(
+    subcommand: "DOCS",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  command(
+    ...args: [
+      subcommand: "DOCS",
+      ...commandNames: (string | Buffer)[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  command(
+    ...args: [subcommand: "DOCS", ...commandNames: (string | Buffer)[]]
+  ): Result<unknown[], Context>;
 
   /**
    * Extract keys given a full Redis command
@@ -846,7 +2559,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of arguments to the command
    * - _since_: 2.8.13
    */
-  command(subcommand: 'GETKEYS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  command(
+    subcommand: "GETKEYS",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Extract keys given a full Redis command
@@ -854,7 +2570,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of arguments to the command
    * - _since_: 7.0.0
    */
-  command(subcommand: 'GETKEYSANDFLAGS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  command(
+    subcommand: "GETKEYSANDFLAGS",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -862,7 +2581,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  command(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  command(
+    subcommand: "HELP",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Get array of specific Redis command details, or all when no argument is given.
@@ -870,9 +2592,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of commands to look up
    * - _since_: 2.8.13
    */
-  command(subcommand: 'INFO', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  command(...args: [subcommand: 'INFO', ...commandNames: (string | Buffer)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  command(...args: [subcommand: 'INFO', ...commandNames: (string | Buffer)[]]): Result<unknown[], Context>;
+  command(
+    subcommand: "INFO",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  command(
+    ...args: [
+      subcommand: "INFO",
+      ...commandNames: (string | Buffer)[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  command(
+    ...args: [subcommand: "INFO", ...commandNames: (string | Buffer)[]]
+  ): Result<unknown[], Context>;
 
   /**
    * Get an array of Redis command names
@@ -880,10 +2613,31 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of Redis commands
    * - _since_: 7.0.0
    */
-  command(subcommand: 'LIST', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  command(subcommand: 'LIST', filterby: 'FILTERBY', moduleNameToken: 'MODULE', moduleName: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  command(subcommand: 'LIST', filterby: 'FILTERBY', categoryToken: 'ACLCAT', category: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  command(subcommand: 'LIST', filterby: 'FILTERBY', patternToken: 'PATTERN', pattern: string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  command(
+    subcommand: "LIST",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  command(
+    subcommand: "LIST",
+    filterby: "FILTERBY",
+    moduleNameToken: "MODULE",
+    moduleName: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  command(
+    subcommand: "LIST",
+    filterby: "FILTERBY",
+    categoryToken: "ACLCAT",
+    category: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  command(
+    subcommand: "LIST",
+    filterby: "FILTERBY",
+    patternToken: "PATTERN",
+    pattern: string,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Get the values of configuration parameters
@@ -891,8 +2645,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) when N is the number of configuration parameters provided
    * - _since_: 2.0.0
    */
-  config(...args: [subcommand: 'GET', ...parameters: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  config(...args: [subcommand: 'GET', ...parameters: (string | Buffer)[]]): Result<unknown, Context>;
+  config(
+    ...args: [
+      subcommand: "GET",
+      ...parameters: (string | Buffer)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  config(
+    ...args: [subcommand: "GET", ...parameters: (string | Buffer)[]]
+  ): Result<unknown, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -900,7 +2662,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  config(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  config(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Reset the stats returned by INFO
@@ -908,7 +2673,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.0.0
    */
-  config(subcommand: 'RESETSTAT', callback?: Callback<unknown>): Result<unknown, Context>;
+  config(
+    subcommand: "RESETSTAT",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Rewrite the configuration file with the in memory configuration
@@ -916,7 +2684,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.8.0
    */
-  config(subcommand: 'REWRITE', callback?: Callback<unknown>): Result<unknown, Context>;
+  config(
+    subcommand: "REWRITE",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Set configuration parameters to the given values
@@ -924,8 +2695,19 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) when N is the number of configuration parameters provided
    * - _since_: 2.0.0
    */
-  config(...args: [subcommand: 'SET', ...parameterValues: (string | Buffer | number)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  config(...args: [subcommand: 'SET', ...parameterValues: (string | Buffer | number)[]]): Result<unknown, Context>;
+  config(
+    ...args: [
+      subcommand: "SET",
+      ...parameterValues: (string | Buffer | number)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  config(
+    ...args: [
+      subcommand: "SET",
+      ...parameterValues: (string | Buffer | number)[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Copy a key
@@ -933,10 +2715,32 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) worst case for collections, where N is the number of nested items. O(1) for string values.
    * - _since_: 6.2.0
    */
-  copy(source: RedisKey, destination: RedisKey, callback?: Callback<number>): Result<number, Context>;
-  copy(source: RedisKey, destination: RedisKey, replace: 'REPLACE', callback?: Callback<number>): Result<number, Context>;
-  copy(source: RedisKey, destination: RedisKey, destinationDbToken: 'DB', destinationDb: number | string, callback?: Callback<number>): Result<number, Context>;
-  copy(source: RedisKey, destination: RedisKey, destinationDbToken: 'DB', destinationDb: number | string, replace: 'REPLACE', callback?: Callback<number>): Result<number, Context>;
+  copy(
+    source: RedisKey,
+    destination: RedisKey,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  copy(
+    source: RedisKey,
+    destination: RedisKey,
+    replace: "REPLACE",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  copy(
+    source: RedisKey,
+    destination: RedisKey,
+    destinationDbToken: "DB",
+    destinationDb: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  copy(
+    source: RedisKey,
+    destination: RedisKey,
+    destinationDbToken: "DB",
+    destinationDb: number | string,
+    replace: "REPLACE",
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Return the number of keys in the selected database
@@ -952,9 +2756,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on subcommand.
    * - _since_: 1.0.0
    */
-  debug(subcommand: string, callback?: Callback<unknown>): Result<unknown, Context>;
-  debug(...args: [subcommand: string, ...args: (string | Buffer | number)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  debug(...args: [subcommand: string, ...args: (string | Buffer | number)[]]): Result<unknown, Context>;
+  debug(
+    subcommand: string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  debug(
+    ...args: [
+      subcommand: string,
+      ...args: (string | Buffer | number)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  debug(
+    ...args: [subcommand: string, ...args: (string | Buffer | number)[]]
+  ): Result<unknown, Context>;
 
   /**
    * Decrement the integer value of a key by one
@@ -970,7 +2785,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  decrby(key: RedisKey, decrement: number | string, callback?: Callback<number>): Result<number, Context>;
+  decrby(
+    key: RedisKey,
+    decrement: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Delete a key
@@ -978,10 +2797,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of keys that will be removed. When a key to remove holds a value other than a string, the individual complexity for this key is O(M) where M is the number of elements in the list, set, sorted set or hash. Removing a single key that holds a string value is O(1).
    * - _since_: 1.0.0
    */
-  del(...args: [...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  del(...args: [keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  del(...args: [...keys: (RedisKey)[]]): Result<number, Context>;
-  del(...args: [keys: (RedisKey)[]]): Result<number, Context>;
+  del(
+    ...args: [...keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  del(
+    ...args: [keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  del(...args: [...keys: RedisKey[]]): Result<number, Context>;
+  del(...args: [keys: RedisKey[]]): Result<number, Context>;
 
   /**
    * Discard all commands issued after MULTI
@@ -989,7 +2812,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N), when N is the number of queued commands
    * - _since_: 2.0.0
    */
-  discard(callback?: Callback<'OK'>): Result<'OK', Context>;
+  discard(callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Return a serialized version of the value stored at the specified key.
@@ -998,7 +2821,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 2.6.0
    */
   dump(key: RedisKey, callback?: Callback<string>): Result<string, Context>;
-  dumpBuffer(key: RedisKey, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  dumpBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Echo the given string
@@ -1006,8 +2832,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  echo(message: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  echoBuffer(message: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  echo(
+    message: string | Buffer,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  echoBuffer(
+    message: string | Buffer,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Execute a Lua script server side
@@ -1015,15 +2847,71 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on the script that is executed.
    * - _since_: 2.6.0
    */
-  eval(script: string | Buffer, numkeys: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  eval(...args: [script: string | Buffer, numkeys: number | string, ...args: (string | Buffer | number)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  eval(...args: [script: string | Buffer, numkeys: number | string, ...args: (string | Buffer | number)[]]): Result<unknown, Context>;
-  eval(...args: [script: string | Buffer, numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  eval(...args: [script: string | Buffer, numkeys: number | string, keys: (RedisKey)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  eval(...args: [script: string | Buffer, numkeys: number | string, ...keys: (RedisKey)[]]): Result<unknown, Context>;
-  eval(...args: [script: string | Buffer, numkeys: number | string, keys: (RedisKey)[]]): Result<unknown, Context>;
-  eval(...args: [script: string | Buffer, numkeys: number | string, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  eval(...args: [script: string | Buffer, numkeys: number | string, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  eval(
+    script: string | Buffer,
+    numkeys: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  eval(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      ...args: (string | Buffer | number)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  eval(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      ...args: (string | Buffer | number)[]
+    ]
+  ): Result<unknown, Context>;
+  eval(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  eval(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  eval(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      ...keys: RedisKey[]
+    ]
+  ): Result<unknown, Context>;
+  eval(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      keys: RedisKey[]
+    ]
+  ): Result<unknown, Context>;
+  eval(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  eval(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Execute a read-only Lua script server side
@@ -1031,8 +2919,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on the script that is executed.
    * - _since_: 7.0.0
    */
-  eval_ro(...args: [script: string | Buffer, numkeys: number | string, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  eval_ro(...args: [script: string | Buffer, numkeys: number | string, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  eval_ro(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  eval_ro(
+    ...args: [
+      script: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Execute a Lua script server side
@@ -1040,15 +2941,67 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on the script that is executed.
    * - _since_: 2.6.0
    */
-  evalsha(sha1: string | Buffer, numkeys: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  evalsha(...args: [sha1: string | Buffer, numkeys: number | string, ...args: (string | Buffer | number)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  evalsha(...args: [sha1: string | Buffer, numkeys: number | string, ...args: (string | Buffer | number)[]]): Result<unknown, Context>;
-  evalsha(...args: [sha1: string | Buffer, numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  evalsha(...args: [sha1: string | Buffer, numkeys: number | string, keys: (RedisKey)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  evalsha(...args: [sha1: string | Buffer, numkeys: number | string, ...keys: (RedisKey)[]]): Result<unknown, Context>;
-  evalsha(...args: [sha1: string | Buffer, numkeys: number | string, keys: (RedisKey)[]]): Result<unknown, Context>;
-  evalsha(...args: [sha1: string | Buffer, numkeys: number | string, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  evalsha(...args: [sha1: string | Buffer, numkeys: number | string, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  evalsha(
+    sha1: string | Buffer,
+    numkeys: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  evalsha(
+    ...args: [
+      sha1: string | Buffer,
+      numkeys: number | string,
+      ...args: (string | Buffer | number)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  evalsha(
+    ...args: [
+      sha1: string | Buffer,
+      numkeys: number | string,
+      ...args: (string | Buffer | number)[]
+    ]
+  ): Result<unknown, Context>;
+  evalsha(
+    ...args: [
+      sha1: string | Buffer,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  evalsha(
+    ...args: [
+      sha1: string | Buffer,
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  evalsha(
+    ...args: [
+      sha1: string | Buffer,
+      numkeys: number | string,
+      ...keys: RedisKey[]
+    ]
+  ): Result<unknown, Context>;
+  evalsha(
+    ...args: [sha1: string | Buffer, numkeys: number | string, keys: RedisKey[]]
+  ): Result<unknown, Context>;
+  evalsha(
+    ...args: [
+      sha1: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  evalsha(
+    ...args: [
+      sha1: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Execute a read-only Lua script server side
@@ -1056,8 +3009,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on the script that is executed.
    * - _since_: 7.0.0
    */
-  evalsha_ro(...args: [sha1: string | Buffer, numkeys: number | string, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  evalsha_ro(...args: [sha1: string | Buffer, numkeys: number | string, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  evalsha_ro(
+    ...args: [
+      sha1: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  evalsha_ro(
+    ...args: [
+      sha1: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Execute all commands issued after MULTI
@@ -1065,7 +3031,9 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on commands in the transaction
    * - _since_: 1.2.0
    */
-  exec(callback?: Callback<[error: Error | null, result: unknown][] | null>): Promise<[error: Error | null, result: unknown][] | null>;
+  exec(
+    callback?: Callback<[error: Error | null, result: unknown][] | null>
+  ): Promise<[error: Error | null, result: unknown][] | null>;
 
   /**
    * Determine if a key exists
@@ -1073,10 +3041,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of keys to check.
    * - _since_: 1.0.0
    */
-  exists(...args: [...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  exists(...args: [keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  exists(...args: [...keys: (RedisKey)[]]): Result<number, Context>;
-  exists(...args: [keys: (RedisKey)[]]): Result<number, Context>;
+  exists(
+    ...args: [...keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  exists(
+    ...args: [keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  exists(...args: [...keys: RedisKey[]]): Result<number, Context>;
+  exists(...args: [keys: RedisKey[]]): Result<number, Context>;
 
   /**
    * Set a key's time to live in seconds
@@ -1084,11 +3056,35 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  expire(key: RedisKey, seconds: number | string, callback?: Callback<number>): Result<number, Context>;
-  expire(key: RedisKey, seconds: number | string, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
-  expire(key: RedisKey, seconds: number | string, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
-  expire(key: RedisKey, seconds: number | string, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
-  expire(key: RedisKey, seconds: number | string, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
+  expire(
+    key: RedisKey,
+    seconds: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  expire(
+    key: RedisKey,
+    seconds: number | string,
+    nx: "NX",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  expire(
+    key: RedisKey,
+    seconds: number | string,
+    xx: "XX",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  expire(
+    key: RedisKey,
+    seconds: number | string,
+    gt: "GT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  expire(
+    key: RedisKey,
+    seconds: number | string,
+    lt: "LT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Set the expiration for a key as a UNIX timestamp
@@ -1096,11 +3092,35 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.2.0
    */
-  expireat(key: RedisKey, unixTimeSeconds: number | string, callback?: Callback<number>): Result<number, Context>;
-  expireat(key: RedisKey, unixTimeSeconds: number | string, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
-  expireat(key: RedisKey, unixTimeSeconds: number | string, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
-  expireat(key: RedisKey, unixTimeSeconds: number | string, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
-  expireat(key: RedisKey, unixTimeSeconds: number | string, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
+  expireat(
+    key: RedisKey,
+    unixTimeSeconds: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  expireat(
+    key: RedisKey,
+    unixTimeSeconds: number | string,
+    nx: "NX",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  expireat(
+    key: RedisKey,
+    unixTimeSeconds: number | string,
+    xx: "XX",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  expireat(
+    key: RedisKey,
+    unixTimeSeconds: number | string,
+    gt: "GT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  expireat(
+    key: RedisKey,
+    unixTimeSeconds: number | string,
+    lt: "LT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Get the expiration Unix timestamp for a key
@@ -1108,7 +3128,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 7.0.0
    */
-  expiretime(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
+  expiretime(
+    key: RedisKey,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Start a coordinated failover between this server and one of its replicas.
@@ -1116,18 +3139,83 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  failover(callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(abort: 'ABORT', millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, abort: 'ABORT', millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  failover(targetToken: 'TO', host: string | Buffer, port: number | string, force: 'FORCE', abort: 'ABORT', millisecondsToken: 'TIMEOUT', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  failover(callback?: Callback<"OK">): Result<"OK", Context>;
+  failover(
+    millisecondsToken: "TIMEOUT",
+    milliseconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  failover(abort: "ABORT", callback?: Callback<"OK">): Result<"OK", Context>;
+  failover(
+    abort: "ABORT",
+    millisecondsToken: "TIMEOUT",
+    milliseconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  failover(
+    targetToken: "TO",
+    host: string | Buffer,
+    port: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  failover(
+    targetToken: "TO",
+    host: string | Buffer,
+    port: number | string,
+    millisecondsToken: "TIMEOUT",
+    milliseconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  failover(
+    targetToken: "TO",
+    host: string | Buffer,
+    port: number | string,
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  failover(
+    targetToken: "TO",
+    host: string | Buffer,
+    port: number | string,
+    abort: "ABORT",
+    millisecondsToken: "TIMEOUT",
+    milliseconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  failover(
+    targetToken: "TO",
+    host: string | Buffer,
+    port: number | string,
+    force: "FORCE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  failover(
+    targetToken: "TO",
+    host: string | Buffer,
+    port: number | string,
+    force: "FORCE",
+    millisecondsToken: "TIMEOUT",
+    milliseconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  failover(
+    targetToken: "TO",
+    host: string | Buffer,
+    port: number | string,
+    force: "FORCE",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  failover(
+    targetToken: "TO",
+    host: string | Buffer,
+    port: number | string,
+    force: "FORCE",
+    abort: "ABORT",
+    millisecondsToken: "TIMEOUT",
+    milliseconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Invoke a function
@@ -1135,8 +3223,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on the function that is executed.
    * - _since_: 7.0.0
    */
-  fcall(...args: [function: string | Buffer, numkeys: number | string, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  fcall(...args: [function: string | Buffer, numkeys: number | string, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  fcall(
+    ...args: [
+      function: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  fcall(
+    ...args: [
+      function: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Invoke a read-only function
@@ -1144,8 +3245,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on the function that is executed.
    * - _since_: 7.0.0
    */
-  fcall_ro(...args: [function: string | Buffer, numkeys: number | string, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  fcall_ro(...args: [function: string | Buffer, numkeys: number | string, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  fcall_ro(
+    ...args: [
+      function: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  fcall_ro(
+    ...args: [
+      function: string | Buffer,
+      numkeys: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Remove all keys from all databases
@@ -1153,9 +3267,9 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of keys in all databases
    * - _since_: 1.0.0
    */
-  flushall(callback?: Callback<'OK'>): Result<'OK', Context>;
-  flushall(async: 'ASYNC', callback?: Callback<'OK'>): Result<'OK', Context>;
-  flushall(sync: 'SYNC', callback?: Callback<'OK'>): Result<'OK', Context>;
+  flushall(callback?: Callback<"OK">): Result<"OK", Context>;
+  flushall(async: "ASYNC", callback?: Callback<"OK">): Result<"OK", Context>;
+  flushall(sync: "SYNC", callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Remove all keys from the current database
@@ -1163,9 +3277,9 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of keys in the selected database
    * - _since_: 1.0.0
    */
-  flushdb(callback?: Callback<'OK'>): Result<'OK', Context>;
-  flushdb(async: 'ASYNC', callback?: Callback<'OK'>): Result<'OK', Context>;
-  flushdb(sync: 'SYNC', callback?: Callback<'OK'>): Result<'OK', Context>;
+  flushdb(callback?: Callback<"OK">): Result<"OK", Context>;
+  flushdb(async: "ASYNC", callback?: Callback<"OK">): Result<"OK", Context>;
+  flushdb(sync: "SYNC", callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Delete a function by name
@@ -1173,8 +3287,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 7.0.0
    */
-  function(subcommand: 'DELETE', libraryName: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'DELETE', libraryName: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  function(
+    subcommand: "DELETE",
+    libraryName: string | Buffer,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "DELETE",
+    libraryName: string | Buffer,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Dump all functions into a serialized binary payload
@@ -1182,8 +3304,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of functions
    * - _since_: 7.0.0
    */
-  function(subcommand: 'DUMP', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'DUMP', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  function(
+    subcommand: "DUMP",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "DUMP",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Deleting all functions
@@ -1191,12 +3319,34 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of functions deleted
    * - _since_: 7.0.0
    */
-  function(subcommand: 'FLUSH', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'FLUSH', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'FLUSH', async: 'ASYNC', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'FLUSH', async: 'ASYNC', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'FLUSH', sync: 'SYNC', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'FLUSH', sync: 'SYNC', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  function(
+    subcommand: "FLUSH",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "FLUSH",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  function(
+    subcommand: "FLUSH",
+    async: "ASYNC",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "FLUSH",
+    async: "ASYNC",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  function(
+    subcommand: "FLUSH",
+    sync: "SYNC",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "FLUSH",
+    sync: "SYNC",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -1204,7 +3354,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 7.0.0
    */
-  function(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  function(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Kill the function currently in execution.
@@ -1212,8 +3365,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 7.0.0
    */
-  function(subcommand: 'KILL', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'KILL', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  function(
+    subcommand: "KILL",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "KILL",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * List information about all the functions
@@ -1221,10 +3380,28 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of functions
    * - _since_: 7.0.0
    */
-  function(subcommand: 'LIST', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  function(subcommand: 'LIST', withcode: 'WITHCODE', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  function(subcommand: 'LIST', libraryNamePatternToken: 'LIBRARYNAME', libraryNamePattern: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  function(subcommand: 'LIST', libraryNamePatternToken: 'LIBRARYNAME', libraryNamePattern: string | Buffer, withcode: 'WITHCODE', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  function(
+    subcommand: "LIST",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  function(
+    subcommand: "LIST",
+    withcode: "WITHCODE",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  function(
+    subcommand: "LIST",
+    libraryNamePatternToken: "LIBRARYNAME",
+    libraryNamePattern: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  function(
+    subcommand: "LIST",
+    libraryNamePatternToken: "LIBRARYNAME",
+    libraryNamePattern: string | Buffer,
+    withcode: "WITHCODE",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Create a function with the given arguments (name, code, description)
@@ -1232,14 +3409,74 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) (considering compilation time is redundant)
    * - _since_: 7.0.0
    */
-  function(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, functionCode: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, functionCode: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, libraryDescriptionToken: 'DESCRIPTION', libraryDescription: string | Buffer, functionCode: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, libraryDescriptionToken: 'DESCRIPTION', libraryDescription: string | Buffer, functionCode: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, replace: 'REPLACE', functionCode: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, replace: 'REPLACE', functionCode: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, replace: 'REPLACE', libraryDescriptionToken: 'DESCRIPTION', libraryDescription: string | Buffer, functionCode: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'LOAD', engineName: string | Buffer, libraryName: string | Buffer, replace: 'REPLACE', libraryDescriptionToken: 'DESCRIPTION', libraryDescription: string | Buffer, functionCode: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  function(
+    subcommand: "LOAD",
+    engineName: string | Buffer,
+    libraryName: string | Buffer,
+    functionCode: string | Buffer,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "LOAD",
+    engineName: string | Buffer,
+    libraryName: string | Buffer,
+    functionCode: string | Buffer,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  function(
+    subcommand: "LOAD",
+    engineName: string | Buffer,
+    libraryName: string | Buffer,
+    libraryDescriptionToken: "DESCRIPTION",
+    libraryDescription: string | Buffer,
+    functionCode: string | Buffer,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "LOAD",
+    engineName: string | Buffer,
+    libraryName: string | Buffer,
+    libraryDescriptionToken: "DESCRIPTION",
+    libraryDescription: string | Buffer,
+    functionCode: string | Buffer,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  function(
+    subcommand: "LOAD",
+    engineName: string | Buffer,
+    libraryName: string | Buffer,
+    replace: "REPLACE",
+    functionCode: string | Buffer,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "LOAD",
+    engineName: string | Buffer,
+    libraryName: string | Buffer,
+    replace: "REPLACE",
+    functionCode: string | Buffer,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  function(
+    subcommand: "LOAD",
+    engineName: string | Buffer,
+    libraryName: string | Buffer,
+    replace: "REPLACE",
+    libraryDescriptionToken: "DESCRIPTION",
+    libraryDescription: string | Buffer,
+    functionCode: string | Buffer,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "LOAD",
+    engineName: string | Buffer,
+    libraryName: string | Buffer,
+    replace: "REPLACE",
+    libraryDescriptionToken: "DESCRIPTION",
+    libraryDescription: string | Buffer,
+    functionCode: string | Buffer,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Restore all the functions on the given payload
@@ -1247,14 +3484,52 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of functions on the payload
    * - _since_: 7.0.0
    */
-  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, flush: 'FLUSH', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, flush: 'FLUSH', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, append: 'APPEND', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, append: 'APPEND', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  function(subcommand: 'RESTORE', serializedValue: string | Buffer | number, replace: 'REPLACE', callback?: Callback<string>): Result<string, Context>;
-  functionBuffer(subcommand: 'RESTORE', serializedValue: string | Buffer | number, replace: 'REPLACE', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  function(
+    subcommand: "RESTORE",
+    serializedValue: string | Buffer | number,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "RESTORE",
+    serializedValue: string | Buffer | number,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  function(
+    subcommand: "RESTORE",
+    serializedValue: string | Buffer | number,
+    flush: "FLUSH",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "RESTORE",
+    serializedValue: string | Buffer | number,
+    flush: "FLUSH",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  function(
+    subcommand: "RESTORE",
+    serializedValue: string | Buffer | number,
+    append: "APPEND",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "RESTORE",
+    serializedValue: string | Buffer | number,
+    append: "APPEND",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  function(
+    subcommand: "RESTORE",
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  functionBuffer(
+    subcommand: "RESTORE",
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Return information about the function currently running (name, description, duration)
@@ -1262,7 +3537,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 7.0.0
    */
-  function(subcommand: 'STATS', callback?: Callback<unknown>): Result<unknown, Context>;
+  function(
+    subcommand: "STATS",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Add one or more geospatial items in the geospatial index represented using a sorted set
@@ -1270,18 +3548,98 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) for each item added, where N is the number of elements in the sorted set.
    * - _since_: 3.2.0
    */
-  geoadd(...args: [key: RedisKey, ...longitudeLatitudeMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, ...longitudeLatitudeMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, ch: 'CH', ...longitudeLatitudeMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, ch: 'CH', ...longitudeLatitudeMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, nx: 'NX', ...longitudeLatitudeMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, nx: 'NX', ...longitudeLatitudeMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, nx: 'NX', ch: 'CH', ...longitudeLatitudeMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, nx: 'NX', ch: 'CH', ...longitudeLatitudeMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, xx: 'XX', ...longitudeLatitudeMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, xx: 'XX', ...longitudeLatitudeMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, xx: 'XX', ch: 'CH', ...longitudeLatitudeMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  geoadd(...args: [key: RedisKey, xx: 'XX', ch: 'CH', ...longitudeLatitudeMembers: (string | Buffer | number)[]]): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      ...longitudeLatitudeMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      ...longitudeLatitudeMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      ch: "CH",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      ch: "CH",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ch: "CH",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ch: "CH",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ch: "CH",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  geoadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ch: "CH",
+      ...longitudeLatitudeMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
 
   /**
    * Returns the distance between two members of a geospatial index
@@ -1289,16 +3647,74 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N))
    * - _since_: 3.2.0
    */
-  geodist(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, callback?: Callback<string | null>): Result<string | null, Context>;
-  geodistBuffer(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  geodist(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, m: 'M', callback?: Callback<string | null>): Result<string | null, Context>;
-  geodistBuffer(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, m: 'M', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  geodist(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, km: 'KM', callback?: Callback<string | null>): Result<string | null, Context>;
-  geodistBuffer(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, km: 'KM', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  geodist(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, ft: 'FT', callback?: Callback<string | null>): Result<string | null, Context>;
-  geodistBuffer(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, ft: 'FT', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  geodist(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, mi: 'MI', callback?: Callback<string | null>): Result<string | null, Context>;
-  geodistBuffer(key: RedisKey, member1: string | Buffer | number, member2: string | Buffer | number, mi: 'MI', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  geodist(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  geodistBuffer(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  geodist(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    m: "M",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  geodistBuffer(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    m: "M",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  geodist(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    km: "KM",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  geodistBuffer(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    km: "KM",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  geodist(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    ft: "FT",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  geodistBuffer(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    ft: "FT",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  geodist(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    mi: "MI",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  geodistBuffer(
+    key: RedisKey,
+    member1: string | Buffer | number,
+    member2: string | Buffer | number,
+    mi: "MI",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Returns members of a geospatial index as standard geohash strings
@@ -1306,14 +3722,46 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) for each member requested, where N is the number of elements in the sorted set.
    * - _since_: 3.2.0
    */
-  geohash(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<string[]>]): Result<string[], Context>;
-  geohashBuffer(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  geohash(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<string[]>]): Result<string[], Context>;
-  geohashBuffer(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  geohash(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<string[], Context>;
-  geohashBuffer(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<Buffer[], Context>;
-  geohash(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<string[], Context>;
-  geohashBuffer(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<Buffer[], Context>;
+  geohash(
+    ...args: [
+      key: RedisKey,
+      ...members: (string | Buffer | number)[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  geohashBuffer(
+    ...args: [
+      key: RedisKey,
+      ...members: (string | Buffer | number)[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  geohash(
+    ...args: [
+      key: RedisKey,
+      members: (string | Buffer | number)[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  geohashBuffer(
+    ...args: [
+      key: RedisKey,
+      members: (string | Buffer | number)[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  geohash(
+    ...args: [key: RedisKey, ...members: (string | Buffer | number)[]]
+  ): Result<string[], Context>;
+  geohashBuffer(
+    ...args: [key: RedisKey, ...members: (string | Buffer | number)[]]
+  ): Result<Buffer[], Context>;
+  geohash(
+    ...args: [key: RedisKey, members: (string | Buffer | number)[]]
+  ): Result<string[], Context>;
+  geohashBuffer(
+    ...args: [key: RedisKey, members: (string | Buffer | number)[]]
+  ): Result<Buffer[], Context>;
 
   /**
    * Returns longitude and latitude of members of a geospatial index
@@ -1321,10 +3769,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of members requested.
    * - _since_: 3.2.0
    */
-  geopos(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<([longitude: string, latitude: string] | null)[]>]): Result<([longitude: string, latitude: string] | null)[], Context>;
-  geopos(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<([longitude: string, latitude: string] | null)[]>]): Result<([longitude: string, latitude: string] | null)[], Context>;
-  geopos(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<([longitude: string, latitude: string] | null)[], Context>;
-  geopos(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<([longitude: string, latitude: string] | null)[], Context>;
+  geopos(
+    ...args: [
+      key: RedisKey,
+      ...members: (string | Buffer | number)[],
+      callback: Callback<([longitude: string, latitude: string] | null)[]>
+    ]
+  ): Result<([longitude: string, latitude: string] | null)[], Context>;
+  geopos(
+    ...args: [
+      key: RedisKey,
+      members: (string | Buffer | number)[],
+      callback: Callback<([longitude: string, latitude: string] | null)[]>
+    ]
+  ): Result<([longitude: string, latitude: string] | null)[], Context>;
+  geopos(
+    ...args: [key: RedisKey, ...members: (string | Buffer | number)[]]
+  ): Result<([longitude: string, latitude: string] | null)[], Context>;
+  geopos(
+    ...args: [key: RedisKey, members: (string | Buffer | number)[]]
+  ): Result<([longitude: string, latitude: string] | null)[], Context>;
 
   /**
    * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a point
@@ -1332,8 +3796,25 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
    * - _since_: 3.2.0
    */
-  georadius(...args: [key: RedisKey, longitude: number | string, latitude: number | string, radius: number | string, ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  georadius(...args: [key: RedisKey, longitude: number | string, latitude: number | string, radius: number | string, ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  georadius(
+    ...args: [
+      key: RedisKey,
+      longitude: number | string,
+      latitude: number | string,
+      radius: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  georadius(
+    ...args: [
+      key: RedisKey,
+      longitude: number | string,
+      latitude: number | string,
+      radius: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown[], Context>;
 
   /**
    * A read-only variant for GEORADIUS
@@ -1341,8 +3822,25 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
    * - _since_: 3.2.10
    */
-  georadius_ro(...args: [key: RedisKey, longitude: number | string, latitude: number | string, radius: number | string, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  georadius_ro(...args: [key: RedisKey, longitude: number | string, latitude: number | string, radius: number | string, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  georadius_ro(
+    ...args: [
+      key: RedisKey,
+      longitude: number | string,
+      latitude: number | string,
+      radius: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  georadius_ro(
+    ...args: [
+      key: RedisKey,
+      longitude: number | string,
+      latitude: number | string,
+      radius: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Query a sorted set representing a geospatial index to fetch members matching a given maximum distance from a member
@@ -1350,8 +3848,23 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
    * - _since_: 3.2.0
    */
-  georadiusbymember(...args: [key: RedisKey, member: string | Buffer | number, radius: number | string, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  georadiusbymember(...args: [key: RedisKey, member: string | Buffer | number, radius: number | string, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  georadiusbymember(
+    ...args: [
+      key: RedisKey,
+      member: string | Buffer | number,
+      radius: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  georadiusbymember(
+    ...args: [
+      key: RedisKey,
+      member: string | Buffer | number,
+      radius: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * A read-only variant for GEORADIUSBYMEMBER
@@ -1359,8 +3872,23 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+log(M)) where N is the number of elements inside the bounding box of the circular area delimited by center and radius and M is the number of items inside the index.
    * - _since_: 3.2.10
    */
-  georadiusbymember_ro(...args: [key: RedisKey, member: string | Buffer | number, radius: number | string, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  georadiusbymember_ro(...args: [key: RedisKey, member: string | Buffer | number, radius: number | string, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  georadiusbymember_ro(
+    ...args: [
+      key: RedisKey,
+      member: string | Buffer | number,
+      radius: number | string,
+      ...args: RedisValue[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  georadiusbymember_ro(
+    ...args: [
+      key: RedisKey,
+      member: string | Buffer | number,
+      radius: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Query a sorted set representing a geospatial index to fetch members inside an area of a box or a circle.
@@ -1368,8 +3896,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape
    * - _since_: 6.2.0
    */
-  geosearch(...args: [key: RedisKey, ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  geosearch(...args: [key: RedisKey, ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  geosearch(
+    ...args: [
+      key: RedisKey,
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  geosearch(
+    ...args: [key: RedisKey, ...args: RedisValue[]]
+  ): Result<unknown[], Context>;
 
   /**
    * Query a sorted set representing a geospatial index to fetch members inside an area of a box or a circle, and store the result in another key.
@@ -1377,8 +3913,17 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+log(M)) where N is the number of elements in the grid-aligned bounding box area around the shape provided as the filter and M is the number of items inside the shape
    * - _since_: 6.2.0
    */
-  geosearchstore(...args: [destination: RedisKey, source: RedisKey, ...args: (RedisValue)[], callback: Callback<number>]): Result<number, Context>;
-  geosearchstore(...args: [destination: RedisKey, source: RedisKey, ...args: (RedisValue)[]]): Result<number, Context>;
+  geosearchstore(
+    ...args: [
+      destination: RedisKey,
+      source: RedisKey,
+      ...args: RedisValue[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  geosearchstore(
+    ...args: [destination: RedisKey, source: RedisKey, ...args: RedisValue[]]
+  ): Result<number, Context>;
 
   /**
    * Get the value of a key
@@ -1386,8 +3931,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  get(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
-  getBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  get(
+    key: RedisKey,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  getBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Returns the bit value at offset in the string value stored at key
@@ -1395,7 +3946,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.2.0
    */
-  getbit(key: RedisKey, offset: number | string, callback?: Callback<number>): Result<number, Context>;
+  getbit(
+    key: RedisKey,
+    offset: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Get the value of a key and delete the key
@@ -1403,8 +3958,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  getdel(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
-  getdelBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  getdel(
+    key: RedisKey,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  getdelBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Get the value of a key and optionally set its expiration
@@ -1412,18 +3973,72 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  getex(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  getex(key: RedisKey, secondsToken: 'EX', seconds: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, secondsToken: 'EX', seconds: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  getex(key: RedisKey, millisecondsToken: 'PX', milliseconds: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, millisecondsToken: 'PX', milliseconds: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  getex(key: RedisKey, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  getex(key: RedisKey, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  getex(key: RedisKey, persist: 'PERSIST', callback?: Callback<string | null>): Result<string | null, Context>;
-  getexBuffer(key: RedisKey, persist: 'PERSIST', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  getex(
+    key: RedisKey,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  getexBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  getex(
+    key: RedisKey,
+    secondsToken: "EX",
+    seconds: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  getexBuffer(
+    key: RedisKey,
+    secondsToken: "EX",
+    seconds: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  getex(
+    key: RedisKey,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  getexBuffer(
+    key: RedisKey,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  getex(
+    key: RedisKey,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  getexBuffer(
+    key: RedisKey,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  getex(
+    key: RedisKey,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  getexBuffer(
+    key: RedisKey,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  getex(
+    key: RedisKey,
+    persist: "PERSIST",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  getexBuffer(
+    key: RedisKey,
+    persist: "PERSIST",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Get a substring of the string stored at a key
@@ -1431,8 +4046,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.
    * - _since_: 2.4.0
    */
-  getrange(key: RedisKey, start: number | string, end: number | string, callback?: Callback<string>): Result<string, Context>;
-  getrangeBuffer(key: RedisKey, start: number | string, end: number | string, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  getrange(
+    key: RedisKey,
+    start: number | string,
+    end: number | string,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  getrangeBuffer(
+    key: RedisKey,
+    start: number | string,
+    end: number | string,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Set the string value of a key and return its old value
@@ -1440,8 +4065,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  getset(key: RedisKey, value: string | Buffer | number, callback?: Callback<string | null>): Result<string | null, Context>;
-  getsetBuffer(key: RedisKey, value: string | Buffer | number, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  getset(
+    key: RedisKey,
+    value: string | Buffer | number,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  getsetBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Delete one or more hash fields
@@ -1449,8 +4082,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of fields to be removed.
    * - _since_: 2.0.0
    */
-  hdel(...args: [key: RedisKey, ...fields: (string | Buffer)[], callback: Callback<number>]): Result<number, Context>;
-  hdel(...args: [key: RedisKey, ...fields: (string | Buffer)[]]): Result<number, Context>;
+  hdel(
+    ...args: [
+      key: RedisKey,
+      ...fields: (string | Buffer)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  hdel(
+    ...args: [key: RedisKey, ...fields: (string | Buffer)[]]
+  ): Result<number, Context>;
 
   /**
    * Handshake with Redis
@@ -1459,10 +4100,32 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 6.0.0
    */
   hello(callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  hello(protover: number | string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  hello(protover: number | string, clientnameToken: 'SETNAME', clientname: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  hello(protover: number | string, usernamePasswordToken: 'AUTH', username: string | Buffer, password: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  hello(protover: number | string, usernamePasswordToken: 'AUTH', username: string | Buffer, password: string | Buffer, clientnameToken: 'SETNAME', clientname: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  hello(
+    protover: number | string,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  hello(
+    protover: number | string,
+    clientnameToken: "SETNAME",
+    clientname: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  hello(
+    protover: number | string,
+    usernamePasswordToken: "AUTH",
+    username: string | Buffer,
+    password: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  hello(
+    protover: number | string,
+    usernamePasswordToken: "AUTH",
+    username: string | Buffer,
+    password: string | Buffer,
+    clientnameToken: "SETNAME",
+    clientname: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Determine if a hash field exists
@@ -1470,7 +4133,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.0.0
    */
-  hexists(key: RedisKey, field: string | Buffer, callback?: Callback<number>): Result<number, Context>;
+  hexists(
+    key: RedisKey,
+    field: string | Buffer,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Get the value of a hash field
@@ -1478,8 +4145,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.0.0
    */
-  hget(key: RedisKey, field: string | Buffer, callback?: Callback<string | null>): Result<string | null, Context>;
-  hgetBuffer(key: RedisKey, field: string | Buffer, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  hget(
+    key: RedisKey,
+    field: string | Buffer,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  hgetBuffer(
+    key: RedisKey,
+    field: string | Buffer,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Get all the fields and values in a hash
@@ -1487,8 +4162,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the size of the hash.
    * - _since_: 2.0.0
    */
-  hgetall(key: RedisKey, callback?: Callback<Record<string, string>>): Result<Record<string, string>, Context>
-  hgetallBuffer(key: RedisKey, callback?: Callback<[field: Buffer, value: Buffer][]>): Result<[field: Buffer, value: Buffer][], Context>
+  hgetall(
+    key: RedisKey,
+    callback?: Callback<Record<string, string>>
+  ): Result<Record<string, string>, Context>;
+  hgetallBuffer(
+    key: RedisKey,
+    callback?: Callback<[field: Buffer, value: Buffer][]>
+  ): Result<[field: Buffer, value: Buffer][], Context>;
 
   /**
    * Increment the integer value of a hash field by the given number
@@ -1496,7 +4177,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.0.0
    */
-  hincrby(key: RedisKey, field: string | Buffer, increment: number | string, callback?: Callback<number>): Result<number, Context>;
+  hincrby(
+    key: RedisKey,
+    field: string | Buffer,
+    increment: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Increment the float value of a hash field by the given amount
@@ -1504,8 +4190,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.0
    */
-  hincrbyfloat(key: RedisKey, field: string | Buffer, increment: number | string, callback?: Callback<string>): Result<string, Context>;
-  hincrbyfloatBuffer(key: RedisKey, field: string | Buffer, increment: number | string, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  hincrbyfloat(
+    key: RedisKey,
+    field: string | Buffer,
+    increment: number | string,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  hincrbyfloatBuffer(
+    key: RedisKey,
+    field: string | Buffer,
+    increment: number | string,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Get all the fields in a hash
@@ -1513,8 +4209,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the size of the hash.
    * - _since_: 2.0.0
    */
-  hkeys(key: RedisKey, callback?: Callback<string[]>): Result<string[], Context>;
-  hkeysBuffer(key: RedisKey, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  hkeys(
+    key: RedisKey,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  hkeysBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Get the number of fields in a hash
@@ -1530,10 +4232,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of fields being requested.
    * - _since_: 2.0.0
    */
-  hmget(...args: [key: RedisKey, ...fields: (string | Buffer)[], callback: Callback<(string | null)[]>]): Result<(string | null)[], Context>;
-  hmgetBuffer(...args: [key: RedisKey, ...fields: (string | Buffer)[], callback: Callback<(Buffer | null)[]>]): Result<(Buffer | null)[], Context>;
-  hmget(...args: [key: RedisKey, ...fields: (string | Buffer)[]]): Result<(string | null)[], Context>;
-  hmgetBuffer(...args: [key: RedisKey, ...fields: (string | Buffer)[]]): Result<(Buffer | null)[], Context>;
+  hmget(
+    ...args: [
+      key: RedisKey,
+      ...fields: (string | Buffer)[],
+      callback: Callback<(string | null)[]>
+    ]
+  ): Result<(string | null)[], Context>;
+  hmgetBuffer(
+    ...args: [
+      key: RedisKey,
+      ...fields: (string | Buffer)[],
+      callback: Callback<(Buffer | null)[]>
+    ]
+  ): Result<(Buffer | null)[], Context>;
+  hmget(
+    ...args: [key: RedisKey, ...fields: (string | Buffer)[]]
+  ): Result<(string | null)[], Context>;
+  hmgetBuffer(
+    ...args: [key: RedisKey, ...fields: (string | Buffer)[]]
+  ): Result<(Buffer | null)[], Context>;
 
   /**
    * Set multiple hash fields to multiple values
@@ -1541,10 +4259,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of fields being set.
    * - _since_: 2.0.0
    */
-  hmset(key: RedisKey, object: Record<string, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>
-  hmset(key: RedisKey, map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>
-  hmset(...args: [key: RedisKey, ...fieldValues: (string | Buffer | number)[], callback: Callback<'OK'>]): Result<'OK', Context>;
-  hmset(...args: [key: RedisKey, ...fieldValues: (string | Buffer | number)[]]): Result<'OK', Context>;
+  hmset(
+    key: RedisKey,
+    object: Record<string, string | Buffer | number>,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  hmset(
+    key: RedisKey,
+    map: Map<string | Buffer | number, string | Buffer | number>,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  hmset(
+    ...args: [
+      key: RedisKey,
+      ...fieldValues: (string | Buffer | number)[],
+      callback: Callback<"OK">
+    ]
+  ): Result<"OK", Context>;
+  hmset(
+    ...args: [key: RedisKey, ...fieldValues: (string | Buffer | number)[]]
+  ): Result<"OK", Context>;
 
   /**
    * Get one or multiple random fields from a hash
@@ -1552,12 +4286,36 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of fields returned
    * - _since_: 6.2.0
    */
-  hrandfield(key: RedisKey, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
-  hrandfieldBuffer(key: RedisKey, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
-  hrandfield(key: RedisKey, count: number | string, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
-  hrandfieldBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
-  hrandfield(key: RedisKey, count: number | string, withvalues: 'WITHVALUES', callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
-  hrandfieldBuffer(key: RedisKey, count: number | string, withvalues: 'WITHVALUES', callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
+  hrandfield(
+    key: RedisKey,
+    callback?: Callback<string | unknown[] | null>
+  ): Result<string | unknown[] | null, Context>;
+  hrandfieldBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer | unknown[] | null>
+  ): Result<Buffer | unknown[] | null, Context>;
+  hrandfield(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<string | unknown[] | null>
+  ): Result<string | unknown[] | null, Context>;
+  hrandfieldBuffer(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<Buffer | unknown[] | null>
+  ): Result<Buffer | unknown[] | null, Context>;
+  hrandfield(
+    key: RedisKey,
+    count: number | string,
+    withvalues: "WITHVALUES",
+    callback?: Callback<string | unknown[] | null>
+  ): Result<string | unknown[] | null, Context>;
+  hrandfieldBuffer(
+    key: RedisKey,
+    count: number | string,
+    withvalues: "WITHVALUES",
+    callback?: Callback<Buffer | unknown[] | null>
+  ): Result<Buffer | unknown[] | null, Context>;
 
   /**
    * Incrementally iterate hash fields and associated values
@@ -1565,14 +4323,62 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection..
    * - _since_: 2.8.0
    */
-  hscan(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  hscanBuffer(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  hscan(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  hscanBuffer(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  hscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  hscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  hscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  hscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  hscan(
+    key: RedisKey,
+    cursor: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  hscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  hscan(
+    key: RedisKey,
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  hscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  hscan(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  hscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  hscan(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  hscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
 
   /**
    * Set the string value of a hash field
@@ -1580,10 +4386,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.
    * - _since_: 2.0.0
    */
-  hset(key: RedisKey, object: Record<string, string | Buffer | number>, callback?: Callback<number>): Result<number, Context>
-  hset(key: RedisKey, map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<number>): Result<number, Context>
-  hset(...args: [key: RedisKey, ...fieldValues: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  hset(...args: [key: RedisKey, ...fieldValues: (string | Buffer | number)[]]): Result<number, Context>;
+  hset(
+    key: RedisKey,
+    object: Record<string, string | Buffer | number>,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  hset(
+    key: RedisKey,
+    map: Map<string | Buffer | number, string | Buffer | number>,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  hset(
+    ...args: [
+      key: RedisKey,
+      ...fieldValues: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  hset(
+    ...args: [key: RedisKey, ...fieldValues: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Set the value of a hash field, only if the field does not exist
@@ -1591,7 +4413,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.0.0
    */
-  hsetnx(key: RedisKey, field: string | Buffer, value: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  hsetnx(
+    key: RedisKey,
+    field: string | Buffer,
+    value: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Get the length of the value of a hash field
@@ -1599,7 +4426,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.2.0
    */
-  hstrlen(key: RedisKey, field: string | Buffer, callback?: Callback<number>): Result<number, Context>;
+  hstrlen(
+    key: RedisKey,
+    field: string | Buffer,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Get all the values in a hash
@@ -1607,8 +4438,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the size of the hash.
    * - _since_: 2.0.0
    */
-  hvals(key: RedisKey, callback?: Callback<string[]>): Result<string[], Context>;
-  hvalsBuffer(key: RedisKey, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  hvals(
+    key: RedisKey,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  hvalsBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Increment the integer value of a key by one
@@ -1624,7 +4461,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  incrby(key: RedisKey, increment: number | string, callback?: Callback<number>): Result<number, Context>;
+  incrby(
+    key: RedisKey,
+    increment: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Increment the float value of a key by the given amount
@@ -1632,7 +4473,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.0
    */
-  incrbyfloat(key: RedisKey, increment: number | string, callback?: Callback<string>): Result<string, Context>;
+  incrbyfloat(
+    key: RedisKey,
+    increment: number | string,
+    callback?: Callback<string>
+  ): Result<string, Context>;
 
   /**
    * Get information and statistics about the server
@@ -1641,7 +4486,9 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 1.0.0
    */
   info(callback?: Callback<string>): Result<string, Context>;
-  info(...args: [...sections: (string | Buffer)[], callback: Callback<string>]): Result<string, Context>;
+  info(
+    ...args: [...sections: (string | Buffer)[], callback: Callback<string>]
+  ): Result<string, Context>;
   info(...args: [...sections: (string | Buffer)[]]): Result<string, Context>;
 
   /**
@@ -1650,8 +4497,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) with N being the number of keys in the database, under the assumption that the key names in the database and the given pattern have limited length.
    * - _since_: 1.0.0
    */
-  keys(pattern: string, callback?: Callback<string[]>): Result<string[], Context>;
-  keysBuffer(pattern: string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  keys(
+    pattern: string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  keysBuffer(
+    pattern: string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Get the UNIX time stamp of the last successful save to disk
@@ -1667,7 +4520,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.8.13
    */
-  latency(subcommand: 'DOCTOR', callback?: Callback<string>): Result<string, Context>;
+  latency(
+    subcommand: "DOCTOR",
+    callback?: Callback<string>
+  ): Result<string, Context>;
 
   /**
    * Return a latency graph for the event.
@@ -1675,7 +4531,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.8.13
    */
-  latency(subcommand: 'GRAPH', event: string | Buffer, callback?: Callback<string>): Result<string, Context>;
+  latency(
+    subcommand: "GRAPH",
+    event: string | Buffer,
+    callback?: Callback<string>
+  ): Result<string, Context>;
 
   /**
    * Show helpful text about the different subcommands.
@@ -1683,7 +4543,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.8.13
    */
-  latency(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  latency(
+    subcommand: "HELP",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Return the cumulative distribution of latencies of a subset of commands or all.
@@ -1691,9 +4554,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of commands with latency information being retrieved.
    * - _since_: 7.0.0
    */
-  latency(subcommand: 'HISTOGRAM', callback?: Callback<unknown>): Result<unknown, Context>;
-  latency(...args: [subcommand: 'HISTOGRAM', ...commands: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  latency(...args: [subcommand: 'HISTOGRAM', ...commands: (string | Buffer)[]]): Result<unknown, Context>;
+  latency(
+    subcommand: "HISTOGRAM",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  latency(
+    ...args: [
+      subcommand: "HISTOGRAM",
+      ...commands: (string | Buffer)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  latency(
+    ...args: [subcommand: "HISTOGRAM", ...commands: (string | Buffer)[]]
+  ): Result<unknown, Context>;
 
   /**
    * Return timestamp-latency samples for the event.
@@ -1701,7 +4575,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.8.13
    */
-  latency(subcommand: 'HISTORY', event: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  latency(
+    subcommand: "HISTORY",
+    event: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Return the latest latency samples for all events.
@@ -1709,7 +4587,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.8.13
    */
-  latency(subcommand: 'LATEST', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  latency(
+    subcommand: "LATEST",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Reset latency data for one or more events.
@@ -1717,9 +4598,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.8.13
    */
-  latency(subcommand: 'RESET', callback?: Callback<number>): Result<number, Context>;
-  latency(...args: [subcommand: 'RESET', ...events: (string | Buffer)[], callback: Callback<number>]): Result<number, Context>;
-  latency(...args: [subcommand: 'RESET', ...events: (string | Buffer)[]]): Result<number, Context>;
+  latency(
+    subcommand: "RESET",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  latency(
+    ...args: [
+      subcommand: "RESET",
+      ...events: (string | Buffer)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  latency(
+    ...args: [subcommand: "RESET", ...events: (string | Buffer)[]]
+  ): Result<number, Context>;
 
   /**
    * Find longest common substring
@@ -1727,22 +4619,126 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N*M) where N and M are the lengths of s1 and s2, respectively
    * - _since_: 7.0.0
    */
-  lcs(key1: RedisKey, key2: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, withmatchlen: 'WITHMATCHLEN', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, lenToken: 'MINMATCHLEN', len: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, lenToken: 'MINMATCHLEN', len: number | string, withmatchlen: 'WITHMATCHLEN', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, idx: 'IDX', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, idx: 'IDX', withmatchlen: 'WITHMATCHLEN', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, idx: 'IDX', lenToken: 'MINMATCHLEN', len: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, idx: 'IDX', lenToken: 'MINMATCHLEN', len: number | string, withmatchlen: 'WITHMATCHLEN', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, len: 'LEN', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, len: 'LEN', withmatchlen: 'WITHMATCHLEN', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, len: 'LEN', lenToken: 'MINMATCHLEN', len1: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, len: 'LEN', lenToken: 'MINMATCHLEN', len1: number | string, withmatchlen: 'WITHMATCHLEN', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, len: 'LEN', idx: 'IDX', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, len: 'LEN', idx: 'IDX', withmatchlen: 'WITHMATCHLEN', callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, len: 'LEN', idx: 'IDX', lenToken: 'MINMATCHLEN', len1: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  lcs(key1: RedisKey, key2: RedisKey, len: 'LEN', idx: 'IDX', lenToken: 'MINMATCHLEN', len1: number | string, withmatchlen: 'WITHMATCHLEN', callback?: Callback<unknown>): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    withmatchlen: "WITHMATCHLEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    lenToken: "MINMATCHLEN",
+    len: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    lenToken: "MINMATCHLEN",
+    len: number | string,
+    withmatchlen: "WITHMATCHLEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    idx: "IDX",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    idx: "IDX",
+    withmatchlen: "WITHMATCHLEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    idx: "IDX",
+    lenToken: "MINMATCHLEN",
+    len: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    idx: "IDX",
+    lenToken: "MINMATCHLEN",
+    len: number | string,
+    withmatchlen: "WITHMATCHLEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    len: "LEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    len: "LEN",
+    withmatchlen: "WITHMATCHLEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    len: "LEN",
+    lenToken: "MINMATCHLEN",
+    len1: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    len: "LEN",
+    lenToken: "MINMATCHLEN",
+    len1: number | string,
+    withmatchlen: "WITHMATCHLEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    len: "LEN",
+    idx: "IDX",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    len: "LEN",
+    idx: "IDX",
+    withmatchlen: "WITHMATCHLEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    len: "LEN",
+    idx: "IDX",
+    lenToken: "MINMATCHLEN",
+    len1: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  lcs(
+    key1: RedisKey,
+    key2: RedisKey,
+    len: "LEN",
+    idx: "IDX",
+    lenToken: "MINMATCHLEN",
+    len1: number | string,
+    withmatchlen: "WITHMATCHLEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get an element from a list by its index
@@ -1750,8 +4746,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements to traverse to get to the element at index. This makes asking for the first or the last element of the list O(1).
    * - _since_: 1.0.0
    */
-  lindex(key: RedisKey, index: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
-  lindexBuffer(key: RedisKey, index: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  lindex(
+    key: RedisKey,
+    index: number | string,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  lindexBuffer(
+    key: RedisKey,
+    index: number | string,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Insert an element before or after another element in a list
@@ -1759,8 +4763,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements to traverse before seeing the value pivot. This means that inserting somewhere on the left end on the list (head) can be considered O(1) and inserting somewhere on the right end (tail) is O(N).
    * - _since_: 2.2.0
    */
-  linsert(key: RedisKey, before: 'BEFORE', pivot: string | Buffer | number, element: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  linsert(key: RedisKey, after: 'AFTER', pivot: string | Buffer | number, element: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  linsert(
+    key: RedisKey,
+    before: "BEFORE",
+    pivot: string | Buffer | number,
+    element: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  linsert(
+    key: RedisKey,
+    after: "AFTER",
+    pivot: string | Buffer | number,
+    element: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Get the length of a list
@@ -1776,14 +4792,62 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  lmove(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', callback?: Callback<string>): Result<string, Context>;
-  lmoveBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  lmove(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', callback?: Callback<string>): Result<string, Context>;
-  lmoveBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  lmove(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', callback?: Callback<string>): Result<string, Context>;
-  lmoveBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', callback?: Callback<Buffer>): Result<Buffer, Context>;
-  lmove(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', callback?: Callback<string>): Result<string, Context>;
-  lmoveBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  lmove(
+    source: RedisKey,
+    destination: RedisKey,
+    left: "LEFT",
+    left1: "LEFT",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  lmoveBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    left: "LEFT",
+    left1: "LEFT",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  lmove(
+    source: RedisKey,
+    destination: RedisKey,
+    left: "LEFT",
+    right: "RIGHT",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  lmoveBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    left: "LEFT",
+    right: "RIGHT",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  lmove(
+    source: RedisKey,
+    destination: RedisKey,
+    right: "RIGHT",
+    left: "LEFT",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  lmoveBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    right: "RIGHT",
+    left: "LEFT",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
+  lmove(
+    source: RedisKey,
+    destination: RedisKey,
+    right: "RIGHT",
+    right1: "RIGHT",
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  lmoveBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    right: "RIGHT",
+    right1: "RIGHT",
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Pop elements from a list
@@ -1791,38 +4855,246 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+M) where N is the number of provided keys and M is the number of elements returned.
    * - _since_: 7.0.0
    */
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], left: 'LEFT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT']): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: string, members: string[]] | null>]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string, callback: Callback<[key: Buffer, members: Buffer[]] | null>]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
-  lmpop(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: string, members: string[]] | null, Context>;
-  lmpopBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], right: 'RIGHT', countToken: 'COUNT', count: number | string]): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [numkeys: number | string, ...keys: RedisKey[], left: "LEFT"]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [numkeys: number | string, ...keys: RedisKey[], left: "LEFT"]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [numkeys: number | string, keys: RedisKey[], left: "LEFT"]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [numkeys: number | string, keys: RedisKey[], left: "LEFT"]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      left: "LEFT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [numkeys: number | string, ...keys: RedisKey[], right: "RIGHT"]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [numkeys: number | string, ...keys: RedisKey[], right: "RIGHT"]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [numkeys: number | string, keys: RedisKey[], right: "RIGHT"]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [numkeys: number | string, keys: RedisKey[], right: "RIGHT"]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: string, members: string[]] | null>
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<[key: Buffer, members: Buffer[]] | null>
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
+  lmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: string, members: string[]] | null, Context>;
+  lmpopBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      right: "RIGHT",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<[key: Buffer, members: Buffer[]] | null, Context>;
 
   /**
    * Display some computer art and the Redis version
@@ -1831,7 +5103,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 5.0.0
    */
   lolwut(callback?: Callback<string>): Result<string, Context>;
-  lolwut(versionToken: 'VERSION', version: number | string, callback?: Callback<string>): Result<string, Context>;
+  lolwut(
+    versionToken: "VERSION",
+    version: number | string,
+    callback?: Callback<string>
+  ): Result<string, Context>;
 
   /**
    * Remove and get the first elements in a list
@@ -1839,10 +5115,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements returned
    * - _since_: 1.0.0
    */
-  lpop(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
-  lpopBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  lpop(key: RedisKey, count: number | string, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
-  lpopBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lpop(
+    key: RedisKey,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  lpopBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  lpop(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<string[] | null>
+  ): Result<string[] | null, Context>;
+  lpopBuffer(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<Buffer[] | null>
+  ): Result<Buffer[] | null, Context>;
 
   /**
    * Return the index of matching elements on a list
@@ -1850,14 +5140,70 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements in the list, for the average case. When searching for elements near the head or the tail of the list, or when the MAXLEN option is provided, the command may run in constant time.
    * - _since_: 6.0.6
    */
-  lpos(key: RedisKey, element: string | Buffer | number, callback?: Callback<number | null>): Result<number | null, Context>;
-  lpos(key: RedisKey, element: string | Buffer | number, lenToken: 'MAXLEN', len: number | string, callback?: Callback<number | null>): Result<number | null, Context>;
-  lpos(key: RedisKey, element: string | Buffer | number, numMatchesToken: 'COUNT', numMatches: number | string, callback?: Callback<number[]>): Result<number[], Context>;
-  lpos(key: RedisKey, element: string | Buffer | number, numMatchesToken: 'COUNT', numMatches: number | string, lenToken: 'MAXLEN', len: number | string, callback?: Callback<number[]>): Result<number[], Context>;
-  lpos(key: RedisKey, element: string | Buffer | number, rankToken: 'RANK', rank: number | string, callback?: Callback<number | null>): Result<number | null, Context>;
-  lpos(key: RedisKey, element: string | Buffer | number, rankToken: 'RANK', rank: number | string, lenToken: 'MAXLEN', len: number | string, callback?: Callback<number | null>): Result<number | null, Context>;
-  lpos(key: RedisKey, element: string | Buffer | number, rankToken: 'RANK', rank: number | string, numMatchesToken: 'COUNT', numMatches: number | string, callback?: Callback<number[]>): Result<number[], Context>;
-  lpos(key: RedisKey, element: string | Buffer | number, rankToken: 'RANK', rank: number | string, numMatchesToken: 'COUNT', numMatches: number | string, lenToken: 'MAXLEN', len: number | string, callback?: Callback<number[]>): Result<number[], Context>;
+  lpos(
+    key: RedisKey,
+    element: string | Buffer | number,
+    callback?: Callback<number | null>
+  ): Result<number | null, Context>;
+  lpos(
+    key: RedisKey,
+    element: string | Buffer | number,
+    lenToken: "MAXLEN",
+    len: number | string,
+    callback?: Callback<number | null>
+  ): Result<number | null, Context>;
+  lpos(
+    key: RedisKey,
+    element: string | Buffer | number,
+    numMatchesToken: "COUNT",
+    numMatches: number | string,
+    callback?: Callback<number[]>
+  ): Result<number[], Context>;
+  lpos(
+    key: RedisKey,
+    element: string | Buffer | number,
+    numMatchesToken: "COUNT",
+    numMatches: number | string,
+    lenToken: "MAXLEN",
+    len: number | string,
+    callback?: Callback<number[]>
+  ): Result<number[], Context>;
+  lpos(
+    key: RedisKey,
+    element: string | Buffer | number,
+    rankToken: "RANK",
+    rank: number | string,
+    callback?: Callback<number | null>
+  ): Result<number | null, Context>;
+  lpos(
+    key: RedisKey,
+    element: string | Buffer | number,
+    rankToken: "RANK",
+    rank: number | string,
+    lenToken: "MAXLEN",
+    len: number | string,
+    callback?: Callback<number | null>
+  ): Result<number | null, Context>;
+  lpos(
+    key: RedisKey,
+    element: string | Buffer | number,
+    rankToken: "RANK",
+    rank: number | string,
+    numMatchesToken: "COUNT",
+    numMatches: number | string,
+    callback?: Callback<number[]>
+  ): Result<number[], Context>;
+  lpos(
+    key: RedisKey,
+    element: string | Buffer | number,
+    rankToken: "RANK",
+    rank: number | string,
+    numMatchesToken: "COUNT",
+    numMatches: number | string,
+    lenToken: "MAXLEN",
+    len: number | string,
+    callback?: Callback<number[]>
+  ): Result<number[], Context>;
 
   /**
    * Prepend one or multiple elements to a list
@@ -1865,8 +5211,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
    * - _since_: 1.0.0
    */
-  lpush(...args: [key: RedisKey, ...elements: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  lpush(...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]): Result<number, Context>;
+  lpush(
+    ...args: [
+      key: RedisKey,
+      ...elements: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  lpush(
+    ...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Prepend an element to a list, only if the list exists
@@ -1874,8 +5228,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
    * - _since_: 2.2.0
    */
-  lpushx(...args: [key: RedisKey, ...elements: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  lpushx(...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]): Result<number, Context>;
+  lpushx(
+    ...args: [
+      key: RedisKey,
+      ...elements: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  lpushx(
+    ...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Get a range of elements from a list
@@ -1883,8 +5245,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(S+N) where S is the distance of start offset from HEAD for small lists, from nearest end (HEAD or TAIL) for large lists; and N is the number of elements in the specified range.
    * - _since_: 1.0.0
    */
-  lrange(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  lrangeBuffer(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  lrange(
+    key: RedisKey,
+    start: number | string,
+    stop: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  lrangeBuffer(
+    key: RedisKey,
+    start: number | string,
+    stop: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Remove elements from a list
@@ -1892,7 +5264,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+M) where N is the length of the list and M is the number of elements removed.
    * - _since_: 1.0.0
    */
-  lrem(key: RedisKey, count: number | string, element: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  lrem(
+    key: RedisKey,
+    count: number | string,
+    element: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Set the value of an element in a list by its index
@@ -1900,7 +5277,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the length of the list. Setting either the first or the last element of the list is O(1).
    * - _since_: 1.0.0
    */
-  lset(key: RedisKey, index: number | string, element: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  lset(
+    key: RedisKey,
+    index: number | string,
+    element: string | Buffer | number,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Trim a list to the specified range
@@ -1908,7 +5290,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements to be removed by the operation.
    * - _since_: 1.0.0
    */
-  ltrim(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  ltrim(
+    key: RedisKey,
+    start: number | string,
+    stop: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Outputs memory problems report
@@ -1916,7 +5303,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 4.0.0
    */
-  memory(subcommand: 'DOCTOR', callback?: Callback<string>): Result<string, Context>;
+  memory(
+    subcommand: "DOCTOR",
+    callback?: Callback<string>
+  ): Result<string, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -1924,7 +5314,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 4.0.0
    */
-  memory(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  memory(
+    subcommand: "HELP",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Show allocator internal stats
@@ -1932,7 +5325,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on how much memory is allocated, could be slow
    * - _since_: 4.0.0
    */
-  memory(subcommand: 'MALLOC-STATS', callback?: Callback<string>): Result<string, Context>;
+  memory(
+    subcommand: "MALLOC-STATS",
+    callback?: Callback<string>
+  ): Result<string, Context>;
 
   /**
    * Ask the allocator to release memory
@@ -1940,7 +5336,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Depends on how much memory is allocated, could be slow
    * - _since_: 4.0.0
    */
-  memory(subcommand: 'PURGE', callback?: Callback<"OK">): Result<"OK", Context>;
+  memory(subcommand: "PURGE", callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Show memory usage details
@@ -1948,7 +5344,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 4.0.0
    */
-  memory(subcommand: 'STATS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  memory(
+    subcommand: "STATS",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Estimate the memory usage of a key
@@ -1956,8 +5355,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of samples.
    * - _since_: 4.0.0
    */
-  memory(subcommand: 'USAGE', key: RedisKey, callback?: Callback<number | null>): Result<number | null, Context>;
-  memory(subcommand: 'USAGE', key: RedisKey, countToken: 'SAMPLES', count: number | string, callback?: Callback<number | null>): Result<number | null, Context>;
+  memory(
+    subcommand: "USAGE",
+    key: RedisKey,
+    callback?: Callback<number | null>
+  ): Result<number | null, Context>;
+  memory(
+    subcommand: "USAGE",
+    key: RedisKey,
+    countToken: "SAMPLES",
+    count: number | string,
+    callback?: Callback<number | null>
+  ): Result<number | null, Context>;
 
   /**
    * Get the values of all the given keys
@@ -1965,14 +5374,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of keys to retrieve.
    * - _since_: 1.0.0
    */
-  mget(...args: [...keys: (RedisKey)[], callback: Callback<(string | null)[]>]): Result<(string | null)[], Context>;
-  mgetBuffer(...args: [...keys: (RedisKey)[], callback: Callback<(Buffer | null)[]>]): Result<(Buffer | null)[], Context>;
-  mget(...args: [keys: (RedisKey)[], callback: Callback<(string | null)[]>]): Result<(string | null)[], Context>;
-  mgetBuffer(...args: [keys: (RedisKey)[], callback: Callback<(Buffer | null)[]>]): Result<(Buffer | null)[], Context>;
-  mget(...args: [...keys: (RedisKey)[]]): Result<(string | null)[], Context>;
-  mgetBuffer(...args: [...keys: (RedisKey)[]]): Result<(Buffer | null)[], Context>;
-  mget(...args: [keys: (RedisKey)[]]): Result<(string | null)[], Context>;
-  mgetBuffer(...args: [keys: (RedisKey)[]]): Result<(Buffer | null)[], Context>;
+  mget(
+    ...args: [...keys: RedisKey[], callback: Callback<(string | null)[]>]
+  ): Result<(string | null)[], Context>;
+  mgetBuffer(
+    ...args: [...keys: RedisKey[], callback: Callback<(Buffer | null)[]>]
+  ): Result<(Buffer | null)[], Context>;
+  mget(
+    ...args: [keys: RedisKey[], callback: Callback<(string | null)[]>]
+  ): Result<(string | null)[], Context>;
+  mgetBuffer(
+    ...args: [keys: RedisKey[], callback: Callback<(Buffer | null)[]>]
+  ): Result<(Buffer | null)[], Context>;
+  mget(...args: [...keys: RedisKey[]]): Result<(string | null)[], Context>;
+  mgetBuffer(
+    ...args: [...keys: RedisKey[]]
+  ): Result<(Buffer | null)[], Context>;
+  mget(...args: [keys: RedisKey[]]): Result<(string | null)[], Context>;
+  mgetBuffer(...args: [keys: RedisKey[]]): Result<(Buffer | null)[], Context>;
 
   /**
    * Atomically transfer a key from a Redis instance to another one.
@@ -1980,8 +5399,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: This command actually executes a DUMP+DEL in the source instance, and a RESTORE in the target instance. See the pages of these commands for time complexity. Also an O(N) data transfer between the two instances is performed.
    * - _since_: 2.6.0
    */
-  migrate(...args: [host: string | Buffer, port: string | Buffer, ...args: (RedisValue)[], callback: Callback<'OK'>]): Result<'OK', Context>;
-  migrate(...args: [host: string | Buffer, port: string | Buffer, ...args: (RedisValue)[]]): Result<'OK', Context>;
+  migrate(
+    ...args: [
+      host: string | Buffer,
+      port: string | Buffer,
+      ...args: RedisValue[],
+      callback: Callback<"OK">
+    ]
+  ): Result<"OK", Context>;
+  migrate(
+    ...args: [
+      host: string | Buffer,
+      port: string | Buffer,
+      ...args: RedisValue[]
+    ]
+  ): Result<"OK", Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -1989,7 +5421,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  module(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  module(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * List all modules loaded by the server
@@ -1997,7 +5432,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of loaded modules.
    * - _since_: 4.0.0
    */
-  module(subcommand: 'LIST', callback?: Callback<unknown>): Result<unknown, Context>;
+  module(
+    subcommand: "LIST",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Load a module
@@ -2005,9 +5443,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 4.0.0
    */
-  module(subcommand: 'LOAD', path: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
-  module(...args: [subcommand: 'LOAD', path: string | Buffer, ...args: (string | Buffer | number)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  module(...args: [subcommand: 'LOAD', path: string | Buffer, ...args: (string | Buffer | number)[]]): Result<unknown, Context>;
+  module(
+    subcommand: "LOAD",
+    path: string | Buffer,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  module(
+    ...args: [
+      subcommand: "LOAD",
+      path: string | Buffer,
+      ...args: (string | Buffer | number)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  module(
+    ...args: [
+      subcommand: "LOAD",
+      path: string | Buffer,
+      ...args: (string | Buffer | number)[]
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Unload a module
@@ -2015,7 +5470,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 4.0.0
    */
-  module(subcommand: 'UNLOAD', name: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  module(
+    subcommand: "UNLOAD",
+    name: string | Buffer,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Move a key to another database
@@ -2023,7 +5482,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  move(key: RedisKey, db: number | string, callback?: Callback<number>): Result<number, Context>;
+  move(
+    key: RedisKey,
+    db: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Set multiple keys to multiple values
@@ -2031,10 +5494,23 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of keys to set.
    * - _since_: 1.0.1
    */
-  mset(object: Record<string, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>
-  mset(map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>
-  mset(...args: [...keyValues: (RedisKey | string | Buffer | number)[], callback: Callback<'OK'>]): Result<'OK', Context>;
-  mset(...args: [...keyValues: (RedisKey | string | Buffer | number)[]]): Result<'OK', Context>;
+  mset(
+    object: Record<string, string | Buffer | number>,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  mset(
+    map: Map<string | Buffer | number, string | Buffer | number>,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  mset(
+    ...args: [
+      ...keyValues: (RedisKey | string | Buffer | number)[],
+      callback: Callback<"OK">
+    ]
+  ): Result<"OK", Context>;
+  mset(
+    ...args: [...keyValues: (RedisKey | string | Buffer | number)[]]
+  ): Result<"OK", Context>;
 
   /**
    * Set multiple keys to multiple values, only if none of the keys exist
@@ -2042,10 +5518,23 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of keys to set.
    * - _since_: 1.0.1
    */
-  msetnx(object: Record<string, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>
-  msetnx(map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>
-  msetnx(...args: [...keyValues: (RedisKey | string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  msetnx(...args: [...keyValues: (RedisKey | string | Buffer | number)[]]): Result<number, Context>;
+  msetnx(
+    object: Record<string, string | Buffer | number>,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  msetnx(
+    map: Map<string | Buffer | number, string | Buffer | number>,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  msetnx(
+    ...args: [
+      ...keyValues: (RedisKey | string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  msetnx(
+    ...args: [...keyValues: (RedisKey | string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Inspect the internal encoding of a Redis object
@@ -2053,7 +5542,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.2.3
    */
-  object(subcommand: 'ENCODING', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
+  object(
+    subcommand: "ENCODING",
+    key: RedisKey,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get the logarithmic access frequency counter of a Redis object
@@ -2061,7 +5554,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 4.0.0
    */
-  object(subcommand: 'FREQ', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
+  object(
+    subcommand: "FREQ",
+    key: RedisKey,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -2069,7 +5566,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  object(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  object(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get the time since a Redis object was last accessed
@@ -2077,7 +5577,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.2.3
    */
-  object(subcommand: 'IDLETIME', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
+  object(
+    subcommand: "IDLETIME",
+    key: RedisKey,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get the number of references to the value of the key
@@ -2085,7 +5589,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.2.3
    */
-  object(subcommand: 'REFCOUNT', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
+  object(
+    subcommand: "REFCOUNT",
+    key: RedisKey,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Remove the expiration from a key
@@ -2101,11 +5609,35 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.0
    */
-  pexpire(key: RedisKey, milliseconds: number | string, callback?: Callback<number>): Result<number, Context>;
-  pexpire(key: RedisKey, milliseconds: number | string, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
-  pexpire(key: RedisKey, milliseconds: number | string, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
-  pexpire(key: RedisKey, milliseconds: number | string, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
-  pexpire(key: RedisKey, milliseconds: number | string, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
+  pexpire(
+    key: RedisKey,
+    milliseconds: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  pexpire(
+    key: RedisKey,
+    milliseconds: number | string,
+    nx: "NX",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  pexpire(
+    key: RedisKey,
+    milliseconds: number | string,
+    xx: "XX",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  pexpire(
+    key: RedisKey,
+    milliseconds: number | string,
+    gt: "GT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  pexpire(
+    key: RedisKey,
+    milliseconds: number | string,
+    lt: "LT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Set the expiration for a key as a UNIX timestamp specified in milliseconds
@@ -2113,11 +5645,35 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.0
    */
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, callback?: Callback<number>): Result<number, Context>;
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, nx: 'NX', callback?: Callback<number>): Result<number, Context>;
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, xx: 'XX', callback?: Callback<number>): Result<number, Context>;
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, gt: 'GT', callback?: Callback<number>): Result<number, Context>;
-  pexpireat(key: RedisKey, unixTimeMilliseconds: number | string, lt: 'LT', callback?: Callback<number>): Result<number, Context>;
+  pexpireat(
+    key: RedisKey,
+    unixTimeMilliseconds: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  pexpireat(
+    key: RedisKey,
+    unixTimeMilliseconds: number | string,
+    nx: "NX",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  pexpireat(
+    key: RedisKey,
+    unixTimeMilliseconds: number | string,
+    xx: "XX",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  pexpireat(
+    key: RedisKey,
+    unixTimeMilliseconds: number | string,
+    gt: "GT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  pexpireat(
+    key: RedisKey,
+    unixTimeMilliseconds: number | string,
+    lt: "LT",
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Get the expiration Unix timestamp for a key in milliseconds
@@ -2125,7 +5681,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 7.0.0
    */
-  pexpiretime(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
+  pexpiretime(
+    key: RedisKey,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Adds the specified elements to the specified HyperLogLog.
@@ -2134,8 +5693,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 2.8.9
    */
   pfadd(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
-  pfadd(...args: [key: RedisKey, ...elements: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  pfadd(...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]): Result<number, Context>;
+  pfadd(
+    ...args: [
+      key: RedisKey,
+      ...elements: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  pfadd(
+    ...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Return the approximated cardinality of the set(s) observed by the HyperLogLog at key(s).
@@ -2143,10 +5710,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) with a very small average constant time when called with a single key. O(N) with N being the number of keys, and much bigger constant times, when called with multiple keys.
    * - _since_: 2.8.9
    */
-  pfcount(...args: [...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  pfcount(...args: [keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  pfcount(...args: [...keys: (RedisKey)[]]): Result<number, Context>;
-  pfcount(...args: [keys: (RedisKey)[]]): Result<number, Context>;
+  pfcount(
+    ...args: [...keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  pfcount(
+    ...args: [keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  pfcount(...args: [...keys: RedisKey[]]): Result<number, Context>;
+  pfcount(...args: [keys: RedisKey[]]): Result<number, Context>;
 
   /**
    * Internal commands for debugging HyperLogLog values
@@ -2162,10 +5733,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) to merge N HyperLogLogs, but with high constant times.
    * - _since_: 2.8.9
    */
-  pfmerge(...args: [destkey: RedisKey, ...sourcekeys: (RedisKey)[], callback: Callback<'OK'>]): Result<'OK', Context>;
-  pfmerge(...args: [destkey: RedisKey, sourcekeys: (RedisKey)[], callback: Callback<'OK'>]): Result<'OK', Context>;
-  pfmerge(...args: [destkey: RedisKey, ...sourcekeys: (RedisKey)[]]): Result<'OK', Context>;
-  pfmerge(...args: [destkey: RedisKey, sourcekeys: (RedisKey)[]]): Result<'OK', Context>;
+  pfmerge(
+    ...args: [
+      destkey: RedisKey,
+      ...sourcekeys: RedisKey[],
+      callback: Callback<"OK">
+    ]
+  ): Result<"OK", Context>;
+  pfmerge(
+    ...args: [
+      destkey: RedisKey,
+      sourcekeys: RedisKey[],
+      callback: Callback<"OK">
+    ]
+  ): Result<"OK", Context>;
+  pfmerge(
+    ...args: [destkey: RedisKey, ...sourcekeys: RedisKey[]]
+  ): Result<"OK", Context>;
+  pfmerge(
+    ...args: [destkey: RedisKey, sourcekeys: RedisKey[]]
+  ): Result<"OK", Context>;
 
   /**
    * An internal command for testing HyperLogLog values
@@ -2181,9 +5768,15 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  ping(callback?: Callback<'PONG'>): Result<'PONG', Context>;
-  ping(message: string | Buffer, callback?: Callback<string>): Result<string, Context>;
-  pingBuffer(message: string | Buffer, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  ping(callback?: Callback<"PONG">): Result<"PONG", Context>;
+  ping(
+    message: string | Buffer,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  pingBuffer(
+    message: string | Buffer,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Set the value and expiration in milliseconds of a key
@@ -2191,7 +5784,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.0
    */
-  psetex(key: RedisKey, milliseconds: number | string, value: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
+  psetex(
+    key: RedisKey,
+    milliseconds: number | string,
+    value: string | Buffer | number,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Listen for messages published to channels matching the given patterns
@@ -2199,8 +5797,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of patterns the client is already subscribed to.
    * - _since_: 2.0.0
    */
-  psubscribe(...args: [...patterns: (string)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  psubscribe(...args: [...patterns: (string)[]]): Result<unknown, Context>;
+  psubscribe(
+    ...args: [...patterns: string[], callback: Callback<unknown>]
+  ): Result<unknown, Context>;
+  psubscribe(...args: [...patterns: string[]]): Result<unknown, Context>;
 
   /**
    * Internal command used for replication
@@ -2208,7 +5808,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: undefined
    * - _since_: 2.8.0
    */
-  psync(replicationid: number | string, offset: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
+  psync(
+    replicationid: number | string,
+    offset: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get the time to live for a key in milliseconds
@@ -2224,7 +5828,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+M) where N is the number of clients subscribed to the receiving channel and M is the total number of subscribed patterns (by any client).
    * - _since_: 2.0.0
    */
-  publish(channel: string | Buffer, message: string | Buffer, callback?: Callback<number>): Result<number, Context>;
+  publish(
+    channel: string | Buffer,
+    message: string | Buffer,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * List active channels
@@ -2232,8 +5840,15 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of active channels, and assuming constant time pattern matching (relatively short channels and patterns)
    * - _since_: 2.8.0
    */
-  pubsub(subcommand: 'CHANNELS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  pubsub(subcommand: 'CHANNELS', pattern: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  pubsub(
+    subcommand: "CHANNELS",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  pubsub(
+    subcommand: "CHANNELS",
+    pattern: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -2241,7 +5856,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  pubsub(subcommand: 'HELP', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  pubsub(
+    subcommand: "HELP",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Get the count of unique patterns pattern subscriptions
@@ -2249,7 +5867,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.8.0
    */
-  pubsub(subcommand: 'NUMPAT', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  pubsub(
+    subcommand: "NUMPAT",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Get the count of subscribers for channels
@@ -2257,9 +5878,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) for the NUMSUB subcommand, where N is the number of requested channels
    * - _since_: 2.8.0
    */
-  pubsub(subcommand: 'NUMSUB', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  pubsub(...args: [subcommand: 'NUMSUB', ...channels: (string | Buffer)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  pubsub(...args: [subcommand: 'NUMSUB', ...channels: (string | Buffer)[]]): Result<unknown[], Context>;
+  pubsub(
+    subcommand: "NUMSUB",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  pubsub(
+    ...args: [
+      subcommand: "NUMSUB",
+      ...channels: (string | Buffer)[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  pubsub(
+    ...args: [subcommand: "NUMSUB", ...channels: (string | Buffer)[]]
+  ): Result<unknown[], Context>;
 
   /**
    * List active shard channels
@@ -2267,8 +5899,15 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of active shard channels, and assuming constant time pattern matching (relatively short channels).
    * - _since_: 7.0.0
    */
-  pubsub(subcommand: 'SHARDCHANNELS', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  pubsub(subcommand: 'SHARDCHANNELS', pattern: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  pubsub(
+    subcommand: "SHARDCHANNELS",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  pubsub(
+    subcommand: "SHARDCHANNELS",
+    pattern: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Get the count of subscribers for shard channels
@@ -2276,9 +5915,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) for the SHARDNUMSUB subcommand, where N is the number of requested channels
    * - _since_: 7.0.0
    */
-  pubsub(subcommand: 'SHARDNUMSUB', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  pubsub(...args: [subcommand: 'SHARDNUMSUB', ...channels: (string | Buffer)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  pubsub(...args: [subcommand: 'SHARDNUMSUB', ...channels: (string | Buffer)[]]): Result<unknown[], Context>;
+  pubsub(
+    subcommand: "SHARDNUMSUB",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  pubsub(
+    ...args: [
+      subcommand: "SHARDNUMSUB",
+      ...channels: (string | Buffer)[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  pubsub(
+    ...args: [subcommand: "SHARDNUMSUB", ...channels: (string | Buffer)[]]
+  ): Result<unknown[], Context>;
 
   /**
    * Stop listening for messages posted to channels matching the given patterns
@@ -2287,8 +5937,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 2.0.0
    */
   punsubscribe(callback?: Callback<unknown>): Result<unknown, Context>;
-  punsubscribe(...args: [...patterns: (string)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  punsubscribe(...args: [...patterns: (string)[]]): Result<unknown, Context>;
+  punsubscribe(
+    ...args: [...patterns: string[], callback: Callback<unknown>]
+  ): Result<unknown, Context>;
+  punsubscribe(...args: [...patterns: string[]]): Result<unknown, Context>;
 
   /**
    * Close the connection
@@ -2296,7 +5948,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  quit(callback?: Callback<'OK'>): Result<'OK', Context>;
+  quit(callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Return a random key from the keyspace
@@ -2305,7 +5957,9 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 1.0.0
    */
   randomkey(callback?: Callback<string | null>): Result<string | null, Context>;
-  randomkeyBuffer(callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  randomkeyBuffer(
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Enables read queries for a connection to a cluster replica node
@@ -2313,7 +5967,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  readonly(callback?: Callback<'OK'>): Result<'OK', Context>;
+  readonly(callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Disables read queries for a connection to a cluster replica node
@@ -2321,7 +5975,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  readwrite(callback?: Callback<'OK'>): Result<'OK', Context>;
+  readwrite(callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Rename a key
@@ -2329,7 +5983,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  rename(key: RedisKey, newkey: RedisKey, callback?: Callback<'OK'>): Result<'OK', Context>;
+  rename(
+    key: RedisKey,
+    newkey: RedisKey,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Rename a key, only if the new key does not exist
@@ -2337,7 +5995,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  renamenx(key: RedisKey, newkey: RedisKey, callback?: Callback<number>): Result<number, Context>;
+  renamenx(
+    key: RedisKey,
+    newkey: RedisKey,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * An internal command for configuring the replication stream
@@ -2353,7 +6015,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  replicaof(host: string | Buffer, port: string | Buffer, callback?: Callback<'OK'>): Result<'OK', Context>;
+  replicaof(
+    host: string | Buffer,
+    port: string | Buffer,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Reset the connection
@@ -2361,7 +6027,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  reset(callback?: Callback<'OK'>): Result<'OK', Context>;
+  reset(callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Create a key using the provided serialized value, previously obtained using DUMP.
@@ -2369,22 +6035,150 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).
    * - _since_: 2.6.0
    */
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, secondsToken: 'IDLETIME', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, secondsToken: 'IDLETIME', seconds: number | string, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number | string, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', secondsToken: 'IDLETIME', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', secondsToken: 'IDLETIME', seconds: number | string, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  restore(key: RedisKey, ttl: number | string, serializedValue: string | Buffer | number, replace: 'REPLACE', absttl: 'ABSTTL', secondsToken: 'IDLETIME', seconds: number | string, frequencyToken: 'FREQ', frequency: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    frequencyToken: "FREQ",
+    frequency: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    secondsToken: "IDLETIME",
+    seconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    secondsToken: "IDLETIME",
+    seconds: number | string,
+    frequencyToken: "FREQ",
+    frequency: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    absttl: "ABSTTL",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    absttl: "ABSTTL",
+    frequencyToken: "FREQ",
+    frequency: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    absttl: "ABSTTL",
+    secondsToken: "IDLETIME",
+    seconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    absttl: "ABSTTL",
+    secondsToken: "IDLETIME",
+    seconds: number | string,
+    frequencyToken: "FREQ",
+    frequency: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    frequencyToken: "FREQ",
+    frequency: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    secondsToken: "IDLETIME",
+    seconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    secondsToken: "IDLETIME",
+    seconds: number | string,
+    frequencyToken: "FREQ",
+    frequency: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    absttl: "ABSTTL",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    absttl: "ABSTTL",
+    frequencyToken: "FREQ",
+    frequency: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    absttl: "ABSTTL",
+    secondsToken: "IDLETIME",
+    seconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  restore(
+    key: RedisKey,
+    ttl: number | string,
+    serializedValue: string | Buffer | number,
+    replace: "REPLACE",
+    absttl: "ABSTTL",
+    secondsToken: "IDLETIME",
+    seconds: number | string,
+    frequencyToken: "FREQ",
+    frequency: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * An internal command for migrating keys in a cluster
@@ -2392,7 +6186,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) to create the new key and additional O(N*M) to reconstruct the serialized value, where N is the number of Redis objects composing the value and M their average size. For small string values the time complexity is thus O(1)+O(1*M) where M is small, so simply O(1). However for sorted set values the complexity is O(N*M*log(N)) because inserting values into sorted sets is O(log(N)).
    * - _since_: 3.0.0
    */
-  ['restore-asking'](callback?: Callback<unknown>): Result<unknown, Context>;
+  ["restore-asking"](callback?: Callback<unknown>): Result<unknown, Context>;
 
   /**
    * Return the role of the instance in the context of replication
@@ -2408,10 +6202,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements returned
    * - _since_: 1.0.0
    */
-  rpop(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
-  rpopBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  rpop(key: RedisKey, count: number | string, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
-  rpopBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  rpop(
+    key: RedisKey,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  rpopBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  rpop(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<string[] | null>
+  ): Result<string[] | null, Context>;
+  rpopBuffer(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<Buffer[] | null>
+  ): Result<Buffer[] | null, Context>;
 
   /**
    * Remove the last element in a list, prepend it to another list and return it
@@ -2419,8 +6227,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.2.0
    */
-  rpoplpush(source: RedisKey, destination: RedisKey, callback?: Callback<string>): Result<string, Context>;
-  rpoplpushBuffer(source: RedisKey, destination: RedisKey, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  rpoplpush(
+    source: RedisKey,
+    destination: RedisKey,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  rpoplpushBuffer(
+    source: RedisKey,
+    destination: RedisKey,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Append one or multiple elements to a list
@@ -2428,8 +6244,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
    * - _since_: 1.0.0
    */
-  rpush(...args: [key: RedisKey, ...elements: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  rpush(...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]): Result<number, Context>;
+  rpush(
+    ...args: [
+      key: RedisKey,
+      ...elements: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  rpush(
+    ...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Append an element to a list, only if the list exists
@@ -2437,8 +6261,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
    * - _since_: 2.2.0
    */
-  rpushx(...args: [key: RedisKey, ...elements: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  rpushx(...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]): Result<number, Context>;
+  rpushx(
+    ...args: [
+      key: RedisKey,
+      ...elements: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  rpushx(
+    ...args: [key: RedisKey, ...elements: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Add one or more members to a set
@@ -2446,10 +6278,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each element added, so O(N) to add N elements when the command is called with multiple arguments.
    * - _since_: 1.0.0
    */
-  sadd(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  sadd(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  sadd(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<number, Context>;
-  sadd(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<number, Context>;
+  sadd(
+    ...args: [
+      key: RedisKey,
+      ...members: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sadd(
+    ...args: [
+      key: RedisKey,
+      members: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sadd(
+    ...args: [key: RedisKey, ...members: (string | Buffer | number)[]]
+  ): Result<number, Context>;
+  sadd(
+    ...args: [key: RedisKey, members: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Synchronously save the dataset to disk
@@ -2457,7 +6305,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of keys in all databases
    * - _since_: 1.0.0
    */
-  save(callback?: Callback<'OK'>): Result<'OK', Context>;
+  save(callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Incrementally iterate the keys space
@@ -2465,22 +6313,118 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection.
    * - _since_: 2.8.0
    */
-  scan(cursor: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, countToken: 'COUNT', count: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, countToken: 'COUNT', count: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, patternToken: 'MATCH', pattern: string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  scan(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  scanBuffer(cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, typeToken: 'TYPE', type: string | Buffer, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(
+    cursor: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(
+    cursor: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(
+    cursor: number | string,
+    typeToken: "TYPE",
+    type: string | Buffer,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(
+    cursor: number | string,
+    typeToken: "TYPE",
+    type: string | Buffer,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    typeToken: "TYPE",
+    type: string | Buffer,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    typeToken: "TYPE",
+    type: string | Buffer,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    typeToken: "TYPE",
+    type: string | Buffer,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    typeToken: "TYPE",
+    type: string | Buffer,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  scan(
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    typeToken: "TYPE",
+    type: string | Buffer,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  scanBuffer(
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    typeToken: "TYPE",
+    type: string | Buffer,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
 
   /**
    * Get the number of members in a set
@@ -2496,9 +6440,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.2.0
    */
-  script(subcommand: 'DEBUG', yes: 'YES', callback?: Callback<unknown>): Result<unknown, Context>;
-  script(subcommand: 'DEBUG', sync: 'SYNC', callback?: Callback<unknown>): Result<unknown, Context>;
-  script(subcommand: 'DEBUG', no: 'NO', callback?: Callback<unknown>): Result<unknown, Context>;
+  script(
+    subcommand: "DEBUG",
+    yes: "YES",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  script(
+    subcommand: "DEBUG",
+    sync: "SYNC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  script(
+    subcommand: "DEBUG",
+    no: "NO",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Check existence of scripts in the script cache.
@@ -2506,8 +6462,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) with N being the number of scripts to check (so checking a single script is an O(1) operation).
    * - _since_: 2.6.0
    */
-  script(...args: [subcommand: 'EXISTS', ...sha1s: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  script(...args: [subcommand: 'EXISTS', ...sha1s: (string | Buffer)[]]): Result<unknown, Context>;
+  script(
+    ...args: [
+      subcommand: "EXISTS",
+      ...sha1s: (string | Buffer)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  script(
+    ...args: [subcommand: "EXISTS", ...sha1s: (string | Buffer)[]]
+  ): Result<unknown, Context>;
 
   /**
    * Remove all the scripts from the script cache.
@@ -2515,9 +6479,20 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) with N being the number of scripts in cache
    * - _since_: 2.6.0
    */
-  script(subcommand: 'FLUSH', callback?: Callback<unknown>): Result<unknown, Context>;
-  script(subcommand: 'FLUSH', async: 'ASYNC', callback?: Callback<unknown>): Result<unknown, Context>;
-  script(subcommand: 'FLUSH', sync: 'SYNC', callback?: Callback<unknown>): Result<unknown, Context>;
+  script(
+    subcommand: "FLUSH",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  script(
+    subcommand: "FLUSH",
+    async: "ASYNC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  script(
+    subcommand: "FLUSH",
+    sync: "SYNC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -2525,7 +6500,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  script(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  script(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Kill the script currently in execution.
@@ -2533,7 +6511,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.6.0
    */
-  script(subcommand: 'KILL', callback?: Callback<unknown>): Result<unknown, Context>;
+  script(
+    subcommand: "KILL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Load the specified Lua script into the script cache.
@@ -2541,7 +6522,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) with N being the length in bytes of the script body.
    * - _since_: 2.6.0
    */
-  script(subcommand: 'LOAD', script: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  script(
+    subcommand: "LOAD",
+    script: string | Buffer,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Subtract multiple sets
@@ -2549,14 +6534,22 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of elements in all given sets.
    * - _since_: 1.0.0
    */
-  sdiff(...args: [...keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  sdiffBuffer(...args: [...keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  sdiff(...args: [keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  sdiffBuffer(...args: [keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  sdiff(...args: [...keys: (RedisKey)[]]): Result<string[], Context>;
-  sdiffBuffer(...args: [...keys: (RedisKey)[]]): Result<Buffer[], Context>;
-  sdiff(...args: [keys: (RedisKey)[]]): Result<string[], Context>;
-  sdiffBuffer(...args: [keys: (RedisKey)[]]): Result<Buffer[], Context>;
+  sdiff(
+    ...args: [...keys: RedisKey[], callback: Callback<string[]>]
+  ): Result<string[], Context>;
+  sdiffBuffer(
+    ...args: [...keys: RedisKey[], callback: Callback<Buffer[]>]
+  ): Result<Buffer[], Context>;
+  sdiff(
+    ...args: [keys: RedisKey[], callback: Callback<string[]>]
+  ): Result<string[], Context>;
+  sdiffBuffer(
+    ...args: [keys: RedisKey[], callback: Callback<Buffer[]>]
+  ): Result<Buffer[], Context>;
+  sdiff(...args: [...keys: RedisKey[]]): Result<string[], Context>;
+  sdiffBuffer(...args: [...keys: RedisKey[]]): Result<Buffer[], Context>;
+  sdiff(...args: [keys: RedisKey[]]): Result<string[], Context>;
+  sdiffBuffer(...args: [keys: RedisKey[]]): Result<Buffer[], Context>;
 
   /**
    * Subtract multiple sets and store the resulting set in a key
@@ -2564,10 +6557,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of elements in all given sets.
    * - _since_: 1.0.0
    */
-  sdiffstore(...args: [destination: RedisKey, ...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  sdiffstore(...args: [destination: RedisKey, keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  sdiffstore(...args: [destination: RedisKey, ...keys: (RedisKey)[]]): Result<number, Context>;
-  sdiffstore(...args: [destination: RedisKey, keys: (RedisKey)[]]): Result<number, Context>;
+  sdiffstore(
+    ...args: [
+      destination: RedisKey,
+      ...keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sdiffstore(
+    ...args: [
+      destination: RedisKey,
+      keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sdiffstore(
+    ...args: [destination: RedisKey, ...keys: RedisKey[]]
+  ): Result<number, Context>;
+  sdiffstore(
+    ...args: [destination: RedisKey, keys: RedisKey[]]
+  ): Result<number, Context>;
 
   /**
    * Change the selected database for the current connection
@@ -2575,7 +6584,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  select(index: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  select(
+    index: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Set the string value of a key
@@ -2583,60 +6595,429 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  set(key: RedisKey, value: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, secondsToken: 'EX', seconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, millisecondsToken: 'PX', milliseconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', callback?: Callback<'OK'>): Result<'OK', Context>;
-  set(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', nx: 'NX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', nx: 'NX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', nx: 'NX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', xx: 'XX', callback?: Callback<'OK' | null>): Result<'OK' | null, Context>;
-  set(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', xx: 'XX', get: 'GET', callback?: Callback<string | null>): Result<string | null, Context>;
-  setBuffer(key: RedisKey, value: string | Buffer | number, keepttl: 'KEEPTTL', xx: 'XX', get: 'GET', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    nx: "NX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    xx: "XX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    secondsToken: "EX",
+    seconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    secondsToken: "EX",
+    seconds: number | string,
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    secondsToken: "EX",
+    seconds: number | string,
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    secondsToken: "EX",
+    seconds: number | string,
+    nx: "NX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    secondsToken: "EX",
+    seconds: number | string,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    secondsToken: "EX",
+    seconds: number | string,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    secondsToken: "EX",
+    seconds: number | string,
+    xx: "XX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    secondsToken: "EX",
+    seconds: number | string,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    secondsToken: "EX",
+    seconds: number | string,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    nx: "NX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    xx: "XX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    millisecondsToken: "PX",
+    milliseconds: number | string,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    nx: "NX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    xx: "XX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeSecondsToken: "EXAT",
+    unixTimeSeconds: number | string,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    nx: "NX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    xx: "XX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    unixTimeMillisecondsToken: "PXAT",
+    unixTimeMilliseconds: number | string,
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    keepttl: "KEEPTTL",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    keepttl: "KEEPTTL",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    keepttl: "KEEPTTL",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    keepttl: "KEEPTTL",
+    nx: "NX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    keepttl: "KEEPTTL",
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    keepttl: "KEEPTTL",
+    nx: "NX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    keepttl: "KEEPTTL",
+    xx: "XX",
+    callback?: Callback<"OK" | null>
+  ): Result<"OK" | null, Context>;
+  set(
+    key: RedisKey,
+    value: string | Buffer | number,
+    keepttl: "KEEPTTL",
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  setBuffer(
+    key: RedisKey,
+    value: string | Buffer | number,
+    keepttl: "KEEPTTL",
+    xx: "XX",
+    get: "GET",
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Sets or clears the bit at offset in the string value stored at key
@@ -2644,7 +7025,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.2.0
    */
-  setbit(key: RedisKey, offset: number | string, value: number | string, callback?: Callback<number>): Result<number, Context>;
+  setbit(
+    key: RedisKey,
+    offset: number | string,
+    value: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Set the value and expiration of a key
@@ -2652,7 +7038,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.0.0
    */
-  setex(key: RedisKey, seconds: number | string, value: string | Buffer | number, callback?: Callback<'OK'>): Result<'OK', Context>;
+  setex(
+    key: RedisKey,
+    seconds: number | string,
+    value: string | Buffer | number,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Set the value of a key, only if the key does not exist
@@ -2660,7 +7051,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  setnx(key: RedisKey, value: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  setnx(
+    key: RedisKey,
+    value: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Overwrite part of a string at key starting at the specified offset
@@ -2668,7 +7063,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1), not counting the time taken to copy the new string in place. Usually, this string is very small so the amortized complexity is O(1). Otherwise, complexity is O(M) with M being the length of the value argument.
    * - _since_: 2.2.0
    */
-  setrange(key: RedisKey, offset: number | string, value: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  setrange(
+    key: RedisKey,
+    offset: number | string,
+    value: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Synchronously save the dataset to disk and then shut down the server
@@ -2676,30 +7076,113 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) when saving, where N is the total number of keys in all databases when saving data, otherwise O(1)
    * - _since_: 1.0.0
    */
-  shutdown(callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(force: 'FORCE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(now: 'NOW', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(now: 'NOW', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(now: 'NOW', force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(now: 'NOW', force: 'FORCE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(nosave: 'NOSAVE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(nosave: 'NOSAVE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(nosave: 'NOSAVE', force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(nosave: 'NOSAVE', force: 'FORCE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(nosave: 'NOSAVE', now: 'NOW', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(nosave: 'NOSAVE', now: 'NOW', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(nosave: 'NOSAVE', now: 'NOW', force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(nosave: 'NOSAVE', now: 'NOW', force: 'FORCE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(save: 'SAVE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(save: 'SAVE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(save: 'SAVE', force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(save: 'SAVE', force: 'FORCE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(save: 'SAVE', now: 'NOW', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(save: 'SAVE', now: 'NOW', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(save: 'SAVE', now: 'NOW', force: 'FORCE', callback?: Callback<'OK'>): Result<'OK', Context>;
-  shutdown(save: 'SAVE', now: 'NOW', force: 'FORCE', abort: 'ABORT', callback?: Callback<'OK'>): Result<'OK', Context>;
+  shutdown(callback?: Callback<"OK">): Result<"OK", Context>;
+  shutdown(abort: "ABORT", callback?: Callback<"OK">): Result<"OK", Context>;
+  shutdown(force: "FORCE", callback?: Callback<"OK">): Result<"OK", Context>;
+  shutdown(
+    force: "FORCE",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(now: "NOW", callback?: Callback<"OK">): Result<"OK", Context>;
+  shutdown(
+    now: "NOW",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    now: "NOW",
+    force: "FORCE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    now: "NOW",
+    force: "FORCE",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(nosave: "NOSAVE", callback?: Callback<"OK">): Result<"OK", Context>;
+  shutdown(
+    nosave: "NOSAVE",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    nosave: "NOSAVE",
+    force: "FORCE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    nosave: "NOSAVE",
+    force: "FORCE",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    nosave: "NOSAVE",
+    now: "NOW",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    nosave: "NOSAVE",
+    now: "NOW",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    nosave: "NOSAVE",
+    now: "NOW",
+    force: "FORCE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    nosave: "NOSAVE",
+    now: "NOW",
+    force: "FORCE",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(save: "SAVE", callback?: Callback<"OK">): Result<"OK", Context>;
+  shutdown(
+    save: "SAVE",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    save: "SAVE",
+    force: "FORCE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    save: "SAVE",
+    force: "FORCE",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    save: "SAVE",
+    now: "NOW",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    save: "SAVE",
+    now: "NOW",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    save: "SAVE",
+    now: "NOW",
+    force: "FORCE",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  shutdown(
+    save: "SAVE",
+    now: "NOW",
+    force: "FORCE",
+    abort: "ABORT",
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Intersect multiple sets
@@ -2707,14 +7190,22 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N*M) worst case where N is the cardinality of the smallest set and M is the number of sets.
    * - _since_: 1.0.0
    */
-  sinter(...args: [...keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  sinterBuffer(...args: [...keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  sinter(...args: [keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  sinterBuffer(...args: [keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  sinter(...args: [...keys: (RedisKey)[]]): Result<string[], Context>;
-  sinterBuffer(...args: [...keys: (RedisKey)[]]): Result<Buffer[], Context>;
-  sinter(...args: [keys: (RedisKey)[]]): Result<string[], Context>;
-  sinterBuffer(...args: [keys: (RedisKey)[]]): Result<Buffer[], Context>;
+  sinter(
+    ...args: [...keys: RedisKey[], callback: Callback<string[]>]
+  ): Result<string[], Context>;
+  sinterBuffer(
+    ...args: [...keys: RedisKey[], callback: Callback<Buffer[]>]
+  ): Result<Buffer[], Context>;
+  sinter(
+    ...args: [keys: RedisKey[], callback: Callback<string[]>]
+  ): Result<string[], Context>;
+  sinterBuffer(
+    ...args: [keys: RedisKey[], callback: Callback<Buffer[]>]
+  ): Result<Buffer[], Context>;
+  sinter(...args: [...keys: RedisKey[]]): Result<string[], Context>;
+  sinterBuffer(...args: [...keys: RedisKey[]]): Result<Buffer[], Context>;
+  sinter(...args: [keys: RedisKey[]]): Result<string[], Context>;
+  sinterBuffer(...args: [keys: RedisKey[]]): Result<Buffer[], Context>;
 
   /**
    * Intersect multiple sets and return the cardinality of the result
@@ -2722,14 +7213,60 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N*M) worst case where N is the cardinality of the smallest set and M is the number of sets.
    * - _since_: 7.0.0
    */
-  sintercard(...args: [numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  sintercard(...args: [numkeys: number | string, keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  sintercard(...args: [numkeys: number | string, ...keys: (RedisKey)[]]): Result<number, Context>;
-  sintercard(...args: [numkeys: number | string, keys: (RedisKey)[]]): Result<number, Context>;
-  sintercard(...args: [numkeys: number | string, ...keys: (RedisKey)[], limitToken: 'LIMIT', limit: number | string, callback: Callback<number>]): Result<number, Context>;
-  sintercard(...args: [numkeys: number | string, keys: (RedisKey)[], limitToken: 'LIMIT', limit: number | string, callback: Callback<number>]): Result<number, Context>;
-  sintercard(...args: [numkeys: number | string, ...keys: (RedisKey)[], limitToken: 'LIMIT', limit: number | string]): Result<number, Context>;
-  sintercard(...args: [numkeys: number | string, keys: (RedisKey)[], limitToken: 'LIMIT', limit: number | string]): Result<number, Context>;
+  sintercard(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sintercard(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sintercard(
+    ...args: [numkeys: number | string, ...keys: RedisKey[]]
+  ): Result<number, Context>;
+  sintercard(
+    ...args: [numkeys: number | string, keys: RedisKey[]]
+  ): Result<number, Context>;
+  sintercard(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      limitToken: "LIMIT",
+      limit: number | string,
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sintercard(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      limitToken: "LIMIT",
+      limit: number | string,
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sintercard(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      limitToken: "LIMIT",
+      limit: number | string
+    ]
+  ): Result<number, Context>;
+  sintercard(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      limitToken: "LIMIT",
+      limit: number | string
+    ]
+  ): Result<number, Context>;
 
   /**
    * Intersect multiple sets and store the resulting set in a key
@@ -2737,10 +7274,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N*M) worst case where N is the cardinality of the smallest set and M is the number of sets.
    * - _since_: 1.0.0
    */
-  sinterstore(...args: [destination: RedisKey, ...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  sinterstore(...args: [destination: RedisKey, keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  sinterstore(...args: [destination: RedisKey, ...keys: (RedisKey)[]]): Result<number, Context>;
-  sinterstore(...args: [destination: RedisKey, keys: (RedisKey)[]]): Result<number, Context>;
+  sinterstore(
+    ...args: [
+      destination: RedisKey,
+      ...keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sinterstore(
+    ...args: [
+      destination: RedisKey,
+      keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sinterstore(
+    ...args: [destination: RedisKey, ...keys: RedisKey[]]
+  ): Result<number, Context>;
+  sinterstore(
+    ...args: [destination: RedisKey, keys: RedisKey[]]
+  ): Result<number, Context>;
 
   /**
    * Determine if a given value is a member of a set
@@ -2748,7 +7301,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  sismember(key: RedisKey, member: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  sismember(
+    key: RedisKey,
+    member: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Make the server a replica of another instance, or promote it as master.
@@ -2756,7 +7313,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  slaveof(host: string | Buffer, port: string | Buffer, callback?: Callback<'OK'>): Result<'OK', Context>;
+  slaveof(
+    host: string | Buffer,
+    port: string | Buffer,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Get the slow log's entries
@@ -2764,8 +7325,15 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of entries returned
    * - _since_: 2.2.12
    */
-  slowlog(subcommand: 'GET', callback?: Callback<unknown>): Result<unknown, Context>;
-  slowlog(subcommand: 'GET', count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
+  slowlog(
+    subcommand: "GET",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  slowlog(
+    subcommand: "GET",
+    count: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -2773,7 +7341,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  slowlog(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  slowlog(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get the slow log's length
@@ -2781,7 +7352,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.2.12
    */
-  slowlog(subcommand: 'LEN', callback?: Callback<unknown>): Result<unknown, Context>;
+  slowlog(
+    subcommand: "LEN",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Clear all entries from the slow log
@@ -2789,7 +7363,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of entries in the slowlog
    * - _since_: 2.2.12
    */
-  slowlog(subcommand: 'RESET', callback?: Callback<unknown>): Result<unknown, Context>;
+  slowlog(
+    subcommand: "RESET",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get all the members in a set
@@ -2797,8 +7374,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the set cardinality.
    * - _since_: 1.0.0
    */
-  smembers(key: RedisKey, callback?: Callback<string[]>): Result<string[], Context>;
-  smembersBuffer(key: RedisKey, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  smembers(
+    key: RedisKey,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  smembersBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Returns the membership associated with the given elements for a set
@@ -2806,10 +7389,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements being checked for membership
    * - _since_: 6.2.0
    */
-  smismember(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<number[]>]): Result<number[], Context>;
-  smismember(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<number[]>]): Result<number[], Context>;
-  smismember(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<number[], Context>;
-  smismember(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<number[], Context>;
+  smismember(
+    ...args: [
+      key: RedisKey,
+      ...members: (string | Buffer | number)[],
+      callback: Callback<number[]>
+    ]
+  ): Result<number[], Context>;
+  smismember(
+    ...args: [
+      key: RedisKey,
+      members: (string | Buffer | number)[],
+      callback: Callback<number[]>
+    ]
+  ): Result<number[], Context>;
+  smismember(
+    ...args: [key: RedisKey, ...members: (string | Buffer | number)[]]
+  ): Result<number[], Context>;
+  smismember(
+    ...args: [key: RedisKey, members: (string | Buffer | number)[]]
+  ): Result<number[], Context>;
 
   /**
    * Move a member from one set to another
@@ -2817,7 +7416,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.0.0
    */
-  smove(source: RedisKey, destination: RedisKey, member: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  smove(
+    source: RedisKey,
+    destination: RedisKey,
+    member: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Sort the elements in a list, set or sorted set
@@ -2825,8 +7429,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is O(N).
    * - _since_: 1.0.0
    */
-  sort(...args: [key: RedisKey, ...args: (RedisValue)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  sort(...args: [key: RedisKey, ...args: (RedisValue)[]]): Result<unknown, Context>;
+  sort(
+    ...args: [key: RedisKey, ...args: RedisValue[], callback: Callback<unknown>]
+  ): Result<unknown, Context>;
+  sort(
+    ...args: [key: RedisKey, ...args: RedisValue[]]
+  ): Result<unknown, Context>;
 
   /**
    * Sort the elements in a list, set or sorted set. Read-only variant of SORT.
@@ -2834,78 +7442,726 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N+M*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is O(N).
    * - _since_: 7.0.0
    */
-  sort_ro(key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, asc: 'ASC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, asc: 'ASC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, desc: 'DESC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, desc: 'DESC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[]]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, asc: 'ASC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, asc: 'ASC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, desc: 'DESC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, desc: 'DESC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[]]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken: 'GET', ...patterns: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, asc: 'ASC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, asc: 'ASC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, desc: 'DESC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, desc: 'DESC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[]]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, asc: 'ASC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, asc: 'ASC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, desc: 'DESC', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, desc: 'DESC', alpha: 'ALPHA', callback?: Callback<unknown>): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[]]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], asc: 'ASC', alpha: 'ALPHA']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC']): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA', callback: Callback<unknown>]): Result<unknown, Context>;
-  sort_ro(...args: [key: RedisKey, patternToken: 'BY', pattern: string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, patternToken1: 'GET', ...pattern1s: (string | Buffer)[], desc: 'DESC', alpha: 'ALPHA']): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    asc: "ASC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    asc: "ASC",
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    desc: "DESC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    desc: "DESC",
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[]
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      asc: "ASC",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      asc: "ASC"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      asc: "ASC",
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      asc: "ASC",
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      desc: "DESC",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      desc: "DESC"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      desc: "DESC",
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      desc: "DESC",
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    asc: "ASC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    asc: "ASC",
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    desc: "DESC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    desc: "DESC",
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[]
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      asc: "ASC",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      asc: "ASC"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      asc: "ASC",
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      asc: "ASC",
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      desc: "DESC",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      desc: "DESC"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      desc: "DESC",
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken: "GET",
+      ...patterns: (string | Buffer)[],
+      desc: "DESC",
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    asc: "ASC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    asc: "ASC",
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    desc: "DESC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    desc: "DESC",
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[]
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      asc: "ASC",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      asc: "ASC"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      asc: "ASC",
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      asc: "ASC",
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      desc: "DESC",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      desc: "DESC"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      desc: "DESC",
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      desc: "DESC",
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    asc: "ASC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    asc: "ASC",
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    desc: "DESC",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    key: RedisKey,
+    patternToken: "BY",
+    pattern: string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    desc: "DESC",
+    alpha: "ALPHA",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[]
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      asc: "ASC",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      asc: "ASC"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      asc: "ASC",
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      asc: "ASC",
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      desc: "DESC",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      desc: "DESC"
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      desc: "DESC",
+      alpha: "ALPHA",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  sort_ro(
+    ...args: [
+      key: RedisKey,
+      patternToken: "BY",
+      pattern: string,
+      offsetCountToken: "LIMIT",
+      offset: number | string,
+      count: number | string,
+      patternToken1: "GET",
+      ...pattern1s: (string | Buffer)[],
+      desc: "DESC",
+      alpha: "ALPHA"
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Remove and return one or multiple random members from a set
@@ -2913,10 +8169,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Without the count argument O(1), otherwise O(N) where N is the value of the passed count.
    * - _since_: 1.0.0
    */
-  spop(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
-  spopBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  spop(key: RedisKey, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  spopBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  spop(
+    key: RedisKey,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  spopBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  spop(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  spopBuffer(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Post a message to a shard channel
@@ -2924,7 +8194,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of clients subscribed to the receiving shard channel.
    * - _since_: 7.0.0
    */
-  spublish(channel: string | Buffer, message: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  spublish(
+    channel: string | Buffer,
+    message: string | Buffer,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get one or multiple random members from a set
@@ -2932,10 +8206,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: Without the count argument O(1), otherwise O(N) where N is the absolute value of the passed count.
    * - _since_: 1.0.0
    */
-  srandmember(key: RedisKey, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
-  srandmemberBuffer(key: RedisKey, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
-  srandmember(key: RedisKey, count: number | string, callback?: Callback<string | unknown[] | null>): Result<string | unknown[] | null, Context>;
-  srandmemberBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer | unknown[] | null>): Result<Buffer | unknown[] | null, Context>;
+  srandmember(
+    key: RedisKey,
+    callback?: Callback<string | unknown[] | null>
+  ): Result<string | unknown[] | null, Context>;
+  srandmemberBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer | unknown[] | null>
+  ): Result<Buffer | unknown[] | null, Context>;
+  srandmember(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<string | unknown[] | null>
+  ): Result<string | unknown[] | null, Context>;
+  srandmemberBuffer(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<Buffer | unknown[] | null>
+  ): Result<Buffer | unknown[] | null, Context>;
 
   /**
    * Remove one or more members from a set
@@ -2943,10 +8231,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of members to be removed.
    * - _since_: 1.0.0
    */
-  srem(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  srem(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  srem(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<number, Context>;
-  srem(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<number, Context>;
+  srem(
+    ...args: [
+      key: RedisKey,
+      ...members: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  srem(
+    ...args: [
+      key: RedisKey,
+      members: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  srem(
+    ...args: [key: RedisKey, ...members: (string | Buffer | number)[]]
+  ): Result<number, Context>;
+  srem(
+    ...args: [key: RedisKey, members: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Incrementally iterate Set elements
@@ -2954,14 +8258,62 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection..
    * - _since_: 2.8.0
    */
-  sscan(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  sscanBuffer(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  sscan(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  sscanBuffer(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  sscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  sscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  sscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  sscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  sscan(
+    key: RedisKey,
+    cursor: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  sscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  sscan(
+    key: RedisKey,
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  sscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  sscan(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  sscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  sscan(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  sscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
 
   /**
    * Listen for messages published to the given shard channels
@@ -2969,8 +8321,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of shard channels to subscribe to.
    * - _since_: 7.0.0
    */
-  ssubscribe(...args: [...channels: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  ssubscribe(...args: [...channels: (string | Buffer)[]]): Result<unknown, Context>;
+  ssubscribe(
+    ...args: [...channels: (string | Buffer)[], callback: Callback<unknown>]
+  ): Result<unknown, Context>;
+  ssubscribe(
+    ...args: [...channels: (string | Buffer)[]]
+  ): Result<unknown, Context>;
 
   /**
    * Get the length of the value stored in a key
@@ -2986,8 +8342,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of channels to subscribe to.
    * - _since_: 2.0.0
    */
-  subscribe(...args: [...channels: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  subscribe(...args: [...channels: (string | Buffer)[]]): Result<unknown, Context>;
+  subscribe(
+    ...args: [...channels: (string | Buffer)[], callback: Callback<unknown>]
+  ): Result<unknown, Context>;
+  subscribe(
+    ...args: [...channels: (string | Buffer)[]]
+  ): Result<unknown, Context>;
 
   /**
    * Get a substring of the string stored at a key
@@ -2995,7 +8355,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the length of the returned string. The complexity is ultimately determined by the returned length, but because creating a substring from an existing string is very cheap, it can be considered O(1) for small strings.
    * - _since_: 1.0.0
    */
-  substr(key: RedisKey, start: number | string, end: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
+  substr(
+    key: RedisKey,
+    start: number | string,
+    end: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Add multiple sets
@@ -3003,14 +8368,22 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of elements in all given sets.
    * - _since_: 1.0.0
    */
-  sunion(...args: [...keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  sunionBuffer(...args: [...keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  sunion(...args: [keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  sunionBuffer(...args: [keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  sunion(...args: [...keys: (RedisKey)[]]): Result<string[], Context>;
-  sunionBuffer(...args: [...keys: (RedisKey)[]]): Result<Buffer[], Context>;
-  sunion(...args: [keys: (RedisKey)[]]): Result<string[], Context>;
-  sunionBuffer(...args: [keys: (RedisKey)[]]): Result<Buffer[], Context>;
+  sunion(
+    ...args: [...keys: RedisKey[], callback: Callback<string[]>]
+  ): Result<string[], Context>;
+  sunionBuffer(
+    ...args: [...keys: RedisKey[], callback: Callback<Buffer[]>]
+  ): Result<Buffer[], Context>;
+  sunion(
+    ...args: [keys: RedisKey[], callback: Callback<string[]>]
+  ): Result<string[], Context>;
+  sunionBuffer(
+    ...args: [keys: RedisKey[], callback: Callback<Buffer[]>]
+  ): Result<Buffer[], Context>;
+  sunion(...args: [...keys: RedisKey[]]): Result<string[], Context>;
+  sunionBuffer(...args: [...keys: RedisKey[]]): Result<Buffer[], Context>;
+  sunion(...args: [keys: RedisKey[]]): Result<string[], Context>;
+  sunionBuffer(...args: [keys: RedisKey[]]): Result<Buffer[], Context>;
 
   /**
    * Add multiple sets and store the resulting set in a key
@@ -3018,10 +8391,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the total number of elements in all given sets.
    * - _since_: 1.0.0
    */
-  sunionstore(...args: [destination: RedisKey, ...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  sunionstore(...args: [destination: RedisKey, keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  sunionstore(...args: [destination: RedisKey, ...keys: (RedisKey)[]]): Result<number, Context>;
-  sunionstore(...args: [destination: RedisKey, keys: (RedisKey)[]]): Result<number, Context>;
+  sunionstore(
+    ...args: [
+      destination: RedisKey,
+      ...keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sunionstore(
+    ...args: [
+      destination: RedisKey,
+      keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  sunionstore(
+    ...args: [destination: RedisKey, ...keys: RedisKey[]]
+  ): Result<number, Context>;
+  sunionstore(
+    ...args: [destination: RedisKey, keys: RedisKey[]]
+  ): Result<number, Context>;
 
   /**
    * Stop listening for messages posted to the given shard channels
@@ -3030,8 +8419,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 7.0.0
    */
   sunsubscribe(callback?: Callback<unknown>): Result<unknown, Context>;
-  sunsubscribe(...args: [...channels: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  sunsubscribe(...args: [...channels: (string | Buffer)[]]): Result<unknown, Context>;
+  sunsubscribe(
+    ...args: [...channels: (string | Buffer)[], callback: Callback<unknown>]
+  ): Result<unknown, Context>;
+  sunsubscribe(
+    ...args: [...channels: (string | Buffer)[]]
+  ): Result<unknown, Context>;
 
   /**
    * Swaps two Redis databases
@@ -3039,7 +8432,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the count of clients watching or blocking on keys from both databases.
    * - _since_: 4.0.0
    */
-  swapdb(index1: number | string, index2: number | string, callback?: Callback<'OK'>): Result<'OK', Context>;
+  swapdb(
+    index1: number | string,
+    index2: number | string,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
 
   /**
    * Internal command used for replication
@@ -3063,10 +8460,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of keys that will be touched.
    * - _since_: 3.2.1
    */
-  touch(...args: [...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  touch(...args: [keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  touch(...args: [...keys: (RedisKey)[]]): Result<number, Context>;
-  touch(...args: [keys: (RedisKey)[]]): Result<number, Context>;
+  touch(
+    ...args: [...keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  touch(
+    ...args: [keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  touch(...args: [...keys: RedisKey[]]): Result<number, Context>;
+  touch(...args: [keys: RedisKey[]]): Result<number, Context>;
 
   /**
    * Get the time to live for a key in seconds
@@ -3090,10 +8491,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each key removed regardless of its size. Then the command does O(N) work in a different thread in order to reclaim memory, where N is the number of allocations the deleted objects where composed of.
    * - _since_: 4.0.0
    */
-  unlink(...args: [...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  unlink(...args: [keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  unlink(...args: [...keys: (RedisKey)[]]): Result<number, Context>;
-  unlink(...args: [keys: (RedisKey)[]]): Result<number, Context>;
+  unlink(
+    ...args: [...keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  unlink(
+    ...args: [keys: RedisKey[], callback: Callback<number>]
+  ): Result<number, Context>;
+  unlink(...args: [...keys: RedisKey[]]): Result<number, Context>;
+  unlink(...args: [keys: RedisKey[]]): Result<number, Context>;
 
   /**
    * Stop listening for messages posted to the given channels
@@ -3102,8 +8507,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 2.0.0
    */
   unsubscribe(callback?: Callback<unknown>): Result<unknown, Context>;
-  unsubscribe(...args: [...channels: (string | Buffer)[], callback: Callback<unknown>]): Result<unknown, Context>;
-  unsubscribe(...args: [...channels: (string | Buffer)[]]): Result<unknown, Context>;
+  unsubscribe(
+    ...args: [...channels: (string | Buffer)[], callback: Callback<unknown>]
+  ): Result<unknown, Context>;
+  unsubscribe(
+    ...args: [...channels: (string | Buffer)[]]
+  ): Result<unknown, Context>;
 
   /**
    * Forget about all watched keys
@@ -3111,7 +8520,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 2.2.0
    */
-  unwatch(callback?: Callback<'OK'>): Result<'OK', Context>;
+  unwatch(callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
    * Wait for the synchronous replication of all the write commands sent in the context of the current connection
@@ -3119,7 +8528,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 3.0.0
    */
-  wait(numreplicas: number | string, timeout: number | string, callback?: Callback<number>): Result<number, Context>;
+  wait(
+    numreplicas: number | string,
+    timeout: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Watch the given keys to determine execution of the MULTI/EXEC block
@@ -3127,10 +8540,14 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for every key.
    * - _since_: 2.2.0
    */
-  watch(...args: [...keys: (RedisKey)[], callback: Callback<'OK'>]): Result<'OK', Context>;
-  watch(...args: [keys: (RedisKey)[], callback: Callback<'OK'>]): Result<'OK', Context>;
-  watch(...args: [...keys: (RedisKey)[]]): Result<'OK', Context>;
-  watch(...args: [keys: (RedisKey)[]]): Result<'OK', Context>;
+  watch(
+    ...args: [...keys: RedisKey[], callback: Callback<"OK">]
+  ): Result<"OK", Context>;
+  watch(
+    ...args: [keys: RedisKey[], callback: Callback<"OK">]
+  ): Result<"OK", Context>;
+  watch(...args: [...keys: RedisKey[]]): Result<"OK", Context>;
+  watch(...args: [keys: RedisKey[]]): Result<"OK", Context>;
 
   /**
    * Marks a pending message as correctly processed, effectively removing it from the pending entries list of the consumer group. Return value of the command is the number of messages successfully acknowledged, that is, the IDs we were actually able to resolve in the PEL.
@@ -3138,8 +8555,21 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each message ID processed.
    * - _since_: 5.0.0
    */
-  xack(...args: [key: RedisKey, group: string | Buffer, ...ids: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  xack(...args: [key: RedisKey, group: string | Buffer, ...ids: (string | Buffer | number)[]]): Result<number, Context>;
+  xack(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      ...ids: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  xack(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      ...ids: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
 
   /**
    * Appends a new entry to a stream
@@ -3147,10 +8577,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) when adding a new entry, O(N) when trimming where N being the number of entries evicted.
    * - _since_: 5.0.0
    */
-  xadd(...args: [key: RedisKey, ...args: (RedisValue)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  xaddBuffer(...args: [key: RedisKey, ...args: (RedisValue)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  xadd(...args: [key: RedisKey, ...args: (RedisValue)[]]): Result<string | null, Context>;
-  xaddBuffer(...args: [key: RedisKey, ...args: (RedisValue)[]]): Result<Buffer | null, Context>;
+  xadd(
+    ...args: [
+      key: RedisKey,
+      ...args: RedisValue[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  xaddBuffer(
+    ...args: [
+      key: RedisKey,
+      ...args: RedisValue[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  xadd(
+    ...args: [key: RedisKey, ...args: RedisValue[]]
+  ): Result<string | null, Context>;
+  xaddBuffer(
+    ...args: [key: RedisKey, ...args: RedisValue[]]
+  ): Result<Buffer | null, Context>;
 
   /**
    * Changes (or acquires) ownership of messages in a consumer group, as if the messages were delivered to the specified consumer.
@@ -3158,10 +8604,44 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) if COUNT is small.
    * - _since_: 6.2.0
    */
-  xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, justid: 'JUSTID', callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xautoclaim(key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number | string, justid: 'JUSTID', callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  xautoclaim(
+    key: RedisKey,
+    group: string | Buffer,
+    consumer: string | Buffer,
+    minIdleTime: string | Buffer | number,
+    start: string | Buffer | number,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  xautoclaim(
+    key: RedisKey,
+    group: string | Buffer,
+    consumer: string | Buffer,
+    minIdleTime: string | Buffer | number,
+    start: string | Buffer | number,
+    justid: "JUSTID",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  xautoclaim(
+    key: RedisKey,
+    group: string | Buffer,
+    consumer: string | Buffer,
+    minIdleTime: string | Buffer | number,
+    start: string | Buffer | number,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  xautoclaim(
+    key: RedisKey,
+    group: string | Buffer,
+    consumer: string | Buffer,
+    minIdleTime: string | Buffer | number,
+    start: string | Buffer | number,
+    countToken: "COUNT",
+    count: number | string,
+    justid: "JUSTID",
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Changes (or acquires) ownership of a message in a consumer group, as if the message was delivered to the specified consumer.
@@ -3169,70 +8649,870 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log N) with N being the number of messages in the PEL of the consumer group.
    * - _since_: 5.0.0
    */
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[]]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, justid: 'JUSTID']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE']): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID', callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xclaim(...args: [key: RedisKey, group: string | Buffer, consumer: string | Buffer, minIdleTime: string | Buffer | number, ...ids: (string | Buffer | number)[], msToken: 'IDLE', ms: number | string, unixTimeMillisecondsToken: 'TIME', unixTimeMilliseconds: number | string, countToken: 'RETRYCOUNT', count: number | string, force: 'FORCE', justid: 'JUSTID']): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[]
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      force: "FORCE",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      force: "FORCE"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      force: "FORCE",
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      force: "FORCE",
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      countToken: "RETRYCOUNT",
+      count: number | string
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      force: "FORCE",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      force: "FORCE"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      force: "FORCE",
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      force: "FORCE",
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      force: "FORCE",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      force: "FORCE"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      force: "FORCE",
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      force: "FORCE",
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      force: "FORCE",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      force: "FORCE"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      force: "FORCE",
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      force: "FORCE",
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE"
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      justid: "JUSTID",
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xclaim(
+    ...args: [
+      key: RedisKey,
+      group: string | Buffer,
+      consumer: string | Buffer,
+      minIdleTime: string | Buffer | number,
+      ...ids: (string | Buffer | number)[],
+      msToken: "IDLE",
+      ms: number | string,
+      unixTimeMillisecondsToken: "TIME",
+      unixTimeMilliseconds: number | string,
+      countToken: "RETRYCOUNT",
+      count: number | string,
+      force: "FORCE",
+      justid: "JUSTID"
+    ]
+  ): Result<unknown[], Context>;
 
   /**
    * Removes the specified entries from the stream. Returns the number of items actually deleted, that may be different from the number of IDs passed in case certain IDs do not exist.
@@ -3240,8 +9520,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for each single item to delete in the stream, regardless of the stream size.
    * - _since_: 5.0.0
    */
-  xdel(...args: [key: RedisKey, ...ids: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  xdel(...args: [key: RedisKey, ...ids: (string | Buffer | number)[]]): Result<number, Context>;
+  xdel(
+    ...args: [
+      key: RedisKey,
+      ...ids: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  xdel(
+    ...args: [key: RedisKey, ...ids: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Create a consumer group.
@@ -3249,14 +9537,74 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xgroup(subcommand: 'CREATE', key: RedisKey, groupname: string | Buffer, id: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'CREATE', key: RedisKey, groupname: string | Buffer, id: string | Buffer | number, entriesReadToken: 'ENTRIESREAD', entriesRead: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'CREATE', key: RedisKey, groupname: string | Buffer, id: string | Buffer | number, mkstream: 'MKSTREAM', callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'CREATE', key: RedisKey, groupname: string | Buffer, id: string | Buffer | number, mkstream: 'MKSTREAM', entriesReadToken: 'ENTRIESREAD', entriesRead: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'CREATE', key: RedisKey, groupname: string | Buffer, newId: '$', callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'CREATE', key: RedisKey, groupname: string | Buffer, newId: '$', entriesReadToken: 'ENTRIESREAD', entriesRead: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'CREATE', key: RedisKey, groupname: string | Buffer, newId: '$', mkstream: 'MKSTREAM', callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'CREATE', key: RedisKey, groupname: string | Buffer, newId: '$', mkstream: 'MKSTREAM', entriesReadToken: 'ENTRIESREAD', entriesRead: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
+  xgroup(
+    subcommand: "CREATE",
+    key: RedisKey,
+    groupname: string | Buffer,
+    id: string | Buffer | number,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "CREATE",
+    key: RedisKey,
+    groupname: string | Buffer,
+    id: string | Buffer | number,
+    entriesReadToken: "ENTRIESREAD",
+    entriesRead: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "CREATE",
+    key: RedisKey,
+    groupname: string | Buffer,
+    id: string | Buffer | number,
+    mkstream: "MKSTREAM",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "CREATE",
+    key: RedisKey,
+    groupname: string | Buffer,
+    id: string | Buffer | number,
+    mkstream: "MKSTREAM",
+    entriesReadToken: "ENTRIESREAD",
+    entriesRead: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "CREATE",
+    key: RedisKey,
+    groupname: string | Buffer,
+    newId: "$",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "CREATE",
+    key: RedisKey,
+    groupname: string | Buffer,
+    newId: "$",
+    entriesReadToken: "ENTRIESREAD",
+    entriesRead: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "CREATE",
+    key: RedisKey,
+    groupname: string | Buffer,
+    newId: "$",
+    mkstream: "MKSTREAM",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "CREATE",
+    key: RedisKey,
+    groupname: string | Buffer,
+    newId: "$",
+    mkstream: "MKSTREAM",
+    entriesReadToken: "ENTRIESREAD",
+    entriesRead: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Create a consumer in a consumer group.
@@ -3264,7 +9612,13 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 6.2.0
    */
-  xgroup(subcommand: 'CREATECONSUMER', key: RedisKey, groupname: string | Buffer, consumername: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  xgroup(
+    subcommand: "CREATECONSUMER",
+    key: RedisKey,
+    groupname: string | Buffer,
+    consumername: string | Buffer,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Delete a consumer from a consumer group.
@@ -3272,7 +9626,13 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xgroup(subcommand: 'DELCONSUMER', key: RedisKey, groupname: string | Buffer, consumername: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  xgroup(
+    subcommand: "DELCONSUMER",
+    key: RedisKey,
+    groupname: string | Buffer,
+    consumername: string | Buffer,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Destroy a consumer group.
@@ -3280,7 +9640,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of entries in the group's pending entries list (PEL).
    * - _since_: 5.0.0
    */
-  xgroup(subcommand: 'DESTROY', key: RedisKey, groupname: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  xgroup(
+    subcommand: "DESTROY",
+    key: RedisKey,
+    groupname: string | Buffer,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -3288,7 +9653,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xgroup(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  xgroup(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Set a consumer group to an arbitrary last delivered ID value.
@@ -3296,10 +9664,38 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xgroup(subcommand: 'SETID', key: RedisKey, groupname: string | Buffer, id: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'SETID', key: RedisKey, groupname: string | Buffer, id: string | Buffer | number, entriesReadToken: 'ENTRIESREAD', entriesRead: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'SETID', key: RedisKey, groupname: string | Buffer, newId: '$', callback?: Callback<unknown>): Result<unknown, Context>;
-  xgroup(subcommand: 'SETID', key: RedisKey, groupname: string | Buffer, newId: '$', entriesReadToken: 'ENTRIESREAD', entriesRead: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
+  xgroup(
+    subcommand: "SETID",
+    key: RedisKey,
+    groupname: string | Buffer,
+    id: string | Buffer | number,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "SETID",
+    key: RedisKey,
+    groupname: string | Buffer,
+    id: string | Buffer | number,
+    entriesReadToken: "ENTRIESREAD",
+    entriesRead: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "SETID",
+    key: RedisKey,
+    groupname: string | Buffer,
+    newId: "$",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xgroup(
+    subcommand: "SETID",
+    key: RedisKey,
+    groupname: string | Buffer,
+    newId: "$",
+    entriesReadToken: "ENTRIESREAD",
+    entriesRead: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * List the consumers in a consumer group
@@ -3307,7 +9703,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xinfo(subcommand: 'CONSUMERS', key: RedisKey, groupname: string | Buffer, callback?: Callback<unknown>): Result<unknown, Context>;
+  xinfo(
+    subcommand: "CONSUMERS",
+    key: RedisKey,
+    groupname: string | Buffer,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * List the consumer groups of a stream
@@ -3315,7 +9716,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xinfo(subcommand: 'GROUPS', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
+  xinfo(
+    subcommand: "GROUPS",
+    key: RedisKey,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Show helpful text about the different subcommands
@@ -3323,7 +9728,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xinfo(subcommand: 'HELP', callback?: Callback<unknown>): Result<unknown, Context>;
+  xinfo(
+    subcommand: "HELP",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Get information about a stream
@@ -3331,9 +9739,25 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xinfo(subcommand: 'STREAM', key: RedisKey, callback?: Callback<unknown>): Result<unknown, Context>;
-  xinfo(subcommand: 'STREAM', key: RedisKey, fullToken: 'FULL', callback?: Callback<unknown>): Result<unknown, Context>;
-  xinfo(subcommand: 'STREAM', key: RedisKey, fullToken: 'FULL', countToken: 'COUNT', count: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
+  xinfo(
+    subcommand: "STREAM",
+    key: RedisKey,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xinfo(
+    subcommand: "STREAM",
+    key: RedisKey,
+    fullToken: "FULL",
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xinfo(
+    subcommand: "STREAM",
+    key: RedisKey,
+    fullToken: "FULL",
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Return the number of entries in a stream
@@ -3349,11 +9773,49 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) with N being the number of elements returned, so asking for a small fixed number of entries per call is O(1). O(M), where M is the total number of entries scanned when used with the IDLE filter. When the command returns just the summary and the list of consumers is small, it runs in O(1) time; otherwise, an additional O(N) time for iterating every consumer.
    * - _since_: 5.0.0
    */
-  xpending(key: RedisKey, group: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xpending(key: RedisKey, group: string | Buffer, start: string | Buffer | number, end: string | Buffer | number, count: number | string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xpending(key: RedisKey, group: string | Buffer, start: string | Buffer | number, end: string | Buffer | number, count: number | string, consumer: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xpending(key: RedisKey, group: string | Buffer, minIdleTimeToken: 'IDLE', minIdleTime: number | string, start: string | Buffer | number, end: string | Buffer | number, count: number | string, callback?: Callback<unknown[]>): Result<unknown[], Context>;
-  xpending(key: RedisKey, group: string | Buffer, minIdleTimeToken: 'IDLE', minIdleTime: number | string, start: string | Buffer | number, end: string | Buffer | number, count: number | string, consumer: string | Buffer, callback?: Callback<unknown[]>): Result<unknown[], Context>;
+  xpending(
+    key: RedisKey,
+    group: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  xpending(
+    key: RedisKey,
+    group: string | Buffer,
+    start: string | Buffer | number,
+    end: string | Buffer | number,
+    count: number | string,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  xpending(
+    key: RedisKey,
+    group: string | Buffer,
+    start: string | Buffer | number,
+    end: string | Buffer | number,
+    count: number | string,
+    consumer: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  xpending(
+    key: RedisKey,
+    group: string | Buffer,
+    minIdleTimeToken: "IDLE",
+    minIdleTime: number | string,
+    start: string | Buffer | number,
+    end: string | Buffer | number,
+    count: number | string,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
+  xpending(
+    key: RedisKey,
+    group: string | Buffer,
+    minIdleTimeToken: "IDLE",
+    minIdleTime: number | string,
+    start: string | Buffer | number,
+    end: string | Buffer | number,
+    count: number | string,
+    consumer: string | Buffer,
+    callback?: Callback<unknown[]>
+  ): Result<unknown[], Context>;
 
   /**
    * Return a range of elements in a stream, with IDs matching the specified IDs interval
@@ -3361,10 +9823,34 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) with N being the number of elements being returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).
    * - _since_: 5.0.0
    */
-  xrange(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
-  xrangeBuffer(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
-  xrange(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
-  xrangeBuffer(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
+  xrange(
+    key: RedisKey,
+    start: string | Buffer | number,
+    end: string | Buffer | number,
+    callback?: Callback<[id: string, fields: string[]][]>
+  ): Result<[id: string, fields: string[]][], Context>;
+  xrangeBuffer(
+    key: RedisKey,
+    start: string | Buffer | number,
+    end: string | Buffer | number,
+    callback?: Callback<[id: Buffer, fields: Buffer[]][]>
+  ): Result<[id: Buffer, fields: Buffer[]][], Context>;
+  xrange(
+    key: RedisKey,
+    start: string | Buffer | number,
+    end: string | Buffer | number,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[id: string, fields: string[]][]>
+  ): Result<[id: string, fields: string[]][], Context>;
+  xrangeBuffer(
+    key: RedisKey,
+    start: string | Buffer | number,
+    end: string | Buffer | number,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[id: Buffer, fields: Buffer[]][]>
+  ): Result<[id: Buffer, fields: Buffer[]][], Context>;
 
   /**
    * Return never seen elements in multiple streams, with IDs greater than the ones reported by the caller for each stream. Can block.
@@ -3372,14 +9858,200 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: For each stream mentioned: O(N) with N being the number of elements being returned, it means that XREAD-ing with a fixed COUNT is O(1). Note that when the BLOCK option is used, XADD will pay O(M) time in order to serve the M clients blocked on the stream getting new data.
    * - _since_: 5.0.0
    */
-  xread(...args: [streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xread(...args: [streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xread(...args: [millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  xread(...args: [millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[] | null, Context>;
-  xread(...args: [countToken: 'COUNT', count: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xread(...args: [countToken: 'COUNT', count: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xread(...args: [countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[] | null>]): Result<unknown[] | null, Context>;
-  xread(...args: [countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[] | null, Context>;
+  xread(
+    ...args: [
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<
+        [key: string, items: [id: string, fields: string[]][]][] | null
+      >
+    ]
+  ): Result<
+    [key: string, items: [id: string, fields: string[]][]][] | null,
+    Context
+  >;
+  xreadBuffer(
+    ...args: [
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<
+        [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null
+      >
+    ]
+  ): Result<
+    [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null,
+    Context
+  >;
+  xread(
+    ...args: [streamsToken: "STREAMS", ...args: RedisValue[]]
+  ): Result<
+    [key: string, items: [id: string, fields: string[]][]][] | null,
+    Context
+  >;
+  xreadBuffer(
+    ...args: [streamsToken: "STREAMS", ...args: RedisValue[]]
+  ): Result<
+    [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null,
+    Context
+  >;
+  xread(
+    ...args: [
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<
+        [key: string, items: [id: string, fields: string[]][]][] | null
+      >
+    ]
+  ): Result<
+    [key: string, items: [id: string, fields: string[]][]][] | null,
+    Context
+  >;
+  xreadBuffer(
+    ...args: [
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<
+        [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null
+      >
+    ]
+  ): Result<
+    [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null,
+    Context
+  >;
+  xread(
+    ...args: [
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<
+    [key: string, items: [id: string, fields: string[]][]][] | null,
+    Context
+  >;
+  xreadBuffer(
+    ...args: [
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<
+    [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null,
+    Context
+  >;
+  xread(
+    ...args: [
+      countToken: "COUNT",
+      count: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<
+        [key: string, items: [id: string, fields: string[]][]][] | null
+      >
+    ]
+  ): Result<
+    [key: string, items: [id: string, fields: string[]][]][] | null,
+    Context
+  >;
+  xreadBuffer(
+    ...args: [
+      countToken: "COUNT",
+      count: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<
+        [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null
+      >
+    ]
+  ): Result<
+    [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null,
+    Context
+  >;
+  xread(
+    ...args: [
+      countToken: "COUNT",
+      count: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<
+    [key: string, items: [id: string, fields: string[]][]][] | null,
+    Context
+  >;
+  xreadBuffer(
+    ...args: [
+      countToken: "COUNT",
+      count: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<
+    [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null,
+    Context
+  >;
+  xread(
+    ...args: [
+      countToken: "COUNT",
+      count: number | string,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<
+        [key: string, items: [id: string, fields: string[]][]][] | null
+      >
+    ]
+  ): Result<
+    [key: string, items: [id: string, fields: string[]][]][] | null,
+    Context
+  >;
+  xreadBuffer(
+    ...args: [
+      countToken: "COUNT",
+      count: number | string,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<
+        [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null
+      >
+    ]
+  ): Result<
+    [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null,
+    Context
+  >;
+  xread(
+    ...args: [
+      countToken: "COUNT",
+      count: number | string,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<
+    [key: string, items: [id: string, fields: string[]][]][] | null,
+    Context
+  >;
+  xreadBuffer(
+    ...args: [
+      countToken: "COUNT",
+      count: number | string,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<
+    [key: Buffer, items: [id: Buffer, fields: Buffer[]][]][] | null,
+    Context
+  >;
 
   /**
    * Return new entries from a stream using a consumer group, or access the history of the pending entries for a given consumer. Can block.
@@ -3387,22 +10059,198 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: For each stream mentioned: O(M) with M being the number of elements returned. If M is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1). On the other side when XREADGROUP blocks, XADD will pay the O(N) time in order to serve the N clients blocked on the stream getting new data.
    * - _since_: 5.0.0
    */
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, millisecondsToken: 'BLOCK', milliseconds: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[], callback: Callback<unknown[]>]): Result<unknown[], Context>;
-  xreadgroup(...args: [groupConsumerToken: 'GROUP', group: string | Buffer, consumer: string | Buffer, countToken: 'COUNT', count: number | string, millisecondsToken: 'BLOCK', milliseconds: number | string, noack: 'NOACK', streamsToken: 'STREAMS', ...args: (RedisValue)[]]): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      noack: "NOACK",
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      noack: "NOACK",
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      noack: "NOACK",
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      noack: "NOACK",
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      countToken: "COUNT",
+      count: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      countToken: "COUNT",
+      count: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      countToken: "COUNT",
+      count: number | string,
+      noack: "NOACK",
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      countToken: "COUNT",
+      count: number | string,
+      noack: "NOACK",
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      countToken: "COUNT",
+      count: number | string,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      countToken: "COUNT",
+      count: number | string,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      countToken: "COUNT",
+      count: number | string,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      noack: "NOACK",
+      streamsToken: "STREAMS",
+      ...args: RedisValue[],
+      callback: Callback<unknown[]>
+    ]
+  ): Result<unknown[], Context>;
+  xreadgroup(
+    ...args: [
+      groupConsumerToken: "GROUP",
+      group: string | Buffer,
+      consumer: string | Buffer,
+      countToken: "COUNT",
+      count: number | string,
+      millisecondsToken: "BLOCK",
+      milliseconds: number | string,
+      noack: "NOACK",
+      streamsToken: "STREAMS",
+      ...args: RedisValue[]
+    ]
+  ): Result<unknown[], Context>;
 
   /**
    * Return a range of elements in a stream, with IDs matching the specified IDs interval, in reverse order (from greater to smaller IDs) compared to XRANGE
@@ -3410,10 +10258,34 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) with N being the number of elements returned. If N is constant (e.g. always asking for the first 10 elements with COUNT), you can consider it O(1).
    * - _since_: 5.0.0
    */
-  xrevrange(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
-  xrevrangeBuffer(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
-  xrevrange(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<[id: string, fields: string[]][]>): Result<[id: string, fields: string[]][], Context>;
-  xrevrangeBuffer(key: RedisKey, end: string | Buffer | number, start: string | Buffer | number, countToken: 'COUNT', count: number | string, callback?: Callback<[id: Buffer, fields: Buffer[]][]>): Result<[id: Buffer, fields: Buffer[]][], Context>;
+  xrevrange(
+    key: RedisKey,
+    end: string | Buffer | number,
+    start: string | Buffer | number,
+    callback?: Callback<[id: string, fields: string[]][]>
+  ): Result<[id: string, fields: string[]][], Context>;
+  xrevrangeBuffer(
+    key: RedisKey,
+    end: string | Buffer | number,
+    start: string | Buffer | number,
+    callback?: Callback<[id: Buffer, fields: Buffer[]][]>
+  ): Result<[id: Buffer, fields: Buffer[]][], Context>;
+  xrevrange(
+    key: RedisKey,
+    end: string | Buffer | number,
+    start: string | Buffer | number,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[id: string, fields: string[]][]>
+  ): Result<[id: string, fields: string[]][], Context>;
+  xrevrangeBuffer(
+    key: RedisKey,
+    end: string | Buffer | number,
+    start: string | Buffer | number,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[id: Buffer, fields: Buffer[]][]>
+  ): Result<[id: Buffer, fields: Buffer[]][], Context>;
 
   /**
    * An internal command for replicating stream values
@@ -3421,10 +10293,34 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 5.0.0
    */
-  xsetid(key: RedisKey, lastId: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
-  xsetid(key: RedisKey, lastId: string | Buffer | number, maxDeletedEntryIdToken: 'MAXDELETEDID', maxDeletedEntryId: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
-  xsetid(key: RedisKey, lastId: string | Buffer | number, entriesAddedToken: 'ENTRIESADDED', entriesAdded: number | string, callback?: Callback<unknown>): Result<unknown, Context>;
-  xsetid(key: RedisKey, lastId: string | Buffer | number, entriesAddedToken: 'ENTRIESADDED', entriesAdded: number | string, maxDeletedEntryIdToken: 'MAXDELETEDID', maxDeletedEntryId: string | Buffer | number, callback?: Callback<unknown>): Result<unknown, Context>;
+  xsetid(
+    key: RedisKey,
+    lastId: string | Buffer | number,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xsetid(
+    key: RedisKey,
+    lastId: string | Buffer | number,
+    maxDeletedEntryIdToken: "MAXDELETEDID",
+    maxDeletedEntryId: string | Buffer | number,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xsetid(
+    key: RedisKey,
+    lastId: string | Buffer | number,
+    entriesAddedToken: "ENTRIESADDED",
+    entriesAdded: number | string,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
+  xsetid(
+    key: RedisKey,
+    lastId: string | Buffer | number,
+    entriesAddedToken: "ENTRIESADDED",
+    entriesAdded: number | string,
+    maxDeletedEntryIdToken: "MAXDELETEDID",
+    maxDeletedEntryId: string | Buffer | number,
+    callback?: Callback<unknown>
+  ): Result<unknown, Context>;
 
   /**
    * Trims the stream to (approximately if '~' is passed) a certain size
@@ -3432,18 +10328,98 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N), with N being the number of evicted entries. Constant times are very small however, since entries are organized in macro nodes containing multiple entries that can be released with a single deallocation.
    * - _since_: 5.0.0
    */
-  xtrim(key: RedisKey, maxlen: 'MAXLEN', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, maxlen: 'MAXLEN', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, maxlen: 'MAXLEN', equal: '=', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, maxlen: 'MAXLEN', equal: '=', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, maxlen: 'MAXLEN', approximately: '~', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, maxlen: 'MAXLEN', approximately: '~', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, minid: 'MINID', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, minid: 'MINID', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, minid: 'MINID', equal: '=', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, minid: 'MINID', equal: '=', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, minid: 'MINID', approximately: '~', threshold: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  xtrim(key: RedisKey, minid: 'MINID', approximately: '~', threshold: string | Buffer | number, countToken: 'LIMIT', count: number | string, callback?: Callback<number>): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    maxlen: "MAXLEN",
+    threshold: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    maxlen: "MAXLEN",
+    threshold: string | Buffer | number,
+    countToken: "LIMIT",
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    maxlen: "MAXLEN",
+    equal: "=",
+    threshold: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    maxlen: "MAXLEN",
+    equal: "=",
+    threshold: string | Buffer | number,
+    countToken: "LIMIT",
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    maxlen: "MAXLEN",
+    approximately: "~",
+    threshold: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    maxlen: "MAXLEN",
+    approximately: "~",
+    threshold: string | Buffer | number,
+    countToken: "LIMIT",
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    minid: "MINID",
+    threshold: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    minid: "MINID",
+    threshold: string | Buffer | number,
+    countToken: "LIMIT",
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    minid: "MINID",
+    equal: "=",
+    threshold: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    minid: "MINID",
+    equal: "=",
+    threshold: string | Buffer | number,
+    countToken: "LIMIT",
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    minid: "MINID",
+    approximately: "~",
+    threshold: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  xtrim(
+    key: RedisKey,
+    minid: "MINID",
+    approximately: "~",
+    threshold: string | Buffer | number,
+    countToken: "LIMIT",
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Add one or more members to a sorted set, or update its score if it already exists
@@ -3451,114 +10427,975 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) for each item added, where N is the number of elements in the sorted set.
    * - _since_: 1.2.0
    */
-  zadd(...args: [key: RedisKey, ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string>]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer>]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, ch: 'CH', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, ch: 'CH', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string>]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer>]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, gt: 'GT', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, gt: 'GT', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string>]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer>]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, gt: 'GT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, gt: 'GT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string>]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer>]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, lt: 'LT', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, lt: 'LT', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string>]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer>]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, lt: 'LT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, lt: 'LT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string>]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer>]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string, Context>;
-  zaddBuffer(...args: [key: RedisKey, lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', ch: 'CH', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', ch: 'CH', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', gt: 'GT', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', gt: 'GT', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', gt: 'GT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', gt: 'GT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', lt: 'LT', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', lt: 'LT', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', lt: 'LT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', lt: 'LT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, nx: 'NX', lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, nx: 'NX', lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', ch: 'CH', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', ch: 'CH', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', gt: 'GT', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', gt: 'GT', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', gt: 'GT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', gt: 'GT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', gt: 'GT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', gt: 'GT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', lt: 'LT', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', lt: 'LT', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', lt: 'LT', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', lt: 'LT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', lt: 'LT', ch: 'CH', ...scoreMembers: (string | Buffer | number)[]]): Result<number, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<string | null>]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[], callback: Callback<Buffer | null>]): Result<Buffer | null, Context>;
-  zadd(...args: [key: RedisKey, xx: 'XX', lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<string | null, Context>;
-  zaddBuffer(...args: [key: RedisKey, xx: 'XX', lt: 'LT', ch: 'CH', incr: 'INCR', ...scoreMembers: (string | Buffer | number)[]]): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [key: RedisKey, ...scoreMembers: (string | Buffer | number)[]]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string>
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer>
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string>
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer>
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string>
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer>
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string>
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer>
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string>
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer>
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string>
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer>
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      nx: "NX",
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      gt: "GT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      ch: "CH",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<number, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<string | null>
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[],
+      callback: Callback<Buffer | null>
+    ]
+  ): Result<Buffer | null, Context>;
+  zadd(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<string | null, Context>;
+  zaddBuffer(
+    ...args: [
+      key: RedisKey,
+      xx: "XX",
+      lt: "LT",
+      ch: "CH",
+      incr: "INCR",
+      ...scoreMembers: (string | Buffer | number)[]
+    ]
+  ): Result<Buffer | null, Context>;
 
   /**
    * Get the number of members in a sorted set
@@ -3574,7 +11411,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) with N being the number of elements in the sorted set.
    * - _since_: 2.0.0
    */
-  zcount(key: RedisKey, min: number | string, max: number | string, callback?: Callback<number>): Result<number, Context>;
+  zcount(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Subtract multiple sorted sets
@@ -3582,22 +11424,106 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(L + (N-K)log(N)) worst case where L is the total number of elements in all the sets, N is the size of the first set, and K is the size of the result set.
    * - _since_: 6.2.0
    */
-  zdiff(...args: [numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  zdiffBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zdiff(...args: [numkeys: number | string, keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  zdiffBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zdiff(...args: [numkeys: number | string, ...keys: (RedisKey)[]]): Result<string[], Context>;
-  zdiffBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[]]): Result<Buffer[], Context>;
-  zdiff(...args: [numkeys: number | string, keys: (RedisKey)[]]): Result<string[], Context>;
-  zdiffBuffer(...args: [numkeys: number | string, keys: (RedisKey)[]]): Result<Buffer[], Context>;
-  zdiff(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zdiffBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zdiff(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zdiffBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zdiff(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<string[], Context>;
-  zdiffBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zdiff(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<string[], Context>;
-  zdiffBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<Buffer[], Context>;
+  zdiff(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zdiffBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zdiff(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zdiffBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zdiff(
+    ...args: [numkeys: number | string, ...keys: RedisKey[]]
+  ): Result<string[], Context>;
+  zdiffBuffer(
+    ...args: [numkeys: number | string, ...keys: RedisKey[]]
+  ): Result<Buffer[], Context>;
+  zdiff(
+    ...args: [numkeys: number | string, keys: RedisKey[]]
+  ): Result<string[], Context>;
+  zdiffBuffer(
+    ...args: [numkeys: number | string, keys: RedisKey[]]
+  ): Result<Buffer[], Context>;
+  zdiff(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zdiffBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zdiff(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zdiffBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zdiff(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zdiffBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zdiff(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zdiffBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
 
   /**
    * Subtract multiple sorted sets and store the resulting sorted set in a new key
@@ -3605,10 +11531,32 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(L + (N-K)log(N)) worst case where L is the total number of elements in all the sets, N is the size of the first set, and K is the size of the result set.
    * - _since_: 6.2.0
    */
-  zdiffstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  zdiffstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  zdiffstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[]]): Result<number, Context>;
-  zdiffstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[]]): Result<number, Context>;
+  zdiffstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zdiffstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zdiffstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[]
+    ]
+  ): Result<number, Context>;
+  zdiffstore(
+    ...args: [destination: RedisKey, numkeys: number | string, keys: RedisKey[]]
+  ): Result<number, Context>;
 
   /**
    * Increment the score of a member in a sorted set
@@ -3616,8 +11564,18 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) where N is the number of elements in the sorted set.
    * - _since_: 1.2.0
    */
-  zincrby(key: RedisKey, increment: number | string, member: string | Buffer | number, callback?: Callback<string>): Result<string, Context>;
-  zincrbyBuffer(key: RedisKey, increment: number | string, member: string | Buffer | number, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  zincrby(
+    key: RedisKey,
+    increment: number | string,
+    member: string | Buffer | number,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  zincrbyBuffer(
+    key: RedisKey,
+    increment: number | string,
+    member: string | Buffer | number,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Intersect multiple sorted sets
@@ -3625,102 +11583,804 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.
    * - _since_: 6.2.0
    */
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[]]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[]]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[]]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[]]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[]]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[]]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zinter(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zinterBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [numkeys: number | string, ...keys: RedisKey[]]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [numkeys: number | string, ...keys: RedisKey[]]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [numkeys: number | string, keys: RedisKey[]]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [numkeys: number | string, keys: RedisKey[]]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [numkeys: number | string, ...args: RedisValue[]]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [numkeys: number | string, ...args: RedisValue[]]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zinter(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zinterBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
 
   /**
    * Intersect multiple sorted sets and return the cardinality of the result
@@ -3728,14 +12388,60 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N*K) worst case with N being the smallest input sorted set, K being the number of input sorted sets.
    * - _since_: 7.0.0
    */
-  zintercard(...args: [numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  zintercard(...args: [numkeys: number | string, keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  zintercard(...args: [numkeys: number | string, ...keys: (RedisKey)[]]): Result<number, Context>;
-  zintercard(...args: [numkeys: number | string, keys: (RedisKey)[]]): Result<number, Context>;
-  zintercard(...args: [numkeys: number | string, ...keys: (RedisKey)[], limitToken: 'LIMIT', limit: number | string, callback: Callback<number>]): Result<number, Context>;
-  zintercard(...args: [numkeys: number | string, keys: (RedisKey)[], limitToken: 'LIMIT', limit: number | string, callback: Callback<number>]): Result<number, Context>;
-  zintercard(...args: [numkeys: number | string, ...keys: (RedisKey)[], limitToken: 'LIMIT', limit: number | string]): Result<number, Context>;
-  zintercard(...args: [numkeys: number | string, keys: (RedisKey)[], limitToken: 'LIMIT', limit: number | string]): Result<number, Context>;
+  zintercard(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zintercard(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zintercard(
+    ...args: [numkeys: number | string, ...keys: RedisKey[]]
+  ): Result<number, Context>;
+  zintercard(
+    ...args: [numkeys: number | string, keys: RedisKey[]]
+  ): Result<number, Context>;
+  zintercard(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      limitToken: "LIMIT",
+      limit: number | string,
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zintercard(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      limitToken: "LIMIT",
+      limit: number | string,
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zintercard(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      limitToken: "LIMIT",
+      limit: number | string
+    ]
+  ): Result<number, Context>;
+  zintercard(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      limitToken: "LIMIT",
+      limit: number | string
+    ]
+  ): Result<number, Context>;
 
   /**
    * Intersect multiple sorted sets and store the resulting sorted set in a new key
@@ -3743,30 +12449,218 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.
    * - _since_: 2.0.0
    */
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[]]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[]]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[]]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<number>]): Result<number, Context>;
-  zinterstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[]
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [destination: RedisKey, numkeys: number | string, keys: RedisKey[]]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zinterstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<number, Context>;
 
   /**
    * Count the number of members in a sorted set between a given lexicographical range
@@ -3774,7 +12668,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)) with N being the number of elements in the sorted set.
    * - _since_: 2.8.9
    */
-  zlexcount(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  zlexcount(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Remove and return members with scores in a sorted set
@@ -3782,22 +12681,126 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(K) + O(N*log(M)) where K is the number of provided keys, N being the number of elements in the sorted set, and M being the number of elements popped.
    * - _since_: 7.0.0
    */
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN', callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN']): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN']): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], min: 'MIN', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX', callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX']): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX']): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string, callback: Callback<unknown>]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, ...keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
-  zmpop(...args: [numkeys: number | string, keys: (RedisKey)[], max: 'MAX', countToken: 'COUNT', count: number | string]): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      min: "MIN",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      min: "MIN",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [numkeys: number | string, ...keys: RedisKey[], min: "MIN"]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [numkeys: number | string, keys: RedisKey[], min: "MIN"]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      min: "MIN",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      min: "MIN",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      min: "MIN",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      min: "MIN",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      max: "MAX",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      max: "MAX",
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [numkeys: number | string, ...keys: RedisKey[], max: "MAX"]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [numkeys: number | string, keys: RedisKey[], max: "MAX"]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      max: "MAX",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      max: "MAX",
+      countToken: "COUNT",
+      count: number | string,
+      callback: Callback<unknown>
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      max: "MAX",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<unknown, Context>;
+  zmpop(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      max: "MAX",
+      countToken: "COUNT",
+      count: number | string
+    ]
+  ): Result<unknown, Context>;
 
   /**
    * Get the score associated with the given members in a sorted set
@@ -3805,14 +12808,46 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of members being requested.
    * - _since_: 6.2.0
    */
-  zmscore(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<(string | null)[]>]): Result<(string | null)[], Context>;
-  zmscoreBuffer(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<(Buffer | null)[]>]): Result<(Buffer | null)[], Context>;
-  zmscore(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<(string | null)[]>]): Result<(string | null)[], Context>;
-  zmscoreBuffer(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<(Buffer | null)[]>]): Result<(Buffer | null)[], Context>;
-  zmscore(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<(string | null)[], Context>;
-  zmscoreBuffer(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<(Buffer | null)[], Context>;
-  zmscore(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<(string | null)[], Context>;
-  zmscoreBuffer(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<(Buffer | null)[], Context>;
+  zmscore(
+    ...args: [
+      key: RedisKey,
+      ...members: (string | Buffer | number)[],
+      callback: Callback<(string | null)[]>
+    ]
+  ): Result<(string | null)[], Context>;
+  zmscoreBuffer(
+    ...args: [
+      key: RedisKey,
+      ...members: (string | Buffer | number)[],
+      callback: Callback<(Buffer | null)[]>
+    ]
+  ): Result<(Buffer | null)[], Context>;
+  zmscore(
+    ...args: [
+      key: RedisKey,
+      members: (string | Buffer | number)[],
+      callback: Callback<(string | null)[]>
+    ]
+  ): Result<(string | null)[], Context>;
+  zmscoreBuffer(
+    ...args: [
+      key: RedisKey,
+      members: (string | Buffer | number)[],
+      callback: Callback<(Buffer | null)[]>
+    ]
+  ): Result<(Buffer | null)[], Context>;
+  zmscore(
+    ...args: [key: RedisKey, ...members: (string | Buffer | number)[]]
+  ): Result<(string | null)[], Context>;
+  zmscoreBuffer(
+    ...args: [key: RedisKey, ...members: (string | Buffer | number)[]]
+  ): Result<(Buffer | null)[], Context>;
+  zmscore(
+    ...args: [key: RedisKey, members: (string | Buffer | number)[]]
+  ): Result<(string | null)[], Context>;
+  zmscoreBuffer(
+    ...args: [key: RedisKey, members: (string | Buffer | number)[]]
+  ): Result<(Buffer | null)[], Context>;
 
   /**
    * Remove and return members with the highest scores in a sorted set
@@ -3820,10 +12855,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)*M) with N being the number of elements in the sorted set, and M being the number of elements popped.
    * - _since_: 5.0.0
    */
-  zpopmax(key: RedisKey, callback?: Callback<string[]>): Result<string[], Context>;
-  zpopmaxBuffer(key: RedisKey, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zpopmax(key: RedisKey, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zpopmaxBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zpopmax(
+    key: RedisKey,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zpopmaxBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zpopmax(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zpopmaxBuffer(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Remove and return members with the lowest scores in a sorted set
@@ -3831,10 +12880,24 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)*M) with N being the number of elements in the sorted set, and M being the number of elements popped.
    * - _since_: 5.0.0
    */
-  zpopmin(key: RedisKey, callback?: Callback<string[]>): Result<string[], Context>;
-  zpopminBuffer(key: RedisKey, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zpopmin(key: RedisKey, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zpopminBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zpopmin(
+    key: RedisKey,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zpopminBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zpopmin(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zpopminBuffer(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Get one or multiple random elements from a sorted set
@@ -3842,12 +12905,36 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of elements returned
    * - _since_: 6.2.0
    */
-  zrandmember(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
-  zrandmemberBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
-  zrandmember(key: RedisKey, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrandmemberBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrandmember(key: RedisKey, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrandmemberBuffer(key: RedisKey, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrandmember(
+    key: RedisKey,
+    callback?: Callback<string | null>
+  ): Result<string | null, Context>;
+  zrandmemberBuffer(
+    key: RedisKey,
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
+  zrandmember(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrandmemberBuffer(
+    key: RedisKey,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrandmember(
+    key: RedisKey,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrandmemberBuffer(
+    key: RedisKey,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set
@@ -3855,54 +12942,446 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.
    * - _since_: 1.2.0
    */
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrange(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangeBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrange(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangeBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set, by lexicographical range
@@ -3910,10 +13389,36 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).
    * - _since_: 2.8.9
    */
-  zrangebylex(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangebylexBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrangebylex(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangebylexBuffer(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrangebylex(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangebylexBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrangebylex(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangebylexBuffer(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set, by score
@@ -3921,14 +13426,70 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).
    * - _since_: 1.0.5
    */
-  zrangebyscore(key: RedisKey, min: number | string, max: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrangebyscore(key: RedisKey, min: number | string, max: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrangebyscore(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrangebyscore(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrangebyscoreBuffer(key: RedisKey, min: number | string, max: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrangebyscore(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangebyscoreBuffer(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrangebyscore(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangebyscoreBuffer(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrangebyscore(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangebyscoreBuffer(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrangebyscore(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    withscores: "WITHSCORES",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrangebyscoreBuffer(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    withscores: "WITHSCORES",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Store a range of members from sorted set into another key
@@ -3936,18 +13497,122 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements stored into the destination key.
    * - _since_: 6.2.0
    */
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, byscore: 'BYSCORE', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', callback?: Callback<number>): Result<number, Context>;
-  zrangestore(dst: RedisKey, src: RedisKey, min: string | Buffer | number, max: string | Buffer | number, bylex: 'BYLEX', rev: 'REV', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<number>): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    byscore: "BYSCORE",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  zrangestore(
+    dst: RedisKey,
+    src: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    bylex: "BYLEX",
+    rev: "REV",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Determine the index of a member in a sorted set
@@ -3955,7 +13620,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N))
    * - _since_: 2.0.0
    */
-  zrank(key: RedisKey, member: string | Buffer | number, callback?: Callback<number | null>): Result<number | null, Context>;
+  zrank(
+    key: RedisKey,
+    member: string | Buffer | number,
+    callback?: Callback<number | null>
+  ): Result<number | null, Context>;
 
   /**
    * Remove one or more members from a sorted set
@@ -3963,10 +13632,26 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(M*log(N)) with N being the number of elements in the sorted set and M the number of elements to be removed.
    * - _since_: 1.2.0
    */
-  zrem(...args: [key: RedisKey, ...members: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zrem(...args: [key: RedisKey, members: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
-  zrem(...args: [key: RedisKey, ...members: (string | Buffer | number)[]]): Result<number, Context>;
-  zrem(...args: [key: RedisKey, members: (string | Buffer | number)[]]): Result<number, Context>;
+  zrem(
+    ...args: [
+      key: RedisKey,
+      ...members: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zrem(
+    ...args: [
+      key: RedisKey,
+      members: (string | Buffer | number)[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zrem(
+    ...args: [key: RedisKey, ...members: (string | Buffer | number)[]]
+  ): Result<number, Context>;
+  zrem(
+    ...args: [key: RedisKey, members: (string | Buffer | number)[]]
+  ): Result<number, Context>;
 
   /**
    * Remove all members in a sorted set between the given lexicographical range
@@ -3974,7 +13659,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.
    * - _since_: 2.8.9
    */
-  zremrangebylex(key: RedisKey, min: string | Buffer | number, max: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  zremrangebylex(
+    key: RedisKey,
+    min: string | Buffer | number,
+    max: string | Buffer | number,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Remove all members in a sorted set within the given indexes
@@ -3982,7 +13672,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.
    * - _since_: 2.0.0
    */
-  zremrangebyrank(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<number>): Result<number, Context>;
+  zremrangebyrank(
+    key: RedisKey,
+    start: number | string,
+    stop: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Remove all members in a sorted set within the given scores
@@ -3990,7 +13685,12 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements removed by the operation.
    * - _since_: 1.2.0
    */
-  zremrangebyscore(key: RedisKey, min: number | string, max: number | string, callback?: Callback<number>): Result<number, Context>;
+  zremrangebyscore(
+    key: RedisKey,
+    min: number | string,
+    max: number | string,
+    callback?: Callback<number>
+  ): Result<number, Context>;
 
   /**
    * Return a range of members in a sorted set, by index, with scores ordered from high to low
@@ -3998,10 +13698,32 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements returned.
    * - _since_: 1.2.0
    */
-  zrevrange(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangeBuffer(key: RedisKey, start: number | string, stop: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrevrange(key: RedisKey, start: number | string, stop: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangeBuffer(key: RedisKey, start: number | string, stop: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrevrange(
+    key: RedisKey,
+    start: number | string,
+    stop: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrevrangeBuffer(
+    key: RedisKey,
+    start: number | string,
+    stop: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrevrange(
+    key: RedisKey,
+    start: number | string,
+    stop: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrevrangeBuffer(
+    key: RedisKey,
+    start: number | string,
+    stop: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set, by lexicographical range, ordered from higher to lower strings.
@@ -4009,10 +13731,36 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).
    * - _since_: 2.8.9
    */
-  zrevrangebylex(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangebylexBuffer(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrevrangebylex(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangebylexBuffer(key: RedisKey, max: string | Buffer | number, min: string | Buffer | number, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrevrangebylex(
+    key: RedisKey,
+    max: string | Buffer | number,
+    min: string | Buffer | number,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrevrangebylexBuffer(
+    key: RedisKey,
+    max: string | Buffer | number,
+    min: string | Buffer | number,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrevrangebylex(
+    key: RedisKey,
+    max: string | Buffer | number,
+    min: string | Buffer | number,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrevrangebylexBuffer(
+    key: RedisKey,
+    max: string | Buffer | number,
+    min: string | Buffer | number,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Return a range of members in a sorted set, by score, with scores ordered from high to low
@@ -4020,14 +13768,70 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N)+M) with N being the number of elements in the sorted set and M the number of elements being returned. If M is constant (e.g. always asking for the first 10 elements with LIMIT), you can consider it O(log(N)).
    * - _since_: 2.2.0
    */
-  zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
-  zrevrangebyscore(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
-  zrevrangebyscoreBuffer(key: RedisKey, max: number | string, min: number | string, withscores: 'WITHSCORES', offsetCountToken: 'LIMIT', offset: number | string, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  zrevrangebyscore(
+    key: RedisKey,
+    max: number | string,
+    min: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrevrangebyscoreBuffer(
+    key: RedisKey,
+    max: number | string,
+    min: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrevrangebyscore(
+    key: RedisKey,
+    max: number | string,
+    min: number | string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrevrangebyscoreBuffer(
+    key: RedisKey,
+    max: number | string,
+    min: number | string,
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrevrangebyscore(
+    key: RedisKey,
+    max: number | string,
+    min: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrevrangebyscoreBuffer(
+    key: RedisKey,
+    max: number | string,
+    min: number | string,
+    withscores: "WITHSCORES",
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
+  zrevrangebyscore(
+    key: RedisKey,
+    max: number | string,
+    min: number | string,
+    withscores: "WITHSCORES",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<string[]>
+  ): Result<string[], Context>;
+  zrevrangebyscoreBuffer(
+    key: RedisKey,
+    max: number | string,
+    min: number | string,
+    withscores: "WITHSCORES",
+    offsetCountToken: "LIMIT",
+    offset: number | string,
+    count: number | string,
+    callback?: Callback<Buffer[]>
+  ): Result<Buffer[], Context>;
 
   /**
    * Determine the index of a member in a sorted set, with scores ordered from high to low
@@ -4035,7 +13839,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(log(N))
    * - _since_: 2.0.0
    */
-  zrevrank(key: RedisKey, member: string | Buffer | number, callback?: Callback<number | null>): Result<number | null, Context>;
+  zrevrank(
+    key: RedisKey,
+    member: string | Buffer | number,
+    callback?: Callback<number | null>
+  ): Result<number | null, Context>;
 
   /**
    * Incrementally iterate sorted sets elements and associated scores
@@ -4043,14 +13851,62 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1) for every call. O(N) for a complete iteration, including enough command calls for the cursor to return back to 0. N is the number of elements inside the collection..
    * - _since_: 2.8.0
    */
-  zscan(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  zscanBuffer(key: RedisKey, cursor: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  zscan(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  zscanBuffer(key: RedisKey, cursor: number | string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  zscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  zscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
-  zscan(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: string, elements: string[]]>): Result<[cursor: string, elements: string[]], Context>;
-  zscanBuffer(key: RedisKey, cursor: number | string, patternToken: 'MATCH', pattern: string, countToken: 'COUNT', count: number | string, callback?: Callback<[cursor: Buffer, elements: Buffer[]]>): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(
+    key: RedisKey,
+    cursor: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(
+    key: RedisKey,
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
+  zscan(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: string, elements: string[]]>
+  ): Result<[cursor: string, elements: string[]], Context>;
+  zscanBuffer(
+    key: RedisKey,
+    cursor: number | string,
+    patternToken: "MATCH",
+    pattern: string,
+    countToken: "COUNT",
+    count: number | string,
+    callback?: Callback<[cursor: Buffer, elements: Buffer[]]>
+  ): Result<[cursor: Buffer, elements: Buffer[]], Context>;
 
   /**
    * Get the score associated with the given member in a sorted set
@@ -4058,8 +13914,16 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1)
    * - _since_: 1.2.0
    */
-  zscore(key: RedisKey, member: string | Buffer | number, callback?: Callback<string>): Result<string, Context>;
-  zscoreBuffer(key: RedisKey, member: string | Buffer | number, callback?: Callback<Buffer>): Result<Buffer, Context>;
+  zscore(
+    key: RedisKey,
+    member: string | Buffer | number,
+    callback?: Callback<string>
+  ): Result<string, Context>;
+  zscoreBuffer(
+    key: RedisKey,
+    member: string | Buffer | number,
+    callback?: Callback<Buffer>
+  ): Result<Buffer, Context>;
 
   /**
    * Add multiple sorted sets
@@ -4067,102 +13931,804 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N)+O(M*log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.
    * - _since_: 6.2.0
    */
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[]]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[]]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[]]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[]]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[]]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[]]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<string[]>]): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES', callback: Callback<Buffer[]>]): Result<Buffer[], Context>;
-  zunion(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<string[], Context>;
-  zunionBuffer(...args: [numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', withscores: 'WITHSCORES']): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [numkeys: number | string, ...keys: RedisKey[]]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [numkeys: number | string, ...keys: RedisKey[]]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [numkeys: number | string, keys: RedisKey[]]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [numkeys: number | string, keys: RedisKey[]]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [numkeys: number | string, ...args: RedisValue[]]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [numkeys: number | string, ...args: RedisValue[]]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<string[]>
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES",
+      callback: Callback<Buffer[]>
+    ]
+  ): Result<Buffer[], Context>;
+  zunion(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<string[], Context>;
+  zunionBuffer(
+    ...args: [
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      withscores: "WITHSCORES"
+    ]
+  ): Result<Buffer[], Context>;
 
   /**
    * Add multiple sorted sets and store the resulting sorted set in a new key
@@ -4170,30 +14736,218 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N)+O(M log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.
    * - _since_: 2.0.0
    */
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[]]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[]]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, keys: (RedisKey)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[]]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM', callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', sum: 'SUM']): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN', callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', min: 'MIN']): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX', callback: Callback<number>]): Result<number, Context>;
-  zunionstore(...args: [destination: RedisKey, numkeys: number | string, ...args: (RedisValue)[], aggregate: 'AGGREGATE', max: 'MAX']): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[]
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [destination: RedisKey, numkeys: number | string, keys: RedisKey[]]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      keys: RedisKey[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[]
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      sum: "SUM"
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      min: "MIN"
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX",
+      callback: Callback<number>
+    ]
+  ): Result<number, Context>;
+  zunionstore(
+    ...args: [
+      destination: RedisKey,
+      numkeys: number | string,
+      ...args: RedisValue[],
+      aggregate: "AGGREGATE",
+      max: "MAX"
+    ]
+  ): Result<number, Context>;
 }
 
 export default RedisCommander;

--- a/test-d/commands.test-d.ts
+++ b/test-d/commands.test-d.ts
@@ -30,7 +30,6 @@ expectError(redis.get("key", "bar"));
 // SET
 expectType<Promise<"OK">>(redis.set("key", "bar"));
 expectType<Promise<"OK">>(redis.set("key", "bar", "EX", 100));
-expectError(redis.set("key", "bar", "EX", "NX"));
 expectType<Promise<"OK" | null>>(redis.set("key", "bar", "EX", 100, "NX")); // NX can fail thus `null` is returned
 expectType<Promise<string | null>>(redis.set("key", "bar", "GET"));
 
@@ -61,9 +60,16 @@ expectType<Promise<number[]>>(
   redis.lpos("key", "element", "RANK", -1, "COUNT", 2)
 );
 
+// LMISMEMBER
+expectType<Promise<number[]>>(redis.smismember("key", "e1", "e2"));
+
 // ZADD
 expectType<Promise<number>>(redis.zadd("key", 1, "member"));
 expectType<Promise<number>>(redis.zadd("key", "CH", 1, "member"));
+
+// ZRANDMEMBER
+expectType<Promise<string | null>>(redis.zrandmember("key"));
+expectType<Promise<string[]>>(redis.zrandmember("key", 20));
 
 // GETRANGE
 expectType<Promise<Buffer>>(redis.getrangeBuffer("foo", 0, 1));


### PR DESCRIPTION
Closes #1429.

Changes:

1. Improved typings for `smismember` so it returns `number[]` instead of `unknown[]`.
2. Improved typings for`geopos`, `lmpop`, `blmpop`, `bzpopmin`, `bzpopmax`, and `xread`.
3. Make the declaration order stable to make further diffs easier.
5. Make numeric parameters also accept strings. Otherwise, it was a little tricky to figure out where the issue was (the correct fix was to change `'1000'` to `1000`):

<img width="1008" alt="CleanShot 2022-03-15 at 13 08 26@2x" src="https://user-images.githubusercontent.com/635902/158310667-58b7db34-ac6c-42dc-9871-17109808f321.png">
