### PR TITLE
Remove instruction to install @types/node

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,6 @@ Medis starts with all the basic features you need:
 $ npm install ioredis
 ```
 
-In a TypeScript project, you may want to add TypeScript declarations for Node.js:
-
-```shell
-$ npm install --save-dev @types/node
-```
-
 ## Basic Usage
 
 ```javascript


### PR DESCRIPTION
The [upgrade guide](https://github.com/luin/ioredis/wiki/Upgrading-from-v4-to-v5) says that v5 provides TypeScript declarations officially so you can uninstall the types