### PR TITLE
fix: handle NOPERM error for monitor

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -357,14 +357,15 @@ class Redis extends Commander {
    * });
    * ```
    */
-  monitor(callback: Callback<Redis>): Promise<Redis> {
+  monitor(callback?: Callback<Redis>): Promise<Redis> {
     const monitorInstance = this.duplicate({
       monitor: true,
       lazyConnect: false,
     });
 
     return asCallback(
-      new Promise(function (resolve) {
+      new Promise(function (resolve, reject) {
+        monitorInstance.once("error", reject);
         monitorInstance.once("monitoring", function () {
           resolve(monitorInstance);
         });
@@ -443,16 +444,15 @@ class Redis extends Commander {
 
     if (!writable) {
       if (!this.options.enableOfflineQueue) {
-        command.reject(new Error(
-          "Stream isn't writeable and enableOfflineQueue options is false"
-        ));
+        command.reject(
+          new Error(
+            "Stream isn't writeable and enableOfflineQueue options is false"
+          )
+        );
         return command.promise;
       }
 
-      if (
-        command.name === "quit" &&
-        this.offlineQueue.length === 0
-      ) {
+      if (command.name === "quit" && this.offlineQueue.length === 0) {
         this.disconnect();
         command.resolve(Buffer.from("OK"));
         return command.promise;

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -230,7 +230,10 @@ export function readyHandler(self) {
     self.retryAttempts = 0;
 
     if (self.options.monitor) {
-      self.call("monitor");
+      self.call("monitor").then(
+        () => self.setStatus("monitoring"),
+        (error: Error) => self.emit("error", error)
+      );
       const { sendCommand } = self;
       self.sendCommand = function (command) {
         if (Command.checkFlag("VALID_IN_MONITOR_MODE", command.name)) {
@@ -244,7 +247,6 @@ export function readyHandler(self) {
       self.once("close", function () {
         delete self.sendCommand;
       });
-      self.setStatus("monitoring");
       return;
     }
     const finalSelect = self.prevCondition

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@semantic-release/commit-analyzer": "^9.0.2",
         "@semantic-release/git": "^10.0.1",
         "@types/chai": "^4.3.0",
+        "@types/chai-as-promised": "^7.1.5",
         "@types/debug": "^4.1.5",
         "@types/lodash.defaults": "^4.2.6",
         "@types/lodash.isarguments": "^3.1.6",
@@ -1108,6 +1109,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
       "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
       "dev": true
+    },
+    "node_modules/@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
+      }
     },
     "node_modules/@types/debug": {
       "version": "4.1.7",
@@ -10200,6 +10210,15 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.0.tgz",
       "integrity": "sha512-/ceqdqeRraGolFTcfoXNiqjyQhZzbINDngeoAq9GoHa8PPK1yNzTaxWjA6BFWp5Ua9JpXEMSS4s5i9tS0hOJtw==",
       "dev": true
+    },
+    "@types/chai-as-promised": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+      "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
+      }
     },
     "@types/debug": {
       "version": "4.1.7",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@semantic-release/commit-analyzer": "^9.0.2",
     "@semantic-release/git": "^10.0.1",
     "@types/chai": "^4.3.0",
+    "@types/chai-as-promised": "^7.1.5",
     "@types/debug": "^4.1.5",
     "@types/lodash.defaults": "^4.2.6",
     "@types/lodash.isarguments": "^3.1.6",


### PR DESCRIPTION
Closes #1498

The cause was `self.call('monitor')` not being caught and unhandled errors crashed the process.

Test Plan:
1. Create a new user on Redis without the permission of `monitor`:   `ACL SETUSER nomonitor reset +info >123456 on`.
2. Make sure with user `nomonitor`, calling `redis.monitor()` should be rejected.