### PR TITLE
Loosen callback typings

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -773,7 +773,7 @@ class Redis extends Commander {
           );
           return callback(null, {});
         }
-        return callback(err);
+        return callback(err, undefined);
       }
       if (typeof res !== "string") {
         return callback(null, res);

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -827,7 +827,7 @@ class Cluster extends Commander {
 
     duplicatedConnection.cluster(
       "SLOTS",
-      timeout((err: Error, result) => {
+      timeout((err, result) => {
         duplicatedConnection.disconnect();
         if (err) {
           return callback(err);
@@ -842,7 +842,7 @@ class Cluster extends Commander {
             result.length,
             this.status
           );
-          callback();
+          callback(null);
           return;
         }
         const nodes: RedisOptions[] = [];
@@ -900,7 +900,7 @@ class Cluster extends Commander {
         }
 
         this.connectionPool.reset(nodes);
-        callback();
+        callback(null);
       }, this.options.slotsRefreshTimeout)
     );
   }
@@ -922,7 +922,7 @@ class Cluster extends Commander {
         return callback(err);
       }
       if (typeof res !== "string") {
-        return callback();
+        return callback(null);
       }
 
       let state: string;
@@ -939,7 +939,7 @@ class Cluster extends Commander {
         debug("cluster state not ok (%s)", state);
         callback(null, state);
       } else {
-        callback();
+        callback(null);
       }
     });
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,7 +1,7 @@
 import { Socket } from "net";
 import { TLSSocket } from "tls";
 
-export type Callback<T = any> = (err?: Error | null, result?: T) => void;
+export type Callback<T = any> = (err: Error | null, result: T) => void;
 export type NetStream = Socket | TLSSocket;
 
 export type CommandParameter = string | Buffer | number | any[];

--- a/test/typing/commands.test-d.ts
+++ b/test/typing/commands.test-d.ts
@@ -10,21 +10,21 @@ expectType<Promise<unknown>>(redis.call("set", ["foo", "bar"]));
 expectType<Promise<unknown>>(redis.callBuffer("set", ["foo", "bar"]));
 expectType<Promise<unknown>>(
   redis.call("set", ["foo", "bar"], (err, value) => {
-    expectType<Error | undefined | null>(err);
+    expectType<Error | null>(err);
     expectType<unknown | undefined>(value);
   })
 );
 
 expectType<Promise<unknown>>(
   redis.call("get", "foo", (err, value) => {
-    expectType<Error | undefined | null>(err);
+    expectType<Error | null>(err);
     expectType<unknown | undefined>(value);
   })
 );
 
 expectType<Promise<unknown>>(
   redis.call("info", (err, value) => {
-    expectType<Error | undefined | null>(err);
+    expectType<Error | null>(err);
     expectType<unknown | undefined>(value);
   })
 );
@@ -83,26 +83,26 @@ expectType<Promise<Buffer>>(redis.getrangeBuffer("foo", 0, 1));
 
 // Callbacks
 redis.getBuffer("foo", (err, res) => {
-  expectType<Error | null | undefined>(err);
-  expectType<Buffer | null | undefined>(res);
+  expectType<Error | null>(err);
+  expectType<Buffer | null>(res);
 });
 
 redis.set("foo", "bar", (err, res) => {
-  expectType<Error | null | undefined>(err);
-  expectType<"OK" | undefined>(res);
+  expectType<Error | null>(err);
+  expectType<"OK">(res);
 });
 
 redis.set("foo", "bar", "GET", (err, res) => {
-  expectType<Error | null | undefined>(err);
-  expectType<string | null | undefined>(res);
+  expectType<Error | null>(err);
+  expectType<string | null>(res);
 });
 
 redis.del("key1", "key2", (err, res) => {
-  expectType<Error | null | undefined>(err);
-  expectType<number | undefined>(res);
+  expectType<Error | null>(err);
+  expectType<number>(res);
 });
 
 redis.del(["key1", "key2"], (err, res) => {
-  expectType<Error | null | undefined>(err);
-  expectType<number | undefined>(res);
+  expectType<Error | null>(err);
+  expectType<number>(res);
 });


### PR DESCRIPTION
In @types/ioredis, callbacks are defined as `(err: Error | null, res: T) => void`, whereas in ioredis v5, they are `(err?: Error | null, res?: T) => void`.

The intention was to indicate the `res` can be absent when there is an error. However, given TypeScript doesn't provide a way to achieve "if there is no error, then res should be fulfilled, developers will need to check `res` in every callback even if they have already checked `err`:

```ts
return new Promise((resolve, reject) => {
  redis.get('foo', (err, res) => {
    if (err) reject(err);
    // Can't use `else` here
    if (typeof res !== 'undefined') resolve(res);
  });
});
```

I feel it's a bit inconvenient, and apparently, people have different opinions on it: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43583.

I lean towards keeping in line with the Node.js way: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/884d68c/types/node/fs.d.ts#L2416 though no strong opinion.

Open to any suggestions! 😄 