### PR TITLE
remove extraneous TCP/IPC properties from RedisOptions TS type

### DIFF
--- a/lib/connectors/StandaloneConnector.ts
+++ b/lib/connectors/StandaloneConnector.ts
@@ -4,8 +4,10 @@ import { NetStream } from "../types";
 import { CONNECTION_CLOSED_ERROR_MSG } from "../utils";
 import AbstractConnector, { ErrorEmitter } from "./AbstractConnector";
 
-export type StandaloneConnectionOptions = (Partial<TcpNetConnectOpts> &
-  Partial<IpcNetConnectOpts>) & {
+type TcpOptions = Pick<TcpNetConnectOpts, "port" | "host" | "family">;
+type IpcOptions = Pick<IpcNetConnectOpts, "path">;
+
+export type StandaloneConnectionOptions = Partial<TcpOptions & IpcOptions> & {
   disconnectTimeout?: number;
   tls?: ConnectionOptions;
 };
@@ -19,13 +21,13 @@ export default class StandaloneConnector extends AbstractConnector {
     const { options } = this;
     this.connecting = true;
 
-    let connectionOptions: TcpNetConnectOpts | IpcNetConnectOpts;
+    let connectionOptions: TcpOptions | IpcOptions;
     if ("path" in options && options.path) {
       connectionOptions = {
         path: options.path,
-      } as IpcNetConnectOpts;
+      } as IpcOptions;
     } else {
-      connectionOptions = {} as TcpNetConnectOpts;
+      connectionOptions = {} as TcpOptions;
       if ("port" in options && options.port != null) {
         connectionOptions.port = options.port;
       }


### PR DESCRIPTION
Node 18 introduced a new `keepAlive` option in the TCP socket constructor.  

This causes ioredis's TypeScript typings to clash with `@types/node`, because we define `keepAlive` as `number | undefined`, whereas Node defines it as a `boolean`.  

Luckily, this isn't a runtime regression.  We don't pass `keepAlive` into `createConnection`, and in fact only pass in three properties total.  _But_ we pretend that any property of `TcpNetConnectOptions` can be included in `RedisOptions`.  

This PR reduces the surface-area of `RedisOptions` to only include the TCP and IPC connection parameters that we actually use, which results in `keepAlive` once again having the correct TS type.

It should also be less confusing for users, as we've removed several unused properties off of that interface...

Fixes #1680 
Fixes #1684