### PR TITLE
Revert "Revert "fix: preserve replica slots on MOVED in pipelines (#2…

### DIFF
--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -164,7 +164,13 @@ class Pipeline extends Commander<{ type: "pipeline" }> {
         cluster.handleError(commonError, this.leftRedirections, {
           moved: function (_slot: string, key: string) {
             _this.preferKey = key;
-            cluster.slots[errv[1]] = [key];
+            if (cluster.slots[errv[1]]) {
+                if (cluster.slots[errv[1]][0] !== key) {
+                  cluster.slots[errv[1]] = [key];
+                }
+            } else {
+              cluster.slots[errv[1]] = [key];
+            }
             cluster._groupsBySlot[errv[1]] =
               cluster._groupsIds[cluster.slots[errv[1]].join(";")];
             cluster.refreshSlotsCache();

--- a/test/functional/cluster/pipeline.ts
+++ b/test/functional/cluster/pipeline.ts
@@ -261,4 +261,183 @@ describe("cluster:pipeline", () => {
         done();
       });
   });
+
+  it("should preserve replica information when MOVED error occurs with scaleReads=all and autopipelining", (done) => {
+    const slotTable = [
+      [
+        0,
+        12181,
+        ["127.0.0.1", 30001],
+        ["127.0.0.1", 30003], // replica
+      ],
+      [12182, 16383, ["127.0.0.1", 30002]],
+    ];
+    let movedCount = 0;
+    // Use "bar" which maps to slot 5061 (in range 0-12181 with replica)
+    // MOVED should only happen once, on the master node
+    const getHandler = (argv) => {
+      const cmd = String(argv[0]).toLowerCase();
+      const key = String(argv[1] || "");
+      if (cmd === "get" && key === "bar") {
+        if (movedCount === 0) {
+          // First GET request to master - return MOVED to trigger the fix
+          movedCount++;
+          return new Error("MOVED " + calculateSlot("bar") + " 127.0.0.1:30001");
+        }
+        // After MOVED, all GET requests should succeed
+        return "value";
+      }
+      return undefined;
+    };
+    
+    new MockServer(30001, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      return getHandler(argv);
+    });
+    new MockServer(30002, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      // This node handles different slot range, but add handler to avoid "OK" default
+      return getHandler(argv);
+    });
+    // Replica needs to handle GET requests since scaleReads=all can route reads here
+    // Replica should not return MOVED, just serve the read
+    new MockServer(30003, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      const cmd = String(argv[0]).toLowerCase();
+      const key = String(argv[1] || "");
+      if (cmd === "get" && key === "bar") {
+        return "value";
+      }
+      return undefined;
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: "30001" }], {
+      scaleReads: "all",
+      enableAutoPipelining: true,
+    });
+
+    cluster.on("ready", () => {
+      const slot = calculateSlot("bar");
+      
+      // This should trigger autopipelining and MOVED handling
+      Promise.all([
+        cluster.get("bar"),
+        cluster.get("bar"),
+        cluster.get("bar"),
+      ])
+        .then((results) => {
+          // All should succeed
+          expect(results).to.eql(["value", "value", "value"]);
+
+          // Verify that replica information is preserved after MOVED
+          // Since MOVED points to the same master (30001), the slot array should not be overridden
+          // Check slots after operations to avoid race conditions with Node version differences
+          expect(cluster.slots[slot]).to.include("127.0.0.1:30003");
+          expect(cluster.slots[slot][0]).to.eql("127.0.0.1:30001"); // Master should be at position 0
+
+          cluster.disconnect();
+          done();
+        })
+        .catch((err) => {
+          cluster.disconnect();
+          done(err);
+        });
+    });
+  });
+
+  it("should not throw 'All keys in the pipeline should belong to the same slots allocation group' with scaleReads=all and autopipelining", (done) => {
+    const slotTable = [
+      [
+        0,
+        12181,
+        ["127.0.0.1", 30001],
+        ["127.0.0.1", 30003], // replica
+      ],
+      [12182, 16383, ["127.0.0.1", 30002]],
+    ];
+    let movedHappened = false;
+    // Use "bar" which maps to slot 5061 (in range 0-12181 with replica)
+    new MockServer(30001, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      // Handle both individual commands and pipeline commands
+      const cmd = String(argv[0]).toLowerCase();
+      const key = String(argv[1] || "");
+      
+      if (cmd === "get" && key === "bar") {
+        // Only return MOVED once globally to trigger the fix
+        // After MOVED happens, all subsequent requests should succeed
+        if (!movedHappened) {
+          movedHappened = true;
+          return new Error("MOVED " + calculateSlot("bar") + " 127.0.0.1:30001");
+        }
+        return "value";
+      }
+      if (cmd === "set" && key === "bar") {
+        return "OK";
+      }
+    });
+    new MockServer(30002, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+    });
+    // Replica also needs to handle commands (scaleReads=all can send reads here)
+    // Replica should forward to master, not return MOVED itself
+    new MockServer(30003, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      const cmd = String(argv[0]).toLowerCase();
+      const key = String(argv[1] || "");
+      if (cmd === "get" && key === "bar") {
+        // Replica can serve reads, but if MOVED happens, it should go to master
+        // Never return MOVED from replica - let master handle it
+        return "value";
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: "30001" }], {
+      scaleReads: "all",
+      enableAutoPipelining: true,
+    });
+
+    cluster.on("ready", () => {
+      // Use explicit pipeline to test the fix - should not throw allocation group error
+      // even when MOVED error occurs and slot info might be changed
+      cluster
+        .pipeline()
+        .get("bar")
+        .set("bar", "value")
+        .get("bar")
+        .exec((err, results) => {
+          // Should not throw the allocation group error - this is the main test
+          expect(err).to.eql(null);
+          expect(results).to.be.an("array");
+          expect(results.length).to.eql(3);
+          
+          // All commands should succeed (no errors in results)
+          for (let i = 0; i < results.length; i++) {
+            expect(results[i][0]).to.eql(null); // No error
+          }
+          
+          // Verify we got the expected values (order may vary with retries)
+          const values = results.map((r) => r[1]);
+          const valueCount = values.filter((v) => v === "value").length;
+          const okCount = values.filter((v) => v === "OK").length;
+          expect(valueCount).to.eql(2); // Two GET commands
+          expect(okCount).to.eql(1); // One SET command
+
+          cluster.disconnect();
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
…059)" (#2062)"

This reverts commit 517b93239648c06829c695112223c9f17c2e7f80.