### PR TITLE
fix: sentinel slaves called replicas in Redis v7

### DIFF
--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -259,7 +259,7 @@ export default class SentinelConnector extends AbstractConnector {
   private async resolveSlave(
     client: RedisClient
   ): Promise<TcpNetConnectOpts | null> {
-    const result = await client.sentinel("slaves", this.options.name);
+    const result = await client.sentinel("replicas", this.options.name);
 
     if (!Array.isArray(result)) {
       return null;

--- a/lib/connectors/SentinelConnector/types.ts
+++ b/lib/connectors/SentinelConnector/types.ts
@@ -14,6 +14,7 @@ export interface RedisClient {
     subcommand: "get-master-addr-by-name",
     name: string
   ): Promise<string[]>;
+  sentinel(subcommand: "slaves", name: string): Promise<string[]>;
   sentinel(subcommand: "replicas", name: string): Promise<string[]>;
   subscribe(...channelNames: string[]): Promise<number>;
   on(

--- a/lib/connectors/SentinelConnector/types.ts
+++ b/lib/connectors/SentinelConnector/types.ts
@@ -14,7 +14,7 @@ export interface RedisClient {
     subcommand: "get-master-addr-by-name",
     name: string
   ): Promise<string[]>;
-  sentinel(subcommand: "slaves", name: string): Promise<string[]>;
+  sentinel(subcommand: "replicas", name: string): Promise<string[]>;
   subscribe(...channelNames: string[]): Promise<number>;
   on(
     event: "message",

--- a/test/functional/sentinel.ts
+++ b/test/functional/sentinel.ts
@@ -363,7 +363,7 @@ describe("sentinel", () => {
       const sentinel = new MockServer(27379, (argv) => {
         if (
           argv[0] === "sentinel" &&
-          argv[1] === "slaves" &&
+          (argv[1] === "slaves" || argv[1] === "replicas") &&
           argv[2] === "master"
         ) {
           return [["ip", "127.0.0.1", "port", "17381", "flags", "slave"]];
@@ -389,7 +389,7 @@ describe("sentinel", () => {
       const sentinel = new MockServer(27379, (argv) => {
         if (
           argv[0] === "sentinel" &&
-          argv[1] === "slaves" &&
+          (argv[1] === "slaves" || argv[1] === "replicas") &&
           argv[2] === "master"
         ) {
           return [
@@ -426,7 +426,7 @@ describe("sentinel", () => {
       new MockServer(27379, (argv) => {
         if (
           argv[0] === "sentinel" &&
-          argv[1] === "slaves" &&
+          (argv[1] === "slaves" || argv[1] === "replicas") &&
           argv[2] === "master"
         ) {
           return [["ip", "127.0.0.1", "port", "17381", "flags", "slave"]];
@@ -459,7 +459,7 @@ describe("sentinel", () => {
       const sentinel = new MockServer(27379, (argv) => {
         if (
           argv[0] === "sentinel" &&
-          argv[1] === "slaves" &&
+          (argv[1] === "slaves" || argv[1] === "replicas") &&
           argv[2] === "master"
         ) {
           return [];
@@ -488,7 +488,7 @@ describe("sentinel", () => {
       const sentinel = new MockServer(27379, (argv) => {
         if (
           argv[0] === "sentinel" &&
-          argv[1] === "slaves" &&
+          (argv[1] === "slaves" || argv[1] === "replicas") &&
           argv[2] === "master"
         ) {
           return [["ip", "127.0.0.1", "port", "17381", "flags", "slave"]];


### PR DESCRIPTION
In Redis v5.0 the command `SENTINEL SLAVES` has been changed to `SENTINEL REPLICAS`. The old command was still available as alias, however from v7.0 and on the alias has been removed (which isn't mentioned in the Redis release notes, btw). This breaks the preferred slaves functionality, for example.

This change is thus breaking backwards compatibility with Sentinels running v4.0 or older. Maybe we need/must resolve that in one way or another as compatibility from v2.6.12 is claimed for this package.