### PR TITLE
chore: Release new versions manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
-on:
-  push:
-    branches: [main]
+on: workflow_dispatch
 
 concurrency:
   group: release_version
@@ -16,7 +14,7 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
           node-version: "lts/*"


### PR DESCRIPTION
Previously, the release process is triggered on every commit added on the main branch. A drawback is that the approach could release too many versions and it's hard for users to keep track of release notes.

This PR changes the release process to be manually.