### PR TITLE
chore: Update cluster-key-slot to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ioredis/commands": "^1.1.1",
-        "cluster-key-slot": "^1.1.0",
+        "cluster-key-slot": "^1.1.2",
         "debug": "^4.3.4",
         "denque": "^2.1.0",
         "lodash.defaults": "^4.2.0",
@@ -1961,9 +1961,9 @@
       }
     },
     "node_modules/cluster-key-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
-      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11006,9 +11006,9 @@
       }
     },
     "cluster-key-slot": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
-      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="
     },
     "color-convert": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@ioredis/commands": "^1.1.1",
-    "cluster-key-slot": "^1.1.0",
+    "cluster-key-slot": "^1.1.2",
     "debug": "^4.3.4",
     "denque": "^2.1.0",
     "lodash.defaults": "^4.2.0",


### PR DESCRIPTION
When using ioredis, with the [licence-compliance](https://www.npmjs.com/package/license-compliance) package, it fails due to a sub-dependency having an invalid licence string. The sub-dependency has fixed that, but ioredis hasn't updated to use it yet, resulting in this output:

```
ioredis (main) λ  npx license-compliance --allow "ISC;MIT;BSD-3-Clause;BSD-2-Clause;Apache-2.0;Python-2.0;MPL-2.0;LGPL-2.0;LGPL-3.0;LGPL-2.1;0BSD;Unlicense" --report detailed
Packages
└─ cluster-key-slot@1.1.0
   ├─ Licenses: UNKNOWN
   ├─ License file: node_modules/cluster-key-slot/LICENSE
   ├─ Path: node_modules/cluster-key-slot
   └─ Repository: https://github.com/Salakar/cluster-key-slot
````

Upgrading [cluster-key-slot](https://github.com/invertase/cluster-key-slot), to the latest version, so that [this PR](https://github.com/invertase/cluster-key-slot/pull/7) that fixes the incorrect licence string is included. 