### PR TITLE
test(functional): monitor result compare lowercase

### DIFF
--- a/test/functional/monitor.ts
+++ b/test/functional/monitor.ts
@@ -15,7 +15,7 @@ describe("monitor", () => {
           return;
         }
         monitor.on("monitor", function (time, args) {
-          expect(args[0]).to.eql("get");
+          expect(args[0]).to.match(/get/i);
           expect(args[1]).to.eql("foo");
           redis.disconnect();
           monitor.disconnect();
@@ -61,7 +61,7 @@ describe("monitor", () => {
         return;
       }
       monitor.on("monitor", (_time, args) => {
-        if (args[0] === "set") {
+        if (args[0] === "set" || args[0] === "SET") {
           redis.disconnect();
           monitor.disconnect();
           done();

--- a/test/functional/pipeline.ts
+++ b/test/functional/pipeline.ts
@@ -323,7 +323,7 @@ describe("pipeline", () => {
       redis.disconnect();
 
       expectedCommands.forEach((expectedCommand, j) => {
-        expectedCommand.forEach((arg, i) => expect(arg).to.eql(commands[j][i]));
+        expectedCommand.forEach((arg, i) => expect(arg).to.eql(commands[j][i].toLowerCase()));
       });
     });
 
@@ -388,9 +388,7 @@ describe("pipeline", () => {
       redis2.disconnect();
 
       const expected = ["set", "eval", "get"];
-      commands.forEach((c, i) => {
-        expect(c[0]).to.equal(expected[i]);
-      });
+      expect(commands.map((c) => c[0].toLowerCase())).to.have.members(expected);
     });
   });
 

--- a/test/functional/scripting.ts
+++ b/test/functional/scripting.ts
@@ -204,7 +204,7 @@ describe("scripting", () => {
     });
 
     const expectedComands = ["evalsha", "eval", "get", "evalsha", "get"];
-    expect(commands.map((c) => c[0])).to.eql(expectedComands);
+    expect(commands.map((c) => c[0].toLowerCase())).to.have.members(expectedComands);
   });
 
   it("should load scripts first before execution of pipeline", async () => {
@@ -230,7 +230,7 @@ describe("scripting", () => {
 
     const expectedComands = ["evalsha", "get", "eval", "set", "get"];
 
-    expect(commands.map((c) => c[0])).to.eql(expectedComands);
+    expect(commands.map((c) => c[0].toLowerCase())).to.have.members(expectedComands);
   });
 
   it("does not fallback to EVAL in regular transaction", async () => {
@@ -260,7 +260,7 @@ describe("scripting", () => {
     spy.restore();
     expect(spy.callCount).to.equal(4);
     const expectedComands = ["multi", "evalsha", "evalsha", "exec"];
-    expect(commands.map((c) => c[0])).to.eql(expectedComands);
+    expect(commands.map((c) => c[0].toLowerCase())).to.have.members(expectedComands);
   });
 
   it("does not fallback to EVAL in manual transaction", async () => {
@@ -284,7 +284,7 @@ describe("scripting", () => {
     spy.restore();
     expect(spy.callCount).to.equal(4);
     const expectedComands = ["multi", "evalsha", "evalsha", "exec"];
-    expect(commands.map((c) => c[0])).to.eql(expectedComands);
+    expect(commands.map((c) => c[0].toLowerCase())).to.have.members(expectedComands);
   });
 
   it("should support key prefixing", (done) => {


### PR DESCRIPTION
Allow [dragonfly](https://github.com/dragonflydb/dragonfly) to successfully pass tests
This include changes only to the test code!.
This include two changes:
1. Compare result from the monitor to be case insensitive. 
2. The order of the result from the monitor can be out of order.
The reason being - 
In dragonfly the processing of the monitor command in no done single threaded (Redis is single threaded). This means that commands can and will process in parallel and that the name of the commands are changed to upper case (as they are pass between threads). As a result the command that the monitor returning would be in the case of dragonfly in upper case always, and the processing order in not deterministic as in Redis - process is done in parallel. 
Adding these changes would make this popular client part of Dragonfly CI to verify that Dragonfly is compliant with it.
Signed-off-by: Boaz Sade <boaz@dragonflydb.io>