### PR TITLE
fix: prevent RangeError from string accumulation in pipeline

### DIFF
--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -6,6 +6,7 @@ import Redis from "./Redis";
 import Cluster from "./cluster";
 import Command from "./Command";
 import { Callback, PipelineWriteableStream } from "./types";
+import { constants } from "buffer";
 import { noop } from "./utils";
 import Commander from "./utils/Commander";
 
@@ -372,6 +373,15 @@ Pipeline.prototype.exec = function (callback: Callback): Promise<Array<any>> {
 
           buffers.push(writable);
         } else {
+          if (data.length + writable.length >= constants.MAX_STRING_LENGTH) {
+            if (!buffers) {
+              buffers = [];
+            }
+            if (data) {
+              buffers.push(Buffer.from(data, "utf8"));
+              data = "";
+            }
+          }
           data += writable;
         }
 

--- a/test/functional/autopipelining.ts
+++ b/test/functional/autopipelining.ts
@@ -219,6 +219,22 @@ describe("autoPipelining for single node", () => {
     expect(redis.autoPipelineQueueSize).to.eql(2);
   });
 
+  it("should handle large pipelines without RangeError", async () => {
+    const redis = new Redis({ enableAutoPipelining: true });
+
+    const largeValue = "x".repeat(1024 * 1024);
+    await Promise.all(
+      Array.from({ length: 600 }, (_, i) => redis.set(`key${i}`, largeValue))
+    );
+
+    const results = await Promise.all(
+      Array.from({ length: 600 }, (_, i) => redis.get(`key${i}`))
+    );
+
+    expect(results[0]).to.eql(largeValue);
+    expect(results[599]).to.eql(largeValue);
+  });
+
   it("should handle callbacks failures", (done) => {
     const listeners = process.listeners("uncaughtException");
     process.removeAllListeners("uncaughtException");

--- a/test/functional/cluster/autopipelining.ts
+++ b/test/functional/cluster/autopipelining.ts
@@ -383,6 +383,26 @@ describe("autoPipelining for cluster", () => {
     });
   });
 
+  it("should handle large pipelines without RangeError", async () => {
+    const cluster = new Cluster(hosts, { enableAutoPipelining: true });
+    await new Promise((resolve) => cluster.once("connect", resolve));
+
+    const largeValue = "x".repeat(1024 * 1024);
+
+    await Promise.all(
+      Array.from({ length: 600 }, () => cluster.set("foo1", largeValue))
+    );
+
+    const results = await Promise.all(
+      Array.from({ length: 600 }, () => cluster.get("foo1"))
+    );
+
+    expect(results[0]).to.eql("bar1");
+    expect(results[599]).to.eql("bar1");
+
+    cluster.disconnect();
+  });
+
   it("should handle callbacks failures", (done) => {
     const listeners = process.listeners("uncaughtException");
     process.removeAllListeners("uncaughtException");

--- a/test/functional/cluster/autopipelining.ts
+++ b/test/functional/cluster/autopipelining.ts
@@ -384,21 +384,48 @@ describe("autoPipelining for cluster", () => {
   });
 
   it("should handle large pipelines without RangeError", async () => {
-    const cluster = new Cluster(hosts, { enableAutoPipelining: true });
+    const largeValue = "x".repeat(1024 * 1024);
+    const store = {};
+
+    const slotTable = [
+      [0, 8191, ["127.0.0.1", 30005]],
+      [8192, 16383, ["127.0.0.1", 30006]],
+    ];
+
+    const handler = (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+
+      if (argv[0] === "set") {
+        store[argv[1]] = argv[2];
+        return "OK";
+      }
+
+      if (argv[0] === "get") {
+        return store[argv[1]] || null;
+      }
+    };
+
+    new MockServer(30005, handler);
+    new MockServer(30006, handler);
+
+    const cluster = new Cluster(
+      [{ host: "127.0.0.1", port: 30005 }, { host: "127.0.0.1", port: 30006 }],
+      { enableAutoPipelining: true }
+    );
     await new Promise((resolve) => cluster.once("connect", resolve));
 
-    const largeValue = "x".repeat(1024 * 1024);
-
     await Promise.all(
-      Array.from({ length: 600 }, () => cluster.set("foo1", largeValue))
+      Array.from({ length: 600 }, (_, i) => cluster.set(`key${i}`, largeValue))
     );
 
     const results = await Promise.all(
-      Array.from({ length: 600 }, () => cluster.get("foo1"))
+      Array.from({ length: 600 }, (_, i) => cluster.get(`key${i}`))
     );
 
-    expect(results[0]).to.eql("bar1");
-    expect(results[599]).to.eql("bar1");
+    expect(results[0]).to.eql(largeValue);
+    expect(results[599]).to.eql(largeValue);
 
     cluster.disconnect();
   });


### PR DESCRIPTION
### Problem

When using `enableAutoPipelining` with a high volume of commands or large values, the process crashes with an uncatchable `RangeError: Invalid string length`.

In `Pipeline.ts`, `execPipeline()` serializes all queued commands into a single string via `data += writable`. When a pipeline accumulates enough commands (e.g., many SET commands with large values), this string exceeds V8's maximum string length (~512MB), throwing a `RangeError` that propagates as an uncaught exception.

```
RangeError: Invalid string length
    at Object.write (node_modules/ioredis/built/Pipeline.js:310:29)
    at EventEmitter.sendCommand (node_modules/ioredis/built/Redis.js:389:28)
    at execPipeline (node_modules/ioredis/built/Pipeline.js:330:25)
    at Pipeline.exec (node_modules/ioredis/built/Pipeline.js:282:5)
    at executeAutoPipeline (node_modules/ioredis/built/autoPipelining.js:52:14)
```

There is no way for consumers to catch this error since it is thrown synchronously inside `setImmediate`, `executeAutoPipeline`, `pipeline.exec()`.

### Fix

Before each `data += writable` concatenation, check whether `data.length + writable.length` would reach `buffer.constants.MAX_STRING_LENGTH`. If so, flush `data` into the `buffers` array as a `Buffer` before concatenating. This prevents the string from ever exceeding V8's limit.

The check is a cheap property access and addition per command, zero cost for normal pipelines since the threshold (~512MB) is never approached. The final output is identical since all chunks are concatenated via `Buffer.concat` before writing to the socket.

**Note:** When the flush does trigger (pipelines approaching ~512MB), the `Buffer.from(data, "utf8")` call encodes a large string in one shot, causing a brief spike in memory usage and CPU. This only affects extreme edge cases, and the alternative is a process crash. The threshold could be lowered to flush more frequently with smaller buffers, trading a few extra allocations for reduced memory spikes.

### Test plan

- Added functional test for single-node auto-pipelining with 600 x 1MB SET commands
- Added functional test for cluster auto-pipelining with 600 x 1MB SET commands using a dedicated 2-node MockServer setup with dynamic set/get handlers to verify data integrity across nodes
- Both tests crash with `RangeError: Invalid string length` without the fix
- Verified all existing tests pass (`npm test`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core pipeline write/serialization path; while behavior should be identical, it could affect memory/perf or edge-case encoding when very large pipelines are built.
> 
> **Overview**
> Prevents crashes during `enableAutoPipelining` when very large pipelines are serialized by avoiding unbounded `string` growth in `Pipeline.execPipeline()`.
> 
> When accumulated command payload would exceed `buffer.constants.MAX_STRING_LENGTH`, the code now flushes the current `data` string into a `Buffer[]` and continues building the payload via buffers before the final socket write. Adds new functional tests (single-node and cluster) that run 600×1MB `SET`/`GET` operations to ensure large pipelines no longer throw `RangeError: Invalid string length`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7668a7f2a50ff2ba0d2737a52693e108288d8242. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->