### PR TITLE
fix: type of zscore result should be nullable

### DIFF
--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -317,7 +317,7 @@ module.exports = {
   zrevrange: "string[]",
   zrevrangebyscore: "string[]",
   zrevrank: "number | null",
-  zscore: "string",
+  zscore: "string | null",
   zunion: "string[]",
   zmscore: "(string | null)[]",
   zunionstore: "number",

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -13854,7 +13854,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   zscore(
     key: RedisKey,
     member: string | Buffer | number,
-    callback?: Callback<string>
+    callback?: Callback<string | null>
   ): Result<string, Context>;
   zscoreBuffer(
     key: RedisKey,

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -13854,8 +13854,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   zscore(
     key: RedisKey,
     member: string | Buffer | number,
-    callback?: Callback<string | null>
-  ): Result<string, Context>;
+    callback?: Callback<string>
+  ): Result<string | null, Context>;
   zscoreBuffer(
     key: RedisKey,
     member: string | Buffer | number,

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -13854,7 +13854,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   zscore(
     key: RedisKey,
     member: string | Buffer | number,
-    callback?: Callback<string>
+    callback?: Callback<string | null>
   ): Result<string | null, Context>;
   zscoreBuffer(
     key: RedisKey,

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -13859,8 +13859,8 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   zscoreBuffer(
     key: RedisKey,
     member: string | Buffer | number,
-    callback?: Callback<Buffer>
-  ): Result<Buffer, Context>;
+    callback?: Callback<Buffer | null>
+  ): Result<Buffer | null, Context>;
 
   /**
    * Add multiple sorted sets

--- a/test/typing/commands.test-d.ts
+++ b/test/typing/commands.test-d.ts
@@ -88,6 +88,9 @@ expectType<Promise<number>>(redis.zadd("key", "CH", 1, "member"));
 expectType<Promise<string | null>>(redis.zrandmember("key"));
 expectType<Promise<string[]>>(redis.zrandmember("key", 20));
 
+// ZSCORE
+expectType<Promise<string | null>>(redis.zscore("key", "member"));
+
 // GETRANGE
 expectType<Promise<Buffer>>(redis.getrangeBuffer("foo", 0, 1));
 

--- a/test/typing/commands.test-d.ts
+++ b/test/typing/commands.test-d.ts
@@ -90,6 +90,7 @@ expectType<Promise<string[]>>(redis.zrandmember("key", 20));
 
 // ZSCORE
 expectType<Promise<string | null>>(redis.zscore("key", "member"));
+expectType<Promise<Buffer | null>>(redis.zscoreBuffer("key", "member"));
 
 // GETRANGE
 expectType<Promise<Buffer>>(redis.getrangeBuffer("foo", 0, 1));


### PR DESCRIPTION
The result of zscore can be null if member or key does not exist.

```ts
const result = await redis.zscore("key", "member") // return string or null
```

https://redis.io/commands/zscore/