### PR TITLE
Create a section about expiration time on keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,16 @@ async function listenForMessage(lastId = "$") {
 listenForMessage();
 ```
 
+## Expiration
+
+Redis can set a timeout to expire your key, after the timeout has expired the key will be automatically deleted. (You can find the [official Expire documentation](https://redis.io/commands/expire/) to understand better the different parameters you can use), to set your key to expire in 1000 seconds, we will have the following code:
+
+```javascript
+redis.set("key", "data", "EX", 1000);
+// Equivalent to redis command "SET key data EX 1000", because on ioredis set method, 
+// all arguments are passed directly to the redis server.
+```
+
 ## Handle Binary Data
 
 Binary data support is out of the box. Pass buffers to send binary data:


### PR DESCRIPTION
I know it's a section about a specific command in Redis, and I don't know if this library wants to document all Redis commands.

But, as a user of this library, in my research about how I can expire my keys using ioredis, I tried to search on the docs words like "expires", "expiration", and I can't find anything, so I googled and searched on issues to finally find my answer on this issue #159 

I think creating this section will be useful for those who want to use timeout in Redis, one of the most used Redis features for people who use Redis for caching, and I think adding a simple section about it will help those users (like me), which searches on "expiration" words and finds nothing in the docs.

I know you can find it just by searching about "EX", but some users don't mind this, or don't know this specific command in Redis, and take the way to find the answer on the issue again.