### PR TITLE
docs: update readme to fix slotsRefreshInterval default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,7 +1072,7 @@ cluster.get("foo", (err, res) => {
       state stabilized after a failover, so adding a delay before resending can prevent a ping pong effect.
     - `redisOptions`: Default options passed to the constructor of `Redis` when connecting to a node.
     - `slotsRefreshTimeout`: Milliseconds before a timeout occurs while refreshing slots from the cluster (default `1000`).
-    - `slotsRefreshInterval`: Milliseconds between every automatic slots refresh (default `5000`).
+    - `slotsRefreshInterval`: Milliseconds between every automatic slots refresh (by default, it is disabled).
 
 ### Read-Write Splitting
 


### PR DESCRIPTION
## Description 

👋 Hello, when upgrading my version of ioredis from v4 to v5 I noticed a desync in the Readme

[Breaking changes](https://github.com/luin/ioredis/blob/main/CHANGELOG.md#breaking-changes) include that 

> `slotsRefreshInterval` is disabled by default, previously, the default value was 5000.

In the [Readme](https://github.com/luin/ioredis#cluster), it is still mentioned that its default value is 5000