### PR TITLE
fix: support commands added in Redis 7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.6",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "^1.1.1",
+        "@ioredis/commands": "^1.2.0",
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.3.4",
         "denque": "^2.0.1",
@@ -41,12 +41,12 @@
         "eslint-config-prettier": "^8.4.0",
         "mocha": "^9.2.1",
         "nyc": "^15.1.0",
-        "prettier": "^2.6.1",
+        "prettier": "^2.7.1",
         "semantic-release": "^19.0.2",
         "server-destroy": "^1.0.1",
         "sinon": "^13.0.1",
         "ts-node": "^10.4.0",
-        "tsd": "^0.19.1",
+        "tsd": "^0.20.0",
         "typedoc": "^0.22.12",
         "typescript": "^4.6.3",
         "uuid": "^8.3.0"
@@ -525,9 +525,9 @@
       "dev": true
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
-      "integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "node_modules/@ioredis/interface-generator": {
       "version": "1.2.1",
@@ -1095,9 +1095,9 @@
       "dev": true
     },
     "node_modules/@tsd/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TxQ9QiUT94ZjKu++ta/iwTMVHsix4ApohnaHPTSd58WQuTjPIELP0tUYcW7lT6psz7yZiU4eRw+X4v/XV830Sw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-+9o716aWbcjKLbV4bCrGlJKJbS0UZNogfVk9U7ffooYSf/9GOJ6wwahTSrRjW7mWQdywQ/sIg9xxbuPLnkmhwg==",
       "dev": true,
       "bin": {
         "tsc": "typescript/bin/tsc",
@@ -2560,9 +2560,9 @@
       }
     },
     "node_modules/eslint-rule-docs": {
-      "version": "1.1.231",
-      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.231.tgz",
-      "integrity": "sha512-egHz9A1WG7b8CS0x1P6P/Rj5FqZOjray/VjpJa14tMZalfRKvpE2ONJ3plCM7+PcinmU4tcmbPLv0VtwzSdLVA==",
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
       "dev": true
     },
     "node_modules/eslint-scope": {
@@ -7700,9 +7700,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
-      "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -8891,12 +8891,12 @@
       }
     },
     "node_modules/tsd": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.19.1.tgz",
-      "integrity": "sha512-pSwchclr+ADdxlahRUQXUrdAIOjXx1T1PQV+fLfVLuo/S4z+T00YU84fH8iPlZxyA2pWgJjo42BG1p9SDb4NOw==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.20.0.tgz",
+      "integrity": "sha512-iba/JlyT3qtnA9t8VrX2Fipu3L31U48oRIf1PNs+lIwQ7n63GTkt9eQlB5bLtfb7nYfy9t8oZzs+K4QEoEIS8Q==",
       "dev": true,
       "dependencies": {
-        "@tsd/typescript": "~4.5.2",
+        "@tsd/typescript": "~4.6.3",
         "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
         "meow": "^9.0.0",
@@ -9719,9 +9719,9 @@
       "dev": true
     },
     "@ioredis/commands": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
-      "integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
     "@ioredis/interface-generator": {
       "version": "1.2.1",
@@ -10200,9 +10200,9 @@
       "dev": true
     },
     "@tsd/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TxQ9QiUT94ZjKu++ta/iwTMVHsix4ApohnaHPTSd58WQuTjPIELP0tUYcW7lT6psz7yZiU4eRw+X4v/XV830Sw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/@tsd/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-+9o716aWbcjKLbV4bCrGlJKJbS0UZNogfVk9U7ffooYSf/9GOJ6wwahTSrRjW7mWQdywQ/sIg9xxbuPLnkmhwg==",
       "dev": true
     },
     "@types/chai": {
@@ -11315,9 +11315,9 @@
       }
     },
     "eslint-rule-docs": {
-      "version": "1.1.231",
-      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.231.tgz",
-      "integrity": "sha512-egHz9A1WG7b8CS0x1P6P/Rj5FqZOjray/VjpJa14tMZalfRKvpE2ONJ3plCM7+PcinmU4tcmbPLv0VtwzSdLVA==",
+      "version": "1.1.235",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.235.tgz",
+      "integrity": "sha512-+TQ+x4JdTnDoFEXXb3fDvfGOwnyNV7duH8fXWTPD1ieaBmB8omj7Gw/pMBBu4uI2uJCCU8APDaQJzWuXnTsH4A==",
       "dev": true
     },
     "eslint-scope": {
@@ -15040,9 +15040,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
-      "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "process-nextick-args": {
@@ -15939,12 +15939,12 @@
       }
     },
     "tsd": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.19.1.tgz",
-      "integrity": "sha512-pSwchclr+ADdxlahRUQXUrdAIOjXx1T1PQV+fLfVLuo/S4z+T00YU84fH8iPlZxyA2pWgJjo42BG1p9SDb4NOw==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.20.0.tgz",
+      "integrity": "sha512-iba/JlyT3qtnA9t8VrX2Fipu3L31U48oRIf1PNs+lIwQ7n63GTkt9eQlB5bLtfb7nYfy9t8oZzs+K4QEoEIS8Q==",
       "dev": true,
       "requires": {
-        "@tsd/typescript": "~4.5.2",
+        "@tsd/typescript": "~4.6.3",
         "eslint-formatter-pretty": "^4.1.0",
         "globby": "^11.0.1",
         "meow": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://opencollective.com/ioredis"
   },
   "dependencies": {
-    "@ioredis/commands": "^1.1.1",
+    "@ioredis/commands": "^1.2.0",
     "cluster-key-slot": "^1.1.0",
     "debug": "^4.3.4",
     "denque": "^2.0.1",
@@ -73,12 +73,12 @@
     "eslint-config-prettier": "^8.4.0",
     "mocha": "^9.2.1",
     "nyc": "^15.1.0",
-    "prettier": "^2.6.1",
+    "prettier": "^2.7.1",
     "semantic-release": "^19.0.2",
     "server-destroy": "^1.0.1",
     "sinon": "^13.0.1",
     "ts-node": "^10.4.0",
-    "tsd": "^0.19.1",
+    "tsd": "^0.20.0",
     "typedoc": "^0.22.12",
     "typescript": "^4.6.3",
     "uuid": "^8.3.0"


### PR DESCRIPTION
Closes #1591

Previously, the latest Redis commands didn't support well when we wanted to get key indexes from them. This led https://github.com/luin/ioredis/issues/1591.

This PR upgrades @ioredis/commands so they should work.