### PR TITLE
test: Run tests against latest Redis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         node: [12.x, 14.x, 16.x, 18.x]
-        redis: ['2', '6']
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
@@ -21,7 +20,7 @@ jobs:
       - name: Start Redis
         uses: supercharge/redis-github-action@1.4.0
         with:
-          redis-version: ${{ matrix.redis }}
+          redis-version: latest
 
       - run: npm install
       - run: npm run lint
@@ -29,11 +28,11 @@ jobs:
       - run: npm run test:tsd
       - run: npm run test:cov || npm run test:cov || npm run test:cov
       - name: Coveralls
-        if: matrix.node == '18.x' && matrix.redis == '6'
+        if: matrix.node == '18.x'
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: redis-${{matrix.redis}}-node-${{matrix.node}}
+          flag-name: node-${{matrix.node}}
           parallel: true
 
   test-cluster:
@@ -47,8 +46,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        parallel-finished: true
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/test/functional/monitor.ts
+++ b/test/functional/monitor.ts
@@ -1,7 +1,7 @@
 import Redis from "../../lib/Redis";
 import { expect, use } from "chai";
 import * as sinon from "sinon";
-import { getRedisVersion, waitForMonitorReady } from "../helpers/util";
+import { waitForMonitorReady } from "../helpers/util";
 
 use(require("chai-as-promised"));
 
@@ -22,7 +22,7 @@ describe("monitor", () => {
           done();
         });
 
-        await waitForMonitorReady(monitor);
+        await waitForMonitorReady();
         redis.get("foo");
       });
     });
@@ -31,7 +31,7 @@ describe("monitor", () => {
   it("should reject processing commands", (done) => {
     const redis = new Redis();
     redis.monitor(async (err, monitor) => {
-      await waitForMonitorReady(monitor);
+      await waitForMonitorReady();
       monitor.get("foo", function (err) {
         expect(err.message).to.match(/Connection is in monitoring mode/);
         redis.disconnect();
@@ -44,7 +44,7 @@ describe("monitor", () => {
   it("should report being in 'monitor' mode", (done) => {
     const redis = new Redis();
     redis.monitor(async (err, monitor) => {
-      await waitForMonitorReady(monitor);
+      await waitForMonitorReady();
       expect(redis.mode).to.equal("normal");
       expect(monitor.mode).to.equal("monitor");
       redis.disconnect();
@@ -69,7 +69,7 @@ describe("monitor", () => {
       });
       monitor.disconnect(true);
       monitor.on("ready", async () => {
-        await waitForMonitorReady(monitor);
+        await waitForMonitorReady();
         redis.set("foo", "bar");
       });
     });
@@ -91,11 +91,6 @@ describe("monitor", () => {
 
   it("rejects when monitor is disabled", async () => {
     const redis = new Redis();
-    const [major] = await getRedisVersion(redis);
-    if (major < 6) {
-      return;
-    }
-
     await redis.acl("SETUSER", "nomonitor", "reset", "+info", ">123456", "on");
 
     await expect(

--- a/test/functional/scan_stream.ts
+++ b/test/functional/scan_stream.ts
@@ -3,7 +3,6 @@ import { expect } from "chai";
 import { Readable } from "stream";
 import * as sinon from "sinon";
 import MockServer from "../helpers/mock_server";
-import { getRedisVersion } from "../helpers/util";
 import { Cluster } from "../../lib";
 
 describe("*scanStream", () => {
@@ -51,10 +50,6 @@ describe("*scanStream", () => {
     it("should recognize `TYPE`", async () => {
       let keys = [];
       const redis = new Redis();
-      const [major] = await getRedisVersion(redis);
-      if (major < 6) {
-        return;
-      }
       redis.set("foo1", "bar");
       redis.set("foo2", "bar");
       redis.set("foo3", "bar");

--- a/test/functional/transformer.ts
+++ b/test/functional/transformer.ts
@@ -1,5 +1,4 @@
 import Redis from "../../lib/Redis";
-import { getRedisVersion } from "../helpers/util";
 import { expect } from "chai";
 
 describe("transformer", () => {
@@ -135,11 +134,6 @@ describe("transformer", () => {
     describe("hset", () => {
       it("should support object", async () => {
         const redis = new Redis();
-        const [major] = await getRedisVersion(redis);
-        if (major < 4) {
-          // Skip if redis is too outdated to hset multiple pairs at once.
-          return;
-        }
         // NOTE: could simplify these tests using await redis.hset instead,
         // but not sure if this is deliberately testing the transformers with callbacks
         return new Promise((resolve, reject) => {
@@ -157,11 +151,6 @@ describe("transformer", () => {
       });
       it("should support Map", async () => {
         const redis = new Redis();
-        const [major] = await getRedisVersion(redis);
-        if (major < 4) {
-          // Skip if redis is too outdated to hset multiple pairs at once.
-          return;
-        }
         const map = new Map();
         map.set("a", 1);
         map.set("b", "e");
@@ -183,12 +172,6 @@ describe("transformer", () => {
       });
       it("should affect the old way", async () => {
         const redis = new Redis();
-        const [major] = await getRedisVersion(redis);
-        if (major < 4) {
-          // Skip if redis is too outdated to hset multiple pairs at once.
-          return;
-        }
-
         return new Promise((resolve) => {
           redis.hset("foo", "a", 1, "b", "e", function (err, result) {
             expect(result).to.eql(2);

--- a/test/helpers/util.ts
+++ b/test/helpers/util.ts
@@ -1,23 +1,8 @@
-const VERSION_REGEX = /\bredis_version:(\d+)\.(\d+)\.(\d+)/;
-
-export function waitForMonitorReady(redis) {
+export function waitForMonitorReady() {
   // It takes a while for the monitor to be ready.
   // This is a hack to wait for it because the monitor command
   // does not have a response
   return new Promise((resolve) => setTimeout(resolve, 150));
-}
-
-export async function getRedisVersion(
-  redis: any
-): Promise<[number, number, number]> {
-  const raw = await redis.info("server");
-  const match = VERSION_REGEX.exec(raw);
-  if (match) {
-    return [Number(match[1]), Number(match[2]), Number(match[3])];
-  }
-  throw new Error(
-    "Could not determine redis version from: " + JSON.stringify(raw)
-  );
 }
 
 export async function getCommandsFromMonitor(
@@ -25,9 +10,9 @@ export async function getCommandsFromMonitor(
   count: number,
   exec: Function
 ): Promise<[any]> {
-  const arr = [];
+  const arr: string[] = [];
   const monitor = await redis.monitor();
-  await waitForMonitorReady(monitor);
+  await waitForMonitorReady();
   const promise = new Promise((resolve, reject) => {
     setTimeout(reject, 1000, new Error("Monitor timed out"));
     monitor.on("monitor", (_, command) => {


### PR DESCRIPTION
Given that almost all Redis features are added in a backward-compatible way, we will only test against the latest Redis version to make test cases easier to maintain.