### PR TITLE
Include nodeId in key in cluster connectionpool, correctly refreshing connections when nodeId changes

### DIFF
--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -40,7 +40,7 @@ export default class ConnectionPool extends EventEmitter {
    * Find or create a connection to the node
    */
   findOrCreate(node: RedisOptions, readOnly = false): Redis {
-    const key = getNodeKey(node);
+    const key = this.getNodeKey(node);
     readOnly = Boolean(readOnly);
 
     if (this.specifiedOptions[key]) {
@@ -113,7 +113,7 @@ export default class ConnectionPool extends EventEmitter {
     debug("Reset with %O", nodes);
     const newNodes = {};
     nodes.forEach((node) => {
-      const key = getNodeKey(node);
+      const key = this.getNodeKey(node);
 
       // Don't override the existing (master) node
       // when the current one is slave.
@@ -146,5 +146,9 @@ export default class ConnectionPool extends EventEmitter {
     }
     delete nodes.master[key];
     delete nodes.slave[key];
+  }
+
+  private getNodeKey(options: RedisOptions) {
+    return getNodeKey(options) + ':' + options.nodeId;
   }
 }

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -864,6 +864,7 @@ class Cluster extends Commander {
               port: items[j][1],
             });
             node.readOnly = j !== 2;
+            node.nodeId = items[j][2];
             nodes.push(node);
             keys.push(node.host + ":" + node.port);
           }

--- a/lib/cluster/util.ts
+++ b/lib/cluster/util.ts
@@ -10,6 +10,7 @@ export interface RedisOptions {
   host: string;
   username?: string;
   password?: string;
+  nodeId?: string;
   [key: string]: any;
 }
 


### PR DESCRIPTION
Fixes #1778
