### PR TITLE
fix: replace deprecated url.parse() with WHATWG URL API

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -209,25 +209,32 @@ export function parseURL(url: string): Record<string, unknown> {
   if (isInt(url)) {
     return { port: url };
   }
-  const urlStr: string = url;
-
   // Determine if the URL has a known protocol (redis:// or rediss://)
   const hasProtocol =
-    urlStr.startsWith("redis://") || urlStr.startsWith("rediss://");
+    url.startsWith("redis://") || url.startsWith("rediss://");
 
-  // For URLs without a protocol that don't start with "/" (e.g. "127.0.0.1:6379"),
-  // use a dummy base so that `new URL()` can parse them as authority-based URLs.
-  // Unix socket paths (starting with "/") are not valid URLs and are handled separately.
-  if (urlStr[0] === "/") {
-    return { path: urlStr.split("?")[0] };
+  // Unix socket paths (starting with "/") are not valid URLs — handle separately.
+  // Preserve query params (e.g., /tmp/redis.sock?db=2)
+  if (url[0] === "/") {
+    const qIdx = url.indexOf("?");
+    const result: Record<string, unknown> = {
+      path: qIdx === -1 ? url : url.slice(0, qIdx),
+    };
+    if (qIdx !== -1) {
+      const params = new URLSearchParams(url.slice(qIdx + 1));
+      params.forEach((value, key) => {
+        result[key] = value;
+      });
+    }
+    return result;
   }
 
   let parsed: URL;
   if (hasProtocol) {
-    parsed = new URL(urlStr);
+    parsed = new URL(url);
   } else {
     // Prepend a dummy protocol so new URL() can parse "host:port?query" correctly
-    parsed = new URL("redis://" + urlStr);
+    parsed = new URL("redis://" + url);
   }
 
   // Convert searchParams to a plain object (equivalent to url.parse(url, true).query)
@@ -238,8 +245,9 @@ export function parseURL(url: string): Record<string, unknown> {
 
   const result: any = {};
 
-  // Extract auth — WHATWG URL percent-encodes special chars, so decode them
-  if (parsed.username) {
+  // Extract auth — WHATWG URL percent-encodes special chars, so decode them.
+  // Check both username AND password: redis://:password@host has empty username but valid password.
+  if (parsed.username || parsed.password) {
     result.username = decodeURIComponent(parsed.username);
     result.password = decodeURIComponent(parsed.password);
   }
@@ -256,7 +264,9 @@ export function parseURL(url: string): Record<string, unknown> {
   }
 
   if (parsed.hostname) {
-    result.host = parsed.hostname;
+    // WHATWG URL keeps brackets around IPv6 addresses (e.g., "[::1]").
+    // Strip them to match the old url.parse() behavior.
+    result.host = parsed.hostname.replace(/^\[|\]$/g, "");
   }
   if (parsed.port) {
     result.port = parsed.port;

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -214,8 +214,7 @@ export function parseURL(url: string): Record<string, unknown> {
   const rawUrl: string = url;
 
   // Determine if the URL has a known protocol (redis:// or rediss://)
-  const hasProtocol =
-    rawUrl.startsWith("redis://") || rawUrl.startsWith("rediss://");
+  const hasProtocol = /^rediss?:\/\//i.test(rawUrl);
 
   // Unix socket paths (starting with "/") are not valid URLs — handle separately.
   // Preserve query params (e.g., /tmp/redis.sock?db=2)
@@ -225,10 +224,12 @@ export function parseURL(url: string): Record<string, unknown> {
       path: qIdx === -1 ? rawUrl : rawUrl.slice(0, qIdx),
     };
     if (qIdx !== -1) {
+      const options: Record<string, string | number> = {};
       const params = new URLSearchParams(rawUrl.slice(qIdx + 1));
       params.forEach((value, key) => {
-        result[key] = value;
+        options[key] = parseURLQueryItem(key, value);
       });
+      defaults(result, options);
     }
     return result;
   }
@@ -242,9 +243,9 @@ export function parseURL(url: string): Record<string, unknown> {
   }
 
   // Convert searchParams to a plain object (equivalent to url.parse(url, true).query)
-  const options: Record<string, string> = {};
+  const options: Record<string, string | number> = {};
   parsed.searchParams.forEach((value, key) => {
-    options[key] = value;
+    options[key] = parseURLQueryItem(key, value);
   });
 
   const result: any = {};
@@ -276,15 +277,19 @@ export function parseURL(url: string): Record<string, unknown> {
     result.port = parsed.port;
   }
 
-  if (typeof options.family === "string") {
-    const intFamily = Number.parseInt(options.family, 10);
-    if (!Number.isNaN(intFamily)) {
-      result.family = intFamily;
-    }
-  }
   defaults(result, options);
 
   return result;
+}
+
+function parseURLQueryItem(key: string, value: string): string | number {
+  if (key === "family") {
+    const intFamily = Number.parseInt(value, 10);
+    if (!Number.isNaN(intFamily)) {
+      return intFamily;
+    }
+  }
+  return value;
 }
 
 interface TLSOptions {

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -174,6 +174,13 @@ describe("utils", () => {
         password: "pass:word",
         key: "value",
       });
+      expect(utils.parseURL("redis://:authpassword@127.0.0.1:6380/4")).to.eql({
+        host: "127.0.0.1",
+        port: "6380",
+        db: "4",
+        username: "",
+        password: "authpassword",
+      });
       expect(utils.parseURL("redis://user@127.0.0.1:6380/4?key=value")).to.eql({
         host: "127.0.0.1",
         port: "6380",
@@ -202,6 +209,27 @@ describe("utils", () => {
       expect(utils.parseURL("redis://127.0.0.1/?family=IPv6")).to.eql({
         host: "127.0.0.1",
         family: "IPv6",
+      });
+      expect(utils.parseURL("REDIS://127.0.0.1:6379/0")).to.eql({
+        host: "127.0.0.1",
+        port: "6379",
+        db: "0",
+      });
+      expect(utils.parseURL("redis://[::1]:6379/0")).to.eql({
+        host: "::1",
+        port: "6379",
+        db: "0",
+      });
+      expect(utils.parseURL("[::1]:6379")).to.eql({
+        host: "::1",
+        port: "6379",
+      });
+      expect(utils.parseURL("/tmp/redis.sock?key=value")).to.eql({
+        path: "/tmp/redis.sock",
+        key: "value",
+      });
+      expect(utils.parseURL("/tmp/redis.sock?path=/other.sock")).to.eql({
+        path: "/tmp/redis.sock",
       });
     });
   });


### PR DESCRIPTION
## Summary

Replaces the deprecated Node.js `url.parse()` with the WHATWG `URL` API in the `parseURL` function, addressing #1747.

- Replaced `url.parse()` with `new URL()` throughout `parseURL()`
- Handles password-only auth URLs (`redis://:password@host`) correctly — `decodeURIComponent()` on both username and password
- Preserves Unix socket paths with query parameters (`/tmp/redis.sock?db=2`)
- Strips IPv6 hostname brackets to match legacy `url.parse()` behavior
- Handles bare `host:port` strings by prepending `redis://` protocol
- Replaced `.slashes` check with explicit `startsWith("redis://")` / `startsWith("rediss://")`

## Changes

- `lib/utils/index.ts`: Rewrote `parseURL` function (+35/-13 lines)
- Removed `import { parse as urllibParse } from "url"` (URL is a global)

## Property mapping

| `url.parse()` | `new URL()` | Notes |
|---|---|---|
| `.auth` | `.username` + `.password` | Must `decodeURIComponent()` — WHATWG URL percent-encodes |
| `.hostname` | `.hostname` | Strip `[]` brackets for IPv6 |
| `.port` | `.port` | Returns `''` instead of `null` (both falsy) |
| `.pathname` | `.pathname` | Same behavior for `redis://` scheme |
| `.query` | `.searchParams` | Converted to plain object via `forEach` |
| `.slashes` | N/A | Replaced with `startsWith()` protocol check |

## Test plan

- [x] All 12 `parseURL` unit tests pass
- [x] All 6 `Redis` constructor tests pass (including password-only auth)
- [x] TypeScript compilation clean (`tsc --noEmit`)
- [x] ESLint passes (0 errors)
- [x] 136/136 unit tests pass (1 pre-existing sinon failure unrelated to this change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reworks `parseURL`’s parsing logic, which can subtly change connection option resolution (auth/db/host/path/query) for edge-case Redis URLs; coverage is improved but regressions could impact connectivity.
> 
> **Overview**
> Updates `utils.parseURL` to stop using deprecated Node `url.parse()` and instead parse Redis connection strings via the WHATWG `URL`/`URLSearchParams` APIs.
> 
> Adds/adjusts handling for edge cases: password-only auth (`redis://:password@...`), unix socket paths with query params, case-insensitive `redis`/`rediss` schemes, IPv6 hosts (strip `[]`), and bare `host:port` inputs via a prepended protocol; query parsing now normalizes `family` to a number when possible and new unit tests cover these scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d3e0228b9b45515ed8d2a5603b6c788e66e252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->