### PR TITLE
fix: Allow address family to be resolved from DNS

### DIFF
--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -189,7 +189,6 @@ export const DEFAULT_REDIS_OPTIONS: RedisOptions = {
   // Connection
   port: 6379,
   host: "localhost",
-  family: 4,
   connectTimeout: 10000,
   disconnectTimeout: 2000,
   retryStrategy: function (times) {


### PR DESCRIPTION
It may not be possible to know before hand what address a host will
resolve to.

Possibly this fixes #1576 