### PR TITLE
fix: disable client setinfo on error

### DIFF
--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -280,9 +280,10 @@ export function readyHandler(self) {
         })
         .catch(noop)
         .finally(() => {
-          self
-            .client("SETINFO", "LIB-VER", version)
-            .catch(noop);
+          self.client("SETINFO", "LIB-VER", version).catch(() => {
+            // If the server doesn't support CLIENT SETINFO, disable it
+            self.options.disableClientInfo = true;
+          });
         });
 
       self
@@ -293,7 +294,10 @@ export function readyHandler(self) {
             ? `ioredis(${self.options.clientInfoTag})`
             : "ioredis"
         )
-        .catch(noop);
+        .catch(() => {
+          // If the server doesn't support CLIENT SETINFO, disable it
+          self.options.disableClientInfo = true;
+        });
     }
 
     if (self.options.readOnly) {


### PR DESCRIPTION
### Description

This PR fixes a connection issue that occurs when using `reconnectOnError` in client configurations with Redis servers older than version 7.2.x. In these cases, `ioredis` attempts to execute the `CLIENT SETINFO` command, which is not supported in older Redis versions. When combined with `reconnectOnError`, this results in continuous reconnection attempts.

Fixes #2030 & #2031
