### PR TITLE
fix: check that condition is defined before we access it

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -347,7 +347,7 @@ class Redis extends Commander {
    get mode(): "normal" | "subscriber" | "monitor" {
     return this.options.monitor
       ? "monitor"
-      : this.condition.subscriber
+      : this.condition && this.condition.subscriber
       ? "subscriber"
       : "normal";
   }


### PR DESCRIPTION
This fixes an error we are running into. In our code base we have a system that will mock out dependencies. However it iterates over props to stub out functions. In this process it accesses this getter property. Before connect is called this getter tries to access `this.condition` which is undefined so accessing the property of it causes a crash in ioredis. This handles that case so ioredis does not try to access property `subscriber` of undefined.