### PR TITLE
fix: improve typing compatibility with @types/ioredis

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -48,6 +48,14 @@ type OfflineQueueItem = {
   node: unknown;
 };
 
+export type ClusterNode =
+  | string
+  | number
+  | {
+      host?: string | undefined;
+      port?: number | undefined;
+    };
+
 type ClusterStatus =
   | "end"
   | "close"
@@ -106,10 +114,7 @@ class Cluster extends Commander {
   /**
    * Creates an instance of Cluster.
    */
-  constructor(
-    startupNodes: (string | number | object)[],
-    options: ClusterOptions = {}
-  ) {
+  constructor(startupNodes: ClusterNode[], options: ClusterOptions = {}) {
     super();
     EventEmitter.call(this);
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -52,6 +52,9 @@ export {
 } from "./connectors/SentinelConnector";
 export { StandaloneConnectionOptions } from "./connectors/StandaloneConnector";
 export { RedisOptions, CommonRedisOptions } from "./redis/RedisOptions";
+export { ClusterNode } from "./cluster";
+export { ClusterOptions } from "./cluster/ClusterOptions";
+export { NodeRole } from "./cluster/util";
 
 // No TS typings
 export const ReplyError = require("redis-errors").ReplyError;


### PR DESCRIPTION
Expose typings that @types/ioredis exports so users don't need to define their own. No prod code changes.