### PR TITLE
Fixed issue with moved command for replicas

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -1157,10 +1157,21 @@ class Cluster extends Commander {
       this.subscriberGroupEmitter
     );
 
+    // Error handler used only for sharded-subscriber-triggered slots cache refreshes.
+    // Normal (non-subscriber) connections are created with lazyConnect: true and can
+    // become zombied. For sharded subscribers, a ClusterAllFailedError means
+    // we have lost all nodes from the subscriber perspective and must tear down.
+    const refreshSlotsCacheCallback = (err?: Error) => {
+      // Disconnect only when refreshing the slots cache fails with ClusterAllFailedError
+      if (err instanceof ClusterAllFailedError) {
+        this.disconnect(true);
+      }
+    };
+
     this.subscriberGroupEmitter.on("-node", (redis, nodeKey) => {
       this.emit("-node", redis, nodeKey);
 
-      this.refreshSlotsCache();
+      this.refreshSlotsCache(refreshSlotsCacheCallback);
     });
 
     this.subscriberGroupEmitter.on(
@@ -1169,13 +1180,13 @@ class Cluster extends Commander {
         this.emit("error", error);
 
         setTimeout(() => {
-          this.refreshSlotsCache();
+          this.refreshSlotsCache(refreshSlotsCacheCallback);
         }, delay);
       }
     );
 
     this.subscriberGroupEmitter.on("moved", () => {
-      this.refreshSlotsCache();
+      this.refreshSlotsCache(refreshSlotsCacheCallback);
     });
 
     this.subscriberGroupEmitter.on("-subscriber", () => {


### PR DESCRIPTION
Hi, I was fighting with the issue `All keys in the pipeline should belong to the same slots allocation group` for quite a lot of time.
Obviously this validation message can appear when smth is happening on the cluster and ioredis need some time to recalculate slots mapping. But in my case the cluster remained stable, and this validation messages were randomly shown on different instances of the application.
My PR has fixed the issue for the following scenario:
1. My Redis setup is: enabled sharding + read replica for each master node.
2. `scaleReads` = `all` + `enableAutoPipelining` = `true`
3. ioredis is executing a https://redis.io/docs/latest/commands/readonly/ command for all read replicas in order to avoid `MOVED` messages.
4. Sometimes `READONLY` command can be executed after several get operations already made on the replica(just some race condition, which can easily happen when we have `enableOfflineQueue` and `lazyConnect` features enabled). In this case I receive `MOVED <slot-number> <master-node-host>` response.
5. `MOVED` command is not crucial, but the way moved command is handled is. Currently ioredis is rewriting a slot map without checking what is happening in the slot. With read replicas slot map's value is ['master-node-host', ...<replica-nodes-hosts>]. After rewriting it with the master's node address only future validations will fail on `generateMultiWithNodes` before a slots map refresh.

I hope this fix will help a lot of users to stop receiving issues on the same setup I've described.