### PR TITLE
fix: always allow selecting a new node for cluster mode subscriptions when the current one fails

### DIFF
--- a/test/functional/cluster/pub_sub.ts
+++ b/test/functional/cluster/pub_sub.ts
@@ -49,6 +49,7 @@ describe("cluster:pub/sub", function () {
     sub.subscribe("test cluster", function () {
       sub.set("foo", "bar").then((res) => {
         expect(res).to.eql("OK");
+        sub.disconnect()
         done();
       });
     });
@@ -73,6 +74,7 @@ describe("cluster:pub/sub", function () {
     const sub = new Cluster([{ port: "30001", password: "abc" }]);
 
     sub.subscribe("test cluster", function () {
+      sub.disconnect()
       done();
     });
   });


### PR DESCRIPTION
We ran into an issue where some of our redis clients would miss messages from the pubsub bus following a network issue / crash in the redis cluster. This PR changes the reconnect logic in the ClusterSubscriber such that it can pick to connect to a different node when the current connection closes. The idea being that if a single node is having issues, the subscriber can connect immediately to another member of the cluster so it doesn't miss as many messages. 