### PR TITLE
Update hash.js example from deprecated hmset -> hset

### DIFF
--- a/examples/hash.js
+++ b/examples/hash.js
@@ -10,7 +10,7 @@ async function main() {
     description: "I am a programmer",
   };
 
-  await redis.hmset("user-hash", user);
+  await redis.hset("user-hash", user);
 
   const name = await redis.hget("user-hash", "name");
   console.log(name); // "Bob"


### PR DESCRIPTION
`hmset` is deprecated, so I've replaced it with `hset` in this example code.
Ref: https://redis.io/commands/hmset/