### PR TITLE
chore(ci): add custom Redis version to test matrix

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "unstable-23321515778-debian"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Add `custom-21183968220-debian-amd64` Redis version to the `test_with_cov` workflow matrix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that increases test coverage across Redis versions; main impact is longer CI runtime and potential new failures specific to the added Redis build.
> 
> **Overview**
> The `test_with_cov` GitHub Actions workflow now includes an additional Redis version (`unstable-23321515778-debian`) in its test matrix, causing the full test suite to run against that build in CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92b0786ed8aa15efd32872d173cce153dc36d075. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->