### PR TITLE
fix/docs(readme): javascript truthy shenanigans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1149,7 +1149,7 @@ const cluster = new Redis.Cluster(
   ],
   {
     natMap: (key) => {
-      if(key.indexOf('30001')) {
+      if(key.includes('30001')) {
         return { host: "203.0.113.73", port: 30001 };
       }
 


### PR DESCRIPTION
This specific section is confusing. 

`indexOf` returns `-1` when the string is not found, i.e. a `truthy` value.
Hence, the docs suggest that for some reason, the `napMap` application would apply if and only if the `index` of the string `30001` is not 0.

I think it would be a clearer read to use `includes` as it more accurately aligns with an expected usecase