### PR TITLE
Remove lazyConnect from Cluster redisOptions

### DIFF
--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -133,6 +133,7 @@ export interface ClusterOptions extends CommanderOptions {
     | "retryStrategy"
     | "enableOfflineQueue"
     | "readOnly"
+    | "lazyConnect"
   >;
 
   /**


### PR DESCRIPTION
It is already being set by the cluster to `true` and there is no way to override it: https://github.com/luin/ioredis/blob/main/lib/cluster/ConnectionPool.ts#L84