### PR TITLE
fix: redact sensitive command args in error objects

### DIFF
--- a/lib/DataHandler.ts
+++ b/lib/DataHandler.ts
@@ -2,7 +2,7 @@ import { NetStream, CommandItem, Respondable } from "./types";
 import Deque = require("denque");
 import { EventEmitter } from "events";
 import Command from "./Command";
-import { Debug } from "./utils";
+import { Debug, getSafeCommandForError } from "./utils";
 import * as RedisParser from "redis-parser";
 import SubscriptionSet from "./SubscriptionSet";
 
@@ -75,10 +75,10 @@ export default class DataHandler {
       return;
     }
 
-    (err as any).command = {
-      name: item.command.name,
-      args: item.command.args,
-    };
+    (err as any).command = getSafeCommandForError(
+      item.command.name,
+      item.command.args
+    );
 
     if (item.command.name == "ssubscribe" && err.message.includes("MOVED")) {
       this.redis.emit("moved");

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -10,6 +10,7 @@ import {
   noop,
   CONNECTION_CLOSED_ERROR_MSG,
   getPackageMeta,
+  getSafeCommandForError,
 } from "../utils";
 import DataHandler from "../DataHandler";
 
@@ -143,10 +144,7 @@ export function connectHandler(self) {
 
 function abortError(command: Respondable) {
   const err = new AbortError("Command aborted due to connection close");
-  (err as any).command = {
-    name: command.name,
-    args: command.args,
-  };
+  (err as any).command = getSafeCommandForError(command.name, command.args);
   return err;
 }
 

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -358,4 +358,39 @@ export async function getPackageMeta() {
   }
 }
 
+/**
+ * Commands that contain sensitive data that should be redacted
+ * when attached to error objects.
+ */
+const SENSITIVE_COMMANDS = new Set([
+  "auth",
+  "acl",
+  "config",
+]);
+
+type CommandParameter = string | Buffer | number | any[];
+
+/**
+ * Create a safe command object for attaching to errors,
+ * with sensitive arguments redacted.
+ */
+export function getSafeCommandForError(
+  name: string,
+  args: CommandParameter[]
+): { name: string; args: (CommandParameter | "[REDACTED]")[] } {
+  const lowerName = name.toLowerCase();
+
+  // Check if this is a sensitive command
+  if (SENSITIVE_COMMANDS.has(lowerName)) {
+    // For auth, acl setuser, config set requirepass - redact all args
+    // to avoid leaking username/password combinations
+    return {
+      name,
+      args: args.map(() => "[REDACTED]"),
+    };
+  }
+
+  return { name, args };
+}
+
 export { Debug, defaults, noop };


### PR DESCRIPTION
When errors are thrown and include command information (e.g., for debugging purposes), sensitive commands like 'auth', 'acl', and 'config' now have their arguments redacted to '[REDACTED]'.

This prevents credentials from being leaked into logs when authentication fails or connections are aborted.

Commands with redacted args:
- auth (username, password)
- acl (setuser passwords, etc.)
- config (requirepass, etc.)

Closes #1713