### PR TITLE
fix: send correct command during auto-pipelining of .call() operations

### DIFF
--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -185,6 +185,10 @@ export function executeWithAutoPipelining(
       resolve(value);
     });
 
+    if (functionName === "call") {
+      args.unshift(commandName);
+    }
+
     pipeline[functionName](...args);
   });
 


### PR DESCRIPTION
When using custom `.call()` operations (such as `.call("FT.SEARCH", "index", ...)`) in combination with auto-pipelining, the resulting redis command would not include the `FT.SEARCH` command itself.

`call` itself is [defined as the result of `generateFunction("call", "utf8")`](https://github.com/luin/ioredis/blob/7a9e5fd3aaba55fdc15d25b184078934f270a309/lib/utils/Commander.ts#L113) which [shifts the command out of the args array into a separate variable `commandName`](https://github.com/luin/ioredis/blob/main/lib/utils/Commander.ts#L135) and then [uses `functionName` (`call`), `commandName` (`FT.SEARCH`) and `args` (`index`, ...) to call `executeWithAutoPipelining`](https://github.com/luin/ioredis/blob/7a9e5fd3aaba55fdc15d25b184078934f270a309/lib/utils/Commander.ts#L159-L166). [`executeWithAutoPipelining`](https://github.com/luin/ioredis/blob/7a9e5fd3aaba55fdc15d25b184078934f270a309/lib/autoPipelining.ts#L119-L192) however completely ignores the `commandName` and assumes that the `functionName` is what we're actually trying to execute when [it forwards the command to `pipeline[functionName](...args);`](https://github.com/luin/ioredis/blob/7a9e5fd3aaba55fdc15d25b184078934f270a309/lib/autoPipelining.ts#L188). As far as I can tell, we can't just use `commandName` instead of `functionName` in here since the pipeline object itself isn't prepared for arbitrary commands so we have to keep referring to it as `call` but we can push the actual `commandName` back into the arguments which will successfully make it into the command.