### PR TITLE
Update redis sentinel doc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Supports Redis >= 2.6.12 and (Node.js >= 12.22.0). Completely compatible with Re
 ioredis is a robust, full-featured Redis client that is
 used in the world's biggest online commerce company [Alibaba](http://www.alibaba.com/) and many other awesome companies.
 
-0. Full-featured. It supports [Cluster](http://redis.io/topics/cluster-tutorial), [Sentinel](http://redis.io/topics/sentinel), [Streams](https://redis.io/topics/streams-intro), [Pipelining](http://redis.io/topics/pipelining), and of course [Lua scripting](http://redis.io/commands/eval), [Redis Functions](https://redis.io/topics/functions-intro), [Pub/Sub](http://redis.io/topics/pubsub) (with the support of binary messages).
+0. Full-featured. It supports [Cluster](http://redis.io/topics/cluster-tutorial), [Sentinel](https://redis.io/docs/reference/sentinel-clients), [Streams](https://redis.io/topics/streams-intro), [Pipelining](http://redis.io/topics/pipelining), and of course [Lua scripting](http://redis.io/commands/eval), [Redis Functions](https://redis.io/topics/functions-intro), [Pub/Sub](http://redis.io/topics/pubsub) (with the support of binary messages).
 0. High performance 🚀.
 0. Delightful API 😄. It works with Node callbacks and Native promises.
 0. Transformation of command arguments and replies.


### PR DESCRIPTION
The current Redis sentinel url in README not working and you encounter a 404 page on the Redis documentation website and the Sentinel documents URL has changed which I updated the README.