### PR TITLE
feat(options): optionally allow custom logger to be provided

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -601,7 +601,7 @@ class Redis extends Commander implements DataHandledable {
       return this.emit.apply(this, arguments);
     }
     if (error && error instanceof Error) {
-      console.error("[ioredis] Unhandled error event:", error.stack);
+      this.options.logger.error("[ioredis] Unhandled error event:", error.stack);
     }
     return false;
   }
@@ -721,6 +721,10 @@ class Redis extends Commander implements DataHandledable {
       options.db = parseInt(options.db, 10);
     }
 
+    if (!options.logger) {
+      options.logger = console;
+    }
+
     // @ts-expect-error
     this.options = resolveTLSProfile(options);
   }
@@ -796,7 +800,7 @@ class Redis extends Commander implements DataHandledable {
     this.info(function (err, res) {
       if (err) {
         if (err.message && err.message.includes("NOPERM")) {
-          console.warn(
+          _this.options.logger.warn(
             `Skipping the ready check because INFO command fails: "${err.message}". You can disable ready check with "enableReadyCheck". More: https://github.com/luin/ioredis/wiki/Disable-ready-check.`
           );
           return callback(null, {});

--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -23,6 +23,12 @@ export interface NatMap {
   [key: string]: { host: string; port: number };
 }
 
+type Logger = {
+  log(...args: any[]): void;
+  warn(...args: any[]): void;
+  error(...args: any[]): void;
+};
+
 /**
  * Options for Cluster constructor
  */
@@ -196,6 +202,12 @@ export interface ClusterOptions extends CommanderOptions {
     string,
     { lua: string; numberOfKeys?: number; readOnly?: boolean }
   >;
+
+  /**
+   * The logging mechanism to use. If you want to use your own logger, pass an object implementing the `Logger` interface.
+   * @default console
+   */
+  logger?: Logger;
 }
 
 export const DEFAULT_CLUSTER_OPTIONS: ClusterOptions = {
@@ -214,4 +226,5 @@ export const DEFAULT_CLUSTER_OPTIONS: ClusterOptions = {
   dnsLookup: lookup,
   enableAutoPipelining: false,
   autoPipeliningIgnoredCommands: [],
+  logger: console,
 };

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -5,6 +5,12 @@ import { StandaloneConnectionOptions } from "../connectors/StandaloneConnector";
 
 export type ReconnectOnError = (err: Error) => boolean | 1 | 2;
 
+type Logger = {
+  log(...args: any[]): void;
+  warn(...args: any[]): void;
+  error(...args: any[]): void;
+};
+
 export interface CommonRedisOptions extends CommanderOptions {
   Connector?: ConnectorConstructor;
   retryStrategy?: (times: number) => number | void | null;
@@ -179,6 +185,12 @@ export interface CommonRedisOptions extends CommanderOptions {
     string,
     { lua: string; numberOfKeys?: number; readOnly?: boolean }
   >;
+
+  /**
+   * The logging mechanism to use. If you want to use your own logger, pass an object implementing the `Logger` interface.
+   * @default console
+   */
+  logger: Logger;
 }
 
 export type RedisOptions = CommonRedisOptions &
@@ -236,4 +248,5 @@ export const DEFAULT_REDIS_OPTIONS: RedisOptions = {
   enableAutoPipelining: false,
   autoPipeliningIgnoredCommands: [],
   sentinelMaxConnections: 10,
+  logger: console,
 };

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -26,7 +26,7 @@ export function connectHandler(self) {
         }
         if (err) {
           if (err.message.indexOf("no password is set") !== -1) {
-            console.warn(
+            self.options.logger.warn(
               "[WARN] Redis server does not require a password, but a password was supplied."
             );
           } else if (
@@ -34,7 +34,7 @@ export function connectHandler(self) {
               "without any password configured for the default user"
             ) !== -1
           ) {
-            console.warn(
+            self.options.logger.warn(
               "[WARN] This Redis server's `default` user does not require a password, but a password was supplied"
             );
           } else if (
@@ -42,7 +42,7 @@ export function connectHandler(self) {
               "wrong number of arguments for 'auth' command"
             ) !== -1
           ) {
-            console.warn(
+            self.options.logger.warn(
               `[ERROR] The server returned "wrong number of arguments for 'auth' command". You are probably passing both username and password to Redis version 5 or below. You should only pass the 'password' option for Redis version 5 and under.`
             );
           } else {


### PR DESCRIPTION
In many environments logging to console is not recommended, and instead a different logging mechanism is used. This may be to provide metadata, or to ensure the logged message conforms to a particular format (e.g. json), etc..

This Pull Request allows a different logging mechanism to optionally be provided. The logging mechanism must conform to the existing interface expected of `console`; e.g. it must provide an `error`, `warn`, and `log` method.

Defaults to `console`, which is the existing behaviour.