### PR TITLE
feat: add mode property to client

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -339,6 +339,20 @@ class Redis extends Commander {
   }
 
   /**
+   * Mode of the connection.
+   *
+   * One of `"normal"`, `"subscriber"`, or `"monitor"`. When the connection is
+   * not in `"normal"` mode, certain commands are not allowed.
+   */
+   get mode(): "normal" | "subscriber" | "monitor" {
+    return this.options.monitor
+      ? "monitor"
+      : this.condition.subscriber
+      ? "subscriber"
+      : "normal";
+  }
+
+  /**
    * Listen for all requests received by the server in real time.
    *
    * This command will create a new connection to Redis and send a

--- a/test/functional/monitor.ts
+++ b/test/functional/monitor.ts
@@ -41,6 +41,18 @@ describe("monitor", () => {
     });
   });
 
+  it("should report being in 'monitor' mode", (done) => {
+    const redis = new Redis();
+    redis.monitor(async (err, monitor) => {
+      await waitForMonitorReady(monitor);
+      expect(redis.mode).to.equal("normal");
+      expect(monitor.mode).to.equal("monitor");
+      redis.disconnect();
+      monitor.disconnect();
+      done();
+    });
+  });
+
   it("should continue monitoring after reconnection", (done) => {
     const redis = new Redis();
     redis.monitor((err, monitor) => {

--- a/test/functional/pub_sub.ts
+++ b/test/functional/pub_sub.ts
@@ -29,6 +29,15 @@ describe("pub/sub", function () {
     });
   });
 
+  it("should report being in 'subscriber' mode when subscribed", (done) => {
+    const redis = new Redis();
+    redis.subscribe("foo", function () {
+      expect(redis.mode).to.equal("subscriber");
+      redis.disconnect();
+      done();
+    });
+  });
+
   it("should exit subscriber mode using unsubscribe", (done) => {
     const redis = new Redis();
     redis.subscribe("foo", "bar", function () {
@@ -48,6 +57,17 @@ describe("pub/sub", function () {
             });
           });
         });
+      });
+    });
+  });
+
+  it("should report being in 'normal' mode after unsubscribing", (done) => {
+    const redis = new Redis();
+    redis.subscribe("foo", "bar", function () {
+      redis.unsubscribe("foo", "bar", function (err, count) {
+        expect(redis.mode).to.equal("normal");
+        redis.disconnect();
+        done();
       });
     });
   });


### PR DESCRIPTION
Adds a `.mode` getter to the client that reports whether the client is in 'normal', 'subscriber', or 'monitor' mode.