### PR TITLE
fix: support TypeScript interface as parameters of hmset and mset

### DIFF
--- a/bin/overrides.js
+++ b/bin/overrides.js
@@ -1,8 +1,7 @@
 const msetOverrides = {
   overwrite: false,
   defs: [
-    "$1(object: Record<string, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>",
-    "$1(map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>",
+    "$1(object: object, callback?: Callback<'OK'>): Result<'OK', Context>",
   ],
 };
 
@@ -19,15 +18,13 @@ module.exports = {
   hset: {
     overwrite: false,
     defs: [
-      "$1(key: RedisKey, object: Record<string, string | Buffer | number>, callback?: Callback<number>): Result<number, Context>",
-      "$1(key: RedisKey, map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<number>): Result<number, Context>",
+      "$1(key: RedisKey, object: object, callback?: Callback<number>): Result<number, Context>",
     ],
   },
   hmset: {
     overwrite: false,
     defs: [
-      "$1(key: RedisKey, object: Record<string, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>",
-      "$1(key: RedisKey, map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>",
+      "$1(key: RedisKey, object: object, callback?: Callback<'OK'>): Result<'OK', Context>",
     ],
   },
   exec: {

--- a/bin/overrides.js
+++ b/bin/overrides.js
@@ -2,6 +2,7 @@ const msetOverrides = {
   overwrite: false,
   defs: [
     "$1(object: object, callback?: Callback<'OK'>): Result<'OK', Context>",
+    "$1(map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>",
   ],
 };
 
@@ -19,12 +20,14 @@ module.exports = {
     overwrite: false,
     defs: [
       "$1(key: RedisKey, object: object, callback?: Callback<number>): Result<number, Context>",
+      "$1(key: RedisKey, map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<number>): Result<number, Context>",
     ],
   },
   hmset: {
     overwrite: false,
     defs: [
       "$1(key: RedisKey, object: object, callback?: Callback<'OK'>): Result<'OK', Context>",
+      "$1(key: RedisKey, map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>",
     ],
   },
   exec: {

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -4284,6 +4284,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
     callback?: Callback<"OK">
   ): Result<"OK", Context>;
   hmset(
+    key: RedisKey,
+    map: Map<string | Buffer | number, string | Buffer | number>,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  hmset(
     ...args: [
       key: RedisKey,
       ...fieldValues: (string | Buffer | number)[],
@@ -4403,6 +4408,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   hset(
     key: RedisKey,
     object: object,
+    callback?: Callback<number>
+  ): Result<number, Context>;
+  hset(
+    key: RedisKey,
+    map: Map<string | Buffer | number, string | Buffer | number>,
     callback?: Callback<number>
   ): Result<number, Context>;
   hset(
@@ -5505,6 +5515,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   mset(object: object, callback?: Callback<"OK">): Result<"OK", Context>;
   mset(
+    map: Map<string | Buffer | number, string | Buffer | number>,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
+  mset(
     ...args: [
       ...keyValues: (RedisKey | string | Buffer | number)[],
       callback: Callback<"OK">
@@ -5521,6 +5535,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 1.0.1
    */
   msetnx(object: object, callback?: Callback<"OK">): Result<"OK", Context>;
+  msetnx(
+    map: Map<string | Buffer | number, string | Buffer | number>,
+    callback?: Callback<"OK">
+  ): Result<"OK", Context>;
   msetnx(
     ...args: [
       ...keyValues: (RedisKey | string | Buffer | number)[],

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -4280,12 +4280,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   hmset(
     key: RedisKey,
-    object: Record<string, string | Buffer | number>,
-    callback?: Callback<"OK">
-  ): Result<"OK", Context>;
-  hmset(
-    key: RedisKey,
-    map: Map<string | Buffer | number, string | Buffer | number>,
+    object: object,
     callback?: Callback<"OK">
   ): Result<"OK", Context>;
   hmset(
@@ -4407,12 +4402,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    */
   hset(
     key: RedisKey,
-    object: Record<string, string | Buffer | number>,
-    callback?: Callback<number>
-  ): Result<number, Context>;
-  hset(
-    key: RedisKey,
-    map: Map<string | Buffer | number, string | Buffer | number>,
+    object: object,
     callback?: Callback<number>
   ): Result<number, Context>;
   hset(
@@ -5513,14 +5503,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of keys to set.
    * - _since_: 1.0.1
    */
-  mset(
-    object: Record<string, string | Buffer | number>,
-    callback?: Callback<"OK">
-  ): Result<"OK", Context>;
-  mset(
-    map: Map<string | Buffer | number, string | Buffer | number>,
-    callback?: Callback<"OK">
-  ): Result<"OK", Context>;
+  mset(object: object, callback?: Callback<"OK">): Result<"OK", Context>;
   mset(
     ...args: [
       ...keyValues: (RedisKey | string | Buffer | number)[],
@@ -5537,14 +5520,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(N) where N is the number of keys to set.
    * - _since_: 1.0.1
    */
-  msetnx(
-    object: Record<string, string | Buffer | number>,
-    callback?: Callback<"OK">
-  ): Result<"OK", Context>;
-  msetnx(
-    map: Map<string | Buffer | number, string | Buffer | number>,
-    callback?: Callback<"OK">
-  ): Result<"OK", Context>;
+  msetnx(object: object, callback?: Callback<"OK">): Result<"OK", Context>;
   msetnx(
     ...args: [
       ...keyValues: (RedisKey | string | Buffer | number)[],

--- a/test/functional/transformer.ts
+++ b/test/functional/transformer.ts
@@ -11,13 +11,20 @@ describe("transformer", () => {
         expect(await redis.hget("foo", "b")).to.eql("2");
       });
 
-      it("should support Map", async () => {
+      it("should support Map with string keys", async () => {
         const redis = new Redis();
         const map = new Map();
         map.set("a", 1);
         map.set("b", "2");
+        map.set(42, true);
+        map.set(Buffer.from("buffer"), "utf8");
+        map.set(Buffer.from([0xff]), "binary");
         expect(await redis.hmset("foo", map)).to.eql("OK");
+        expect(await redis.hget("foo", "a")).to.eql("1");
         expect(await redis.hget("foo", "b")).to.eql("2");
+        expect(await redis.hget("foo", "42")).to.eql("true");
+        expect(await redis.hget("foo", "buffer")).to.eql("utf8");
+        expect(await redis.hget("foo", Buffer.from([0xff]))).to.eql("binary");
       });
 
       it("should not affect the old way", async () => {

--- a/test/functional/transformer.ts
+++ b/test/functional/transformer.ts
@@ -5,85 +5,56 @@ import { expect } from "chai";
 describe("transformer", () => {
   describe("default transformer", () => {
     describe("hmset", () => {
-      it("should support object", (done) => {
+      it("should support object", async () => {
         const redis = new Redis();
-        redis.hmset("foo", { a: 1, b: "2" }, function (err, result) {
-          expect(result).to.eql("OK");
-          redis.hget("foo", "b", function (err, result) {
-            expect(result).to.eql("2");
-            done();
-          });
-        });
+        expect(await redis.hmset("foo", { a: 1, b: "2" })).to.eql("OK");
+        expect(await redis.hget("foo", "b")).to.eql("2");
       });
-      it("should support Map", (done) => {
+
+      it("should support Map", async () => {
         const redis = new Redis();
         const map = new Map();
         map.set("a", 1);
         map.set("b", "2");
-        redis.hmset("foo", map, function (err, result) {
-          expect(result).to.eql("OK");
-          redis.hget("foo", "b", function (err, result) {
-            expect(result).to.eql("2");
-            done();
-          });
-        });
+        expect(await redis.hmset("foo", map)).to.eql("OK");
+        expect(await redis.hget("foo", "b")).to.eql("2");
       });
-      it("should not affect the old way", (done) => {
+
+      it("should not affect the old way", async () => {
         const redis = new Redis();
-        redis.hmset("foo", "a", 1, "b", "2", function (err, result) {
-          expect(result).to.eql("OK");
-          redis.hget("foo", "b", function (err, result) {
-            expect(result).to.eql("2");
-            done();
-          });
-        });
+        expect(await redis.hmset("foo", "a", 1, "b", "2")).to.eql("OK");
+        expect(await redis.hget("foo", "b")).to.eql("2");
       });
     });
 
     describe("mset", () => {
-      it("should support object", (done) => {
+      it("should support object", async () => {
         const redis = new Redis();
-        redis.mset({ a: 1, b: "2" }, function (err, result) {
-          expect(result).to.eql("OK");
-          redis.mget("a", "b", function (err, result) {
-            expect(result).to.eql(["1", "2"]);
-            done();
-          });
-        });
+        expect(await redis.mset({ a: 1, b: "2" })).to.eql("OK");
+        expect(await redis.mget("a", "b")).to.eql(["1", "2"]);
       });
-      it("should support Map", (done) => {
+
+      it("should support Map", async () => {
         const redis = new Redis();
         const map = new Map();
         map.set("a", 1);
         map.set("b", "2");
-        redis.mset(map, function (err, result) {
-          expect(result).to.eql("OK");
-          redis.mget("a", "b", function (err, result) {
-            expect(result).to.eql(["1", "2"]);
-            done();
-          });
-        });
+        expect(await redis.mset(map)).to.eql("OK");
+        expect(await redis.mget("a", "b")).to.eql(["1", "2"]);
       });
-      it("should not affect the old way", (done) => {
+
+      it("should not affect the old way", async () => {
         const redis = new Redis();
-        redis.mset("a", 1, "b", "2", function (err, result) {
-          expect(result).to.eql("OK");
-          redis.mget("a", "b", function (err, result) {
-            expect(result).to.eql(["1", "2"]);
-            done();
-          });
-        });
+        expect(await redis.mset("a", 1, "b", "2")).to.eql("OK");
+        expect(await redis.mget("a", "b")).to.eql(["1", "2"]);
       });
-      it("should work with keyPrefix option", (done) => {
+
+      it("should work with keyPrefix option", async () => {
         const redis = new Redis({ keyPrefix: "foo:" });
-        redis.mset({ a: 1, b: "2" }, function (err, result) {
-          expect(result).to.eql("OK");
-          const otherRedis = new Redis();
-          otherRedis.mget("foo:a", "foo:b", function (err, result) {
-            expect(result).to.eql(["1", "2"]);
-            done();
-          });
-        });
+        expect(await redis.mset({ a: 1, b: "2" })).to.eql("OK");
+
+        const otherRedis = new Redis();
+        expect(await otherRedis.mget("foo:a", "foo:b")).to.eql(["1", "2"]);
       });
     });
 

--- a/test/typing/transformers.test-d.ts
+++ b/test/typing/transformers.test-d.ts
@@ -7,25 +7,45 @@ interface User {
 }
 
 const user: User = { name: "Bob", title: "Engineer" };
-const map = new Map([["key", "value"]]);
+const stringMap = new Map([["key", "value"]]);
+const numberMap = new Map([[42, "value"]]);
+const bufferMap = new Map([[Buffer.from([0xff]), "value"]]);
+const mixedMap = new Map<string | Buffer | number, string>([
+  [Buffer.from([0xff]), "value"],
+  [42, "value"],
+  ["field", "value"],
+]);
 
 const redis = new Redis();
 
 // mset
+expectType<Promise<"OK">>(redis.mset("key1", "value1", "key2", "value2"));
 expectType<Promise<"OK">>(redis.mset(user));
-expectType<Promise<"OK">>(redis.mset(map));
+expectType<Promise<"OK">>(redis.mset(stringMap));
+expectType<Promise<"OK">>(redis.mset(numberMap));
+expectType<Promise<"OK">>(redis.mset(bufferMap));
+expectType<Promise<"OK">>(redis.mset(mixedMap));
 
 // msetnx
 expectType<Promise<"OK">>(redis.msetnx(user));
-expectType<Promise<"OK">>(redis.msetnx(map));
+expectType<Promise<"OK">>(redis.msetnx(stringMap));
+expectType<Promise<"OK">>(redis.msetnx(numberMap));
+expectType<Promise<"OK">>(redis.msetnx(bufferMap));
+expectType<Promise<"OK">>(redis.msetnx(mixedMap));
 
 // hmset
 expectType<Promise<"OK">>(redis.hmset("key", user));
-expectType<Promise<"OK">>(redis.hmset("key", map));
+expectType<Promise<"OK">>(redis.hmset("key", stringMap));
+expectType<Promise<"OK">>(redis.hmset("key", numberMap));
+expectType<Promise<"OK">>(redis.hmset("key", bufferMap));
+expectType<Promise<"OK">>(redis.hmset("key", mixedMap));
 
 // hset
 expectType<Promise<number>>(redis.hset("key", user));
-expectType<Promise<number>>(redis.hset("key", map));
+expectType<Promise<number>>(redis.hset("key", stringMap));
+expectType<Promise<number>>(redis.hset("key", numberMap));
+expectType<Promise<number>>(redis.hset("key", bufferMap));
+expectType<Promise<number>>(redis.hset("key", mixedMap));
 
 // hgetall
 expectType<Promise<Record<string, string>>>(redis.hgetall("key"));

--- a/test/typing/transformers.test-d.ts
+++ b/test/typing/transformers.test-d.ts
@@ -1,0 +1,31 @@
+import { expectType } from "tsd";
+import Redis from "../../built";
+
+interface User {
+  name: string;
+  title: string;
+}
+
+const user: User = { name: "Bob", title: "Engineer" };
+const map = new Map([["key", "value"]]);
+
+const redis = new Redis();
+
+// mset
+expectType<Promise<"OK">>(redis.mset(user));
+expectType<Promise<"OK">>(redis.mset(map));
+
+// msetnx
+expectType<Promise<"OK">>(redis.msetnx(user));
+expectType<Promise<"OK">>(redis.msetnx(map));
+
+// hmset
+expectType<Promise<"OK">>(redis.hmset("key", user));
+expectType<Promise<"OK">>(redis.hmset("key", map));
+
+// hset
+expectType<Promise<number>>(redis.hset("key", user));
+expectType<Promise<number>>(redis.hset("key", map));
+
+// hgetall
+expectType<Promise<Record<string, string>>>(redis.hgetall("key"));


### PR DESCRIPTION
Closes #1536

There is a limit on the TypeScript side https://github.com/microsoft/TypeScript/issues/15300#issuecomment-891681234 that you can't assign an interface to a record:

```ts
interface User {
  name: string;
  age: string;
}

let newUser: User = {
  name: "suman",
  age: "34",
};

const record: Record<string, string> = newUser; // Error here
```

Given `hmset` and `mset` already support ES6 `Map`, I think it's should be fine to loosen the typing here for convenience.

It's possible that developers may pass invalid object values (e.g. `redis.hmset("user-hash", new WeakMap([[{ name: "Bob" }, "value"]]))`) but I think that's fine since the usage doesn't make sense and it will trigger an runtime error anyway.