### PR TITLE
Fixes passing in family parameter in URL in node 18

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -236,7 +236,7 @@ export function parseURL(url: string): Record<string, unknown> {
   if (parsed.port) {
     result.port = parsed.port;
   }
-  if (typeof options.family === 'string') {
+  if (typeof options.family === "string") {
     const intFamily = Number.parseInt(options.family, 10);
     if (!Number.isNaN(intFamily)) {
       result.family = intFamily;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -236,6 +236,12 @@ export function parseURL(url: string): Record<string, unknown> {
   if (parsed.port) {
     result.port = parsed.port;
   }
+  if (typeof options.family === 'string') {
+    const intFamily = Number.parseInt(options.family, 10);
+    if (!Number.isNaN(intFamily)) {
+      result.family = intFamily;
+    }
+  }
   defaults(result, options);
 
   return result;

--- a/test/unit/redis.ts
+++ b/test/unit/redis.ts
@@ -96,6 +96,9 @@ describe("Redis", () => {
           tls: { hostname: "example.test" },
         });
         expect(option.tls).to.deep.equal({ hostname: "example.test" });
+
+        option = getOption("redis://localhost?family=6");
+        expect(option).to.have.property("family", 6);
       } catch (err) {
         stub.restore();
         throw err;

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -195,6 +195,14 @@ describe("utils", () => {
         password: "pass",
         key: "value",
       });
+      expect(utils.parseURL("redis://127.0.0.1/?family=6")).to.eql({
+        host: "127.0.0.1",
+        family: 6
+      });
+      expect(utils.parseURL("redis://127.0.0.1/?family=IPv6")).to.eql({
+        host: "127.0.0.1",
+        family: "IPv6"
+      });
     });
   });
 

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -197,11 +197,11 @@ describe("utils", () => {
       });
       expect(utils.parseURL("redis://127.0.0.1/?family=6")).to.eql({
         host: "127.0.0.1",
-        family: 6
+        family: 6,
       });
       expect(utils.parseURL("redis://127.0.0.1/?family=IPv6")).to.eql({
         host: "127.0.0.1",
-        family: "IPv6"
+        family: "IPv6",
       });
     });
   });


### PR DESCRIPTION
Node 18 stopped coercing the type for its options (specifically the ip family option) and instead throws an error. So if you pass in `?family=6` in your Redis URL, it would fail because when it does the DNS lookup passing in the string `'6'`, node would throw an error.

Fixes https://github.com/luin/ioredis/issues/1672