### PR TITLE
hgetallBuffer response type should be a Record, not 2-element array 

### DIFF
--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -4189,7 +4189,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   hgetallBuffer(
     key: RedisKey,
     callback?: Callback<[field: Buffer, value: Buffer][]>
-  ): Result<[field: Buffer, value: Buffer][], Context>;
+  ): Result<Record<RedisKey, Buffer>, Context>;
 
   /**
    * Increment the integer value of a hash field by the given number


### PR DESCRIPTION
Tested this on redis version 7