### PR TITLE
Hook up the keepAlive after a successful connect

### DIFF
--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -165,14 +165,15 @@ export default class SentinelConnector extends AbstractConnector {
           resolved.port,
           endpointAddress
         );
+
         if (this.options.enableTLSForSentinelMode && this.options.tls) {
           Object.assign(resolved, this.options.tls);
           this.stream = createTLSConnection(resolved);
+          this.stream.once("secureConnect", this.initFailoverDetector.bind(this));
         } else {
           this.stream = createConnection(resolved);
+          this.stream.once("connect", this.initFailoverDetector.bind(this));
         }
-
-        this.stream.once("connect", () => this.initFailoverDetector());
 
         this.stream.once("error", (err) => {
           this.firstError = err;

--- a/lib/connectors/StandaloneConnector.ts
+++ b/lib/connectors/StandaloneConnector.ts
@@ -19,13 +19,13 @@ export default class StandaloneConnector extends AbstractConnector {
     const { options } = this;
     this.connecting = true;
 
-    let connectionOptions: any;
+    let connectionOptions: TcpNetConnectOpts | IpcNetConnectOpts;
     if ("path" in options && options.path) {
       connectionOptions = {
         path: options.path,
-      };
+      } as IpcNetConnectOpts;
     } else {
-      connectionOptions = {};
+      connectionOptions = {} as TcpNetConnectOpts;
       if ("port" in options && options.port != null) {
         connectionOptions.port = options.port;
       }


### PR DESCRIPTION
I haven't tested it yet as I'm running on macos and there's no way to read out the socket options, but this should fix #1339


### Changelog
- 🐛 Call `socket.setKeepAlive(true, ms)` after a successful connect as workaround for a node issue where it won't work when it's called before a successful connect