### PR TITLE
fix: add named export to support ESM imports in Typescript

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,7 +1,7 @@
 exports = module.exports = require("./Redis").default;
 
 export { default } from "./Redis";
-export type { default as Redis } from "./Redis";
+export { default as Redis } from "./Redis";
 export { default as Cluster } from "./cluster";
 
 /**


### PR DESCRIPTION
Currently getting a "has no construct signatures" error with the following in Typescript 4.9.4, Node 18.12.1, type: module, module: node16, moduleResolution: node16:

```ts
import Redis from 'ioredis'

const redis = new Redis()
```

Changing the ioredis package with this change allows:

```ts
import { Redis } from 'ioredis'

const redis = new Redis()
```

without any error, and with full type information.