### PR TITLE
feat: Implement `TracingChannel` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ Besides the above connection events, there are several other custom events:
 
 ioredis publishes telemetry through Node.js [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html), allowing APM tools and custom instrumentation to observe commands, connections, and batch operations without modifying application code.
 
-These channels use `TracingChannel#tracePromise()` and emit `start`, `end`, `asyncStart`, `asyncEnd`, and `error` sub-events. Requires Node.js >= 20.13.0; on older versions the channels are silently unavailable (zero overhead). Subscribe via `tracing:<name>:<event>`:
+These channels use `TracingChannel#tracePromise()` and emit `start`, `end`, `asyncStart`, `asyncEnd`, and `error` sub-events. Requires Node.js >= 18.19.0; on older versions the channels are silently unavailable (zero overhead). Subscribe via `tracing:<name>:<event>`:
 
 ```typescript
 import dc from "node:diagnostics_channel";

--- a/README.md
+++ b/README.md
@@ -729,13 +729,16 @@ const stream = redis.zscanStream("myhash", {
   match: "age:??",
 });
 ```
+
 The `hscanStream` also accepts the `noValues` option to specify whether Redis should return only the keys in the hash table without their corresponding values.
+
 ```javascript
 const stream = redis.hscanStream("myhash", {
   match: "age:??",
   noValues: true,
 });
 ```
+
 You can learn more from the [Redis documentation](http://redis.io/commands/scan).
 
 **Useful Tips**
@@ -815,6 +818,7 @@ const redis = new Redis({
 ```
 
 When enabled:
+
 - For commands with a finite timeout (e.g., `blpop("key", 5)`), ioredis sets a client-side deadline based on the command's timeout plus a small grace period (`blockingTimeoutGrace`, default 100ms). If no reply arrives before the deadline, the command resolves with `null`—the same value Redis returns when a blocking command times out normally.
 - For commands that block forever (e.g., `timeout = 0` or `BLOCK 0`), the `blockingTimeout` value is used as a safety net.
 
@@ -842,15 +846,15 @@ On ElastiCache instances with Auto-failover enabled, `reconnectOnError` does not
 
 The Redis instance will emit some events about the state of the connection to the Redis server.
 
-| Event        | Description                                                                                                                                                                                                                                     |
-| :----------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| connect      | emits when a connection is established to the Redis server.                                                                                                                                                                                     |
-| ready        | If `enableReadyCheck` is `true`, client will emit `ready` when the server reports that it is ready to receive commands (e.g. finish loading data from disk).<br>Otherwise, `ready` will be emitted immediately right after the `connect` event. |
-| error        | emits when an error occurs while connecting.<br>However, ioredis emits all `error` events silently (only emits when there's at least one listener) so that your application won't crash if you're not listening to the `error` event.<br>When `redis.connect()` is explicitly called the error will also be rejected from the returned promise, in addition to emitting it. If `redis.connect()` is not called explicitly and `lazyConnect` is true, ioredis will try to connect automatically on the first command and emit the `error` event silently.                                                      |
-| close        | emits when an established Redis server connection has closed.                                                                                                                                                                                   |
-| reconnecting | emits after `close` when a reconnection will be made. The argument of the event is the time (in ms) before reconnecting.                                                                                                                        |
-| end          | emits after `close` when no more reconnections will be made, or the connection is failed to establish.                                                                                                                                          |
-| wait         | emits when `lazyConnect` is set and will wait for the first command to be called before connecting.                                                                                                                                             |
+| Event        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| :----------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| connect      | emits when a connection is established to the Redis server.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ready        | If `enableReadyCheck` is `true`, client will emit `ready` when the server reports that it is ready to receive commands (e.g. finish loading data from disk).<br>Otherwise, `ready` will be emitted immediately right after the `connect` event.                                                                                                                                                                                                                                                                                                          |
+| error        | emits when an error occurs while connecting.<br>However, ioredis emits all `error` events silently (only emits when there's at least one listener) so that your application won't crash if you're not listening to the `error` event.<br>When `redis.connect()` is explicitly called the error will also be rejected from the returned promise, in addition to emitting it. If `redis.connect()` is not called explicitly and `lazyConnect` is true, ioredis will try to connect automatically on the first command and emit the `error` event silently. |
+| close        | emits when an established Redis server connection has closed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| reconnecting | emits after `close` when a reconnection will be made. The argument of the event is the time (in ms) before reconnecting.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| end          | emits after `close` when no more reconnections will be made, or the connection is failed to establish.                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| wait         | emits when `lazyConnect` is set and will wait for the first command to be called before connecting.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 You can also check out the `Redis#status` property to get the current connection status.
 
@@ -859,6 +863,38 @@ Besides the above connection events, there are several other custom events:
 | Event  | Description                                                         |
 | :----- | :------------------------------------------------------------------ |
 | select | emits when the database changed. The argument is the new db number. |
+
+## Diagnostics Channel
+
+ioredis publishes telemetry through Node.js [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html), allowing APM tools and custom instrumentation to observe commands, connections, and batch operations without modifying application code.
+
+Requires Node.js >= 18.19.0. These channels use `TracingChannel#tracePromise()` and emit `start`, `end`, `asyncStart`, `asyncEnd`, and `error` sub-events. Subscribe via `tracing:<name>:<event>`:
+
+```typescript
+import dc from "node:diagnostics_channel";
+
+dc.subscribe("tracing:ioredis:command:start", ({ command, args }) => {
+  console.log(`> ${command}`, args);
+});
+
+dc.subscribe("tracing:ioredis:command:asyncEnd", ({ command }) => {
+  console.log(`${command} settled`);
+});
+
+dc.subscribe("tracing:ioredis:command:error", ({ command, error }) => {
+  console.error(`${command} failed:`, error);
+});
+```
+
+| Channel name      | Payload                                          | Description                                 |
+| :---------------- | :----------------------------------------------- | :------------------------------------------ |
+| `ioredis:command` | `CommandTraceContext / BatchCommandTraceContext` | Individual command (standalone or pipeline) |
+| `ioredis:batch`   | `BatchOperationContext`                          | MULTI batch as a whole                      |
+| `ioredis:connect` | `ConnectTraceContext`                            | Socket connection attempt                   |
+
+Command arguments are sanitized before emission using rules adapted from `@opentelemetry/redis-common`. Sensitive values (e.g. values in `SET`, `AUTH` passwords) are replaced with `?`, while read-only commands like `GET` and `DEL` retain all arguments. This is safe by default: unlisted or custom commands have all arguments redacted.
+
+Context types (`CommandTraceContext`, `BatchCommandTraceContext`, `BatchOperationContext`, `ConnectTraceContext`) are exported from `ioredis`.
 
 ## Offline Queue
 
@@ -1159,6 +1195,7 @@ const cluster = new Redis.Cluster(
 ```
 
 Or you can specify this parameter through function:
+
 ```javascript
 const cluster = new Redis.Cluster(
   [
@@ -1169,7 +1206,7 @@ const cluster = new Redis.Cluster(
   ],
   {
     natMap: (key) => {
-      if(key.includes('30001')) {
+      if (key.includes("30001")) {
         return { host: "203.0.113.73", port: 30001 };
       }
 
@@ -1226,27 +1263,32 @@ For sharded Pub/Sub, use the `spublish` and `ssubscribe` commands instead of the
 The following basic example shows you how to use sharded Pub/Sub:
 
 ```javascript
-const cluster: Cluster = new Cluster([{host: host, port: port}], {shardedSubscribers: true});
+const cluster: Cluster = new Cluster([{ host: host, port: port }], {
+  shardedSubscribers: true,
+});
 
 //Register the callback
 cluster.on("smessage", (channel, message) => {
-    console.log(message);
+  console.log(message);
 });
-
 
 //Subscribe to the channels on the same slot
-cluster.ssubscribe("channel{my}:1", "channel{my}:2").then( ( count: number ) => {
+cluster
+  .ssubscribe("channel{my}:1", "channel{my}:2")
+  .then((count: number) => {
     console.log(count);
-}).catch( (err) => {
+  })
+  .catch((err) => {
     console.log(err);
-});
+  });
 
 //Publish a message
-cluster.spublish("channel{my}:1", "This is a test message to my first channel.").then((value: number) => {
+cluster
+  .spublish("channel{my}:1", "This is a test message to my first channel.")
+  .then((value: number) => {
     console.log("Published a message to channel{my}:1");
-});
+  });
 ```
-
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -886,15 +886,15 @@ dc.subscribe("tracing:ioredis:command:error", ({ command, error }) => {
 });
 ```
 
-| Channel name      | Payload                                          | Description                                 |
-| :---------------- | :----------------------------------------------- | :------------------------------------------ |
-| `ioredis:command` | `CommandTraceContext / BatchCommandTraceContext` | Individual command (standalone or pipeline) |
-| `ioredis:batch`   | `BatchOperationContext`                          | MULTI batch as a whole                      |
-| `ioredis:connect` | `ConnectTraceContext`                            | Socket connection attempt                   |
+| Channel name      | Payload                 | Description                                              |
+| :---------------- | :---------------------- | :------------------------------------------------------- |
+| `ioredis:command` | `CommandTraceContext`   | Individual command (standalone, pipeline, or within MULTI) |
+| `ioredis:batch`   | `BatchOperationContext` | MULTI transaction as a whole                             |
+| `ioredis:connect` | `ConnectTraceContext`   | Socket connection attempt                                |
 
 Command arguments are sanitized before emission using rules adapted from `@opentelemetry/redis-common`. Sensitive values (e.g. values in `SET`, `AUTH` passwords) are replaced with `?`, while read-only commands like `GET` and `DEL` retain all arguments. This is safe by default: unlisted or custom commands have all arguments redacted.
 
-Context types (`CommandTraceContext`, `BatchCommandTraceContext`, `BatchOperationContext`, `ConnectTraceContext`) are exported from `ioredis`.
+Context types (`CommandTraceContext`, `BatchOperationContext`, `ConnectTraceContext`) are exported from `ioredis`.
 
 ## Offline Queue
 

--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ Besides the above connection events, there are several other custom events:
 
 ioredis publishes telemetry through Node.js [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html), allowing APM tools and custom instrumentation to observe commands, connections, and batch operations without modifying application code.
 
-Requires Node.js >= 18.19.0. These channels use `TracingChannel#tracePromise()` and emit `start`, `end`, `asyncStart`, `asyncEnd`, and `error` sub-events. Subscribe via `tracing:<name>:<event>`:
+These channels use `TracingChannel#tracePromise()` and emit `start`, `end`, `asyncStart`, `asyncEnd`, and `error` sub-events. Requires Node.js >= 20.13.0; on older versions the channels are silently unavailable (zero overhead). Subscribe via `tracing:<name>:<event>`:
 
 ```typescript
 import dc from "node:diagnostics_channel";

--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -205,6 +205,7 @@ export default class Command implements Respondable {
   args: CommandParameter[];
   inTransaction = false;
   pipelineIndex?: number;
+  isTraced = false;
 
   isResolved = false;
   reject: (err: Error) => void;

--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -205,7 +205,7 @@ export default class Command implements Respondable {
   args: CommandParameter[];
   inTransaction = false;
   pipelineIndex?: number;
-  batchMode?: "pipeline" | "multi";
+  batchMode?: "PIPELINE" | "MULTI";
   batchSize?: number;
 
   isResolved = false;

--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -205,8 +205,6 @@ export default class Command implements Respondable {
   args: CommandParameter[];
   inTransaction = false;
   pipelineIndex?: number;
-  batchMode?: "PIPELINE" | "MULTI";
-  batchSize?: number;
 
   isResolved = false;
   reject: (err: Error) => void;

--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -205,6 +205,8 @@ export default class Command implements Respondable {
   args: CommandParameter[];
   inTransaction = false;
   pipelineIndex?: number;
+  batchMode?: "pipeline" | "multi";
+  batchSize?: number;
 
   isResolved = false;
   reject: (err: Error) => void;

--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -395,8 +395,8 @@ Pipeline.prototype.exec = function (callback: Callback): Promise<Array<any>> {
 
     // Determine batch mode: if any command is inTransaction, this is a multi
     const batchMode = _this._queue.some((cmd) => cmd.inTransaction)
-      ? "multi" as const
-      : "pipeline" as const;
+      ? "MULTI" as const
+      : "PIPELINE" as const;
     const batchSize = _this._queue.length;
 
     for (let i = 0; i < _this._queue.length; ++i) {

--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -7,6 +7,7 @@ import Cluster from "./cluster";
 import Command from "./Command";
 import { Callback, PipelineWriteableStream } from "./types";
 import { noop } from "./utils";
+import { traceBatch } from "./tracing";
 import Commander from "./utils/Commander";
 
 /*
@@ -408,6 +409,16 @@ Pipeline.prototype.exec = function (callback: Callback): Promise<Array<any>> {
       _this._queue[i].batchSize = batchSize;
       _this.redis.sendCommand(_this._queue[i], stream, node);
     }
+
+    // MULTI is traced as a single batch operation on ioredis:batch.
+    // Pipeline commands are traced per-command on ioredis:command (in sendCommand).
+    if (isMulti) {
+      return traceBatch(
+        () => _this.promise,
+        () => _this.redis._buildBatchContext(batchSize)
+      );
+    }
+
     return _this.promise;
   }
 };

--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -393,7 +393,15 @@ Pipeline.prototype.exec = function (callback: Callback): Promise<Array<any>> {
       },
     };
 
+    // Determine batch mode: if any command is inTransaction, this is a multi
+    const batchMode = _this._queue.some((cmd) => cmd.inTransaction)
+      ? "multi" as const
+      : "pipeline" as const;
+    const batchSize = _this._queue.length;
+
     for (let i = 0; i < _this._queue.length; ++i) {
+      _this._queue[i].batchMode = batchMode;
+      _this._queue[i].batchSize = batchSize;
       _this.redis.sendCommand(_this._queue[i], stream, node);
     }
     return _this.promise;

--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -7,7 +7,6 @@ import Cluster from "./cluster";
 import Command from "./Command";
 import { Callback, PipelineWriteableStream } from "./types";
 import { noop } from "./utils";
-import { traceBatch } from "./tracing";
 import Commander from "./utils/Commander";
 
 /*
@@ -166,9 +165,9 @@ class Pipeline extends Commander<{ type: "pipeline" }> {
           moved: function (_slot: string, key: string) {
             _this.preferKey = key;
             if (cluster.slots[errv[1]]) {
-              if (cluster.slots[errv[1]][0] !== key) {
-                cluster.slots[errv[1]] = [key];
-              }
+                if (cluster.slots[errv[1]][0] !== key) {
+                  cluster.slots[errv[1]] = [key];
+                }
             } else {
               cluster.slots[errv[1]] = [key];
             }
@@ -394,32 +393,9 @@ Pipeline.prototype.exec = function (callback: Callback): Promise<Array<any>> {
       },
     };
 
-    // Determine batch mode: if any command is inTransaction, this is a multi
-    const isMulti = _this._queue.some((cmd) => cmd.inTransaction);
-    const batchMode = isMulti ? ("MULTI" as const) : ("PIPELINE" as const);
-    // For MULTI, count only user commands: EXEC already has inTransaction=false
-    // (exec() decrements _transactions before sendCommand), and MULTI is excluded
-    // by name since multi() increments _transactions before sendCommand runs.
-    const batchSize = isMulti
-      ? _this._queue.filter((cmd) => cmd.inTransaction && cmd.name !== "multi")
-          .length
-      : _this._queue.length;
-
     for (let i = 0; i < _this._queue.length; ++i) {
-      _this._queue[i].batchMode = batchMode;
-      _this._queue[i].batchSize = batchSize;
       _this.redis.sendCommand(_this._queue[i], stream, node);
     }
-
-    // MULTI is traced as a single batch operation on ioredis:batch.
-    // Pipeline commands are traced per-command on ioredis:command (in sendCommand).
-    if (isMulti && "_buildBatchContext" in _this.redis) {
-      return traceBatch(
-        () => _this.promise,
-        () => (_this.redis as Redis)._buildBatchContext(batchSize)
-      );
-    }
-
     return _this.promise;
   }
 };

--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -166,9 +166,9 @@ class Pipeline extends Commander<{ type: "pipeline" }> {
           moved: function (_slot: string, key: string) {
             _this.preferKey = key;
             if (cluster.slots[errv[1]]) {
-                if (cluster.slots[errv[1]][0] !== key) {
-                  cluster.slots[errv[1]] = [key];
-                }
+              if (cluster.slots[errv[1]][0] !== key) {
+                cluster.slots[errv[1]] = [key];
+              }
             } else {
               cluster.slots[errv[1]] = [key];
             }
@@ -396,12 +396,13 @@ Pipeline.prototype.exec = function (callback: Callback): Promise<Array<any>> {
 
     // Determine batch mode: if any command is inTransaction, this is a multi
     const isMulti = _this._queue.some((cmd) => cmd.inTransaction);
-    const batchMode = isMulti ? "MULTI" as const : "PIPELINE" as const;
+    const batchMode = isMulti ? ("MULTI" as const) : ("PIPELINE" as const);
     // For MULTI, count only user commands: EXEC already has inTransaction=false
     // (exec() decrements _transactions before sendCommand), and MULTI is excluded
     // by name since multi() increments _transactions before sendCommand runs.
     const batchSize = isMulti
-      ? _this._queue.filter((cmd) => cmd.inTransaction && cmd.name !== "multi").length
+      ? _this._queue.filter((cmd) => cmd.inTransaction && cmd.name !== "multi")
+          .length
       : _this._queue.length;
 
     for (let i = 0; i < _this._queue.length; ++i) {

--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -413,10 +413,10 @@ Pipeline.prototype.exec = function (callback: Callback): Promise<Array<any>> {
 
     // MULTI is traced as a single batch operation on ioredis:batch.
     // Pipeline commands are traced per-command on ioredis:command (in sendCommand).
-    if (isMulti) {
+    if (isMulti && "_buildBatchContext" in _this.redis) {
       return traceBatch(
         () => _this.promise,
-        () => _this.redis._buildBatchContext(batchSize)
+        () => (_this.redis as Redis)._buildBatchContext(batchSize)
       );
     }
 

--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -394,10 +394,14 @@ Pipeline.prototype.exec = function (callback: Callback): Promise<Array<any>> {
     };
 
     // Determine batch mode: if any command is inTransaction, this is a multi
-    const batchMode = _this._queue.some((cmd) => cmd.inTransaction)
-      ? "MULTI" as const
-      : "PIPELINE" as const;
-    const batchSize = _this._queue.length;
+    const isMulti = _this._queue.some((cmd) => cmd.inTransaction);
+    const batchMode = isMulti ? "MULTI" as const : "PIPELINE" as const;
+    // For MULTI, count only user commands: EXEC already has inTransaction=false
+    // (exec() decrements _transactions before sendCommand), and MULTI is excluded
+    // by name since multi() increments _transactions before sendCommand runs.
+    const batchSize = isMulti
+      ? _this._queue.filter((cmd) => cmd.inTransaction && cmd.name !== "multi").length
+      : _this._queue.length;
 
     for (let i = 0; i < _this._queue.length; ++i) {
       _this._queue[i].batchMode = batchMode;

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -29,6 +29,7 @@ import {
   parseURL,
   resolveTLSProfile,
 } from "./utils";
+import { traceCommand, traceConnect, type CommandContext } from "./tracing";
 import applyMixin from "./utils/applyMixin";
 import Commander from "./utils/Commander";
 import { defaults, noop } from "./utils/lodash";
@@ -174,7 +175,19 @@ class Redis extends Commander implements DataHandledable {
    * if the connection fails, times out, or if Redis is already connecting/connected.
    */
   connect(callback?: Callback<void>): Promise<void> {
-    const promise = new Promise<void>((resolve, reject) => {
+    const promise = traceConnect(
+      () => this._connect(),
+      () => {
+        const { address, port } = this._getServerAddress();
+        return { serverAddress: address, serverPort: port };
+      }
+    );
+
+    return asCallback(promise, callback);
+  }
+
+  private _connect(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
       if (
         this.status === "connecting" ||
         this.status === "connect" ||
@@ -299,8 +312,6 @@ class Redis extends Commander implements DataHandledable {
         }
       );
     });
-
-    return asCallback(promise, callback);
   }
 
   /**
@@ -557,7 +568,11 @@ class Redis extends Commander implements DataHandledable {
       }
     }
 
-    return command.promise;
+    // Wrap command promise with tracing (zero-cost when no subscribers)
+    return traceCommand(
+      () => command.promise as Promise<unknown>,
+      () => this._buildCommandContext(command)
+    );
   }
 
   private getBlockingTimeoutInMs(command: Command): number | undefined {
@@ -735,6 +750,35 @@ class Redis extends Commander implements DataHandledable {
       default:
         item.command.reject(err);
     }
+  }
+
+  /**
+   * @ignore
+   */
+  _getServerAddress(): { address: string; port: number | undefined } {
+    if ("path" in this.options && this.options.path) {
+      return { address: this.options.path, port: undefined };
+    }
+    return {
+      address: ("host" in this.options && this.options.host) || "localhost",
+      port: ("port" in this.options && this.options.port) || 6379,
+    };
+  }
+
+  private _buildCommandContext(command: Command): CommandContext {
+    const { address, port } = this._getServerAddress();
+    const ctx: CommandContext = {
+      command: command.name,
+      args: command.args,
+      database: this.condition?.select ?? this.options.db ?? 0,
+      serverAddress: address,
+      serverPort: port,
+    };
+    if (command.batchMode) {
+      ctx.batchMode = command.batchMode;
+      ctx.batchSize = command.batchSize;
+    }
+    return ctx;
   }
 
   /**

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -179,7 +179,7 @@ class Redis extends Commander implements DataHandledable {
       () => this._connect(),
       () => {
         const { address, port } = this._getServerAddress();
-        return { serverAddress: address, serverPort: port };
+        return { serverAddress: address, serverPort: port, connectionEpoch: this.connectionEpoch };
       }
     );
 

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -581,14 +581,15 @@ class Redis extends Commander implements DataHandledable {
       }
     }
 
-    if (!writable) {
-      // Offline-queued: skip tracing here. The command will be re-sent via
-      // sendCommand when the connection is ready, and traced at that point.
+    if (!writable || command.isTraced) {
       return command.promise;
     }
 
-    // Trace on the write path only, so offline-queued commands that get
-    // re-sent aren't traced twice.
+    // Trace on the write path only, and only once per command. Commands may
+    // pass through sendCommand multiple times (offline queue flush,
+    // prevCommandQueue resend after reconnect). The isTraced flag ensures
+    // we don't emit duplicate trace events.
+    command.isTraced = true;
     return traceCommand(
       () => command.promise as Promise<unknown>,
       () => this._buildCommandContext(command)

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -29,7 +29,7 @@ import {
   parseURL,
   resolveTLSProfile,
 } from "./utils";
-import { traceCommand, traceConnect, sanitizeArgs, type CommandTraceContext, type BatchCommandTraceContext } from "./tracing";
+import { traceCommand, traceConnect, sanitizeArgs, type CommandTraceContext, type BatchCommandTraceContext, type BatchOperationContext } from "./tracing";
 import applyMixin from "./utils/applyMixin";
 import Commander from "./utils/Commander";
 import { defaults, noop } from "./utils/lodash";
@@ -574,6 +574,12 @@ class Redis extends Commander implements DataHandledable {
       return command.promise;
     }
 
+    // MULTI commands are traced as a single batch via ioredis:batch in Pipeline.
+    // Skip per-command tracing to avoid duplicate events.
+    if (command.batchMode === "MULTI") {
+      return command.promise;
+    }
+
     // Trace on the write path only, so offline-queued commands that get
     // re-sent aren't traced twice.
     return traceCommand(
@@ -781,14 +787,25 @@ class Redis extends Commander implements DataHandledable {
       serverAddress: address,
       serverPort: port,
     };
-    if (command.batchMode) {
+    if (command.batchMode === "PIPELINE") {
       return {
         ...base,
-        batchMode: command.batchMode,
+        batchMode: "PIPELINE",
         batchSize: command.batchSize!,
       };
     }
     return base;
+  }
+
+  _buildBatchContext(batchSize: number): BatchOperationContext {
+    const { address, port } = this._getServerAddress();
+    return {
+      batchMode: "MULTI",
+      batchSize,
+      database: this.condition?.select ?? this.options.db ?? 0,
+      serverAddress: address,
+      serverPort: port,
+    };
   }
 
   /**

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -568,7 +568,14 @@ class Redis extends Commander implements DataHandledable {
       }
     }
 
-    // Wrap command promise with tracing (zero-cost when no subscribers)
+    if (!writable) {
+      // Offline-queued: skip tracing here. The command will be re-sent via
+      // sendCommand when the connection is ready, and traced at that point.
+      return command.promise;
+    }
+
+    // Trace on the write path only, so offline-queued commands that get
+    // re-sent aren't traced twice.
     return traceCommand(
       () => command.promise as Promise<unknown>,
       () => this._buildCommandContext(command)

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -29,7 +29,7 @@ import {
   parseURL,
   resolveTLSProfile,
 } from "./utils";
-import { traceCommand, traceConnect, type CommandContext } from "./tracing";
+import { traceCommand, traceConnect, type CommandTraceContext, type BatchCommandTraceContext } from "./tracing";
 import applyMixin from "./utils/applyMixin";
 import Commander from "./utils/Commander";
 import { defaults, noop } from "./utils/lodash";
@@ -765,9 +765,9 @@ class Redis extends Commander implements DataHandledable {
     };
   }
 
-  private _buildCommandContext(command: Command): CommandContext {
+  private _buildCommandContext(command: Command): CommandTraceContext | BatchCommandTraceContext {
     const { address, port } = this._getServerAddress();
-    const ctx: CommandContext = {
+    const base: CommandTraceContext = {
       command: command.name,
       args: command.args,
       database: this.condition?.select ?? this.options.db ?? 0,
@@ -775,10 +775,13 @@ class Redis extends Commander implements DataHandledable {
       serverPort: port,
     };
     if (command.batchMode) {
-      ctx.batchMode = command.batchMode;
-      ctx.batchSize = command.batchSize;
+      return {
+        ...base,
+        batchMode: command.batchMode,
+        batchSize: command.batchSize!,
+      };
     }
-    return ctx;
+    return base;
   }
 
   /**

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -29,7 +29,14 @@ import {
   parseURL,
   resolveTLSProfile,
 } from "./utils";
-import { traceCommand, traceConnect, sanitizeArgs, type CommandTraceContext, type BatchCommandTraceContext, type BatchOperationContext } from "./tracing";
+import {
+  traceCommand,
+  traceConnect,
+  sanitizeArgs,
+  type CommandTraceContext,
+  type BatchCommandTraceContext,
+  type BatchOperationContext,
+} from "./tracing";
 import applyMixin from "./utils/applyMixin";
 import Commander from "./utils/Commander";
 import { defaults, noop } from "./utils/lodash";
@@ -179,7 +186,11 @@ class Redis extends Commander implements DataHandledable {
       () => this._connect(),
       () => {
         const { address, port } = this._getServerAddress();
-        return { serverAddress: address, serverPort: port, connectionEpoch: this.connectionEpoch };
+        return {
+          serverAddress: address,
+          serverPort: port,
+          connectionEpoch: this.connectionEpoch,
+        };
       }
     );
 
@@ -554,7 +565,10 @@ class Redis extends Commander implements DataHandledable {
         this.manuallyClosing = true;
       }
 
-      if (this.options.socketTimeout !== undefined && this.socketTimeoutTimer === undefined) {
+      if (
+        this.options.socketTimeout !== undefined &&
+        this.socketTimeoutTimer === undefined
+      ) {
         this.setSocketTimeout();
       }
     }
@@ -603,7 +617,11 @@ class Redis extends Commander implements DataHandledable {
     if (typeof timeout === "number") {
       if (timeout > 0) {
         // Finite timeout from command args - add grace period
-        return timeout + (this.options.blockingTimeoutGrace ?? DEFAULT_REDIS_OPTIONS.blockingTimeoutGrace);
+        return (
+          timeout +
+          (this.options.blockingTimeoutGrace ??
+            DEFAULT_REDIS_OPTIONS.blockingTimeoutGrace)
+        );
       }
       // Command has timeout=0 (block forever), use blockingTimeout option as safety net
       return configuredTimeout;
@@ -630,7 +648,11 @@ class Redis extends Commander implements DataHandledable {
 
   private setSocketTimeout() {
     this.socketTimeoutTimer = setTimeout(() => {
-      this.stream.destroy(new Error(`Socket timeout. Expecting data, but didn't receive any in ${this.options.socketTimeout}ms.`));
+      this.stream.destroy(
+        new Error(
+          `Socket timeout. Expecting data, but didn't receive any in ${this.options.socketTimeout}ms.`
+        )
+      );
       this.socketTimeoutTimer = undefined;
     }, this.options.socketTimeout);
 
@@ -778,7 +800,9 @@ class Redis extends Commander implements DataHandledable {
     };
   }
 
-  private _buildCommandContext(command: Command): CommandTraceContext | BatchCommandTraceContext {
+  private _buildCommandContext(
+    command: Command
+  ): CommandTraceContext | BatchCommandTraceContext {
     const { address, port } = this._getServerAddress();
     const base: CommandTraceContext = {
       command: command.name,

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -29,7 +29,7 @@ import {
   parseURL,
   resolveTLSProfile,
 } from "./utils";
-import { traceCommand, traceConnect, type CommandTraceContext, type BatchCommandTraceContext } from "./tracing";
+import { traceCommand, traceConnect, sanitizeArgs, type CommandTraceContext, type BatchCommandTraceContext } from "./tracing";
 import applyMixin from "./utils/applyMixin";
 import Commander from "./utils/Commander";
 import { defaults, noop } from "./utils/lodash";
@@ -776,7 +776,7 @@ class Redis extends Commander implements DataHandledable {
     const { address, port } = this._getServerAddress();
     const base: CommandTraceContext = {
       command: command.name,
-      args: command.args,
+      args: sanitizeArgs(command.name, command.args),
       database: this.condition?.select ?? this.options.db ?? 0,
       serverAddress: address,
       serverPort: port,

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -34,7 +34,6 @@ import {
   traceConnect,
   sanitizeArgs,
   type CommandTraceContext,
-  type BatchCommandTraceContext,
   type BatchOperationContext,
 } from "./tracing";
 import applyMixin from "./utils/applyMixin";
@@ -588,12 +587,6 @@ class Redis extends Commander implements DataHandledable {
       return command.promise;
     }
 
-    // MULTI commands are traced as a single batch via ioredis:batch in Pipeline.
-    // Skip per-command tracing to avoid duplicate events.
-    if (command.batchMode === "MULTI") {
-      return command.promise;
-    }
-
     // Trace on the write path only, so offline-queued commands that get
     // re-sent aren't traced twice.
     return traceCommand(
@@ -802,23 +795,15 @@ class Redis extends Commander implements DataHandledable {
 
   private _buildCommandContext(
     command: Command
-  ): CommandTraceContext | BatchCommandTraceContext {
+  ): CommandTraceContext {
     const { address, port } = this._getServerAddress();
-    const base: CommandTraceContext = {
+    return {
       command: command.name,
       args: sanitizeArgs(command.name, command.args),
       database: this.condition?.select ?? this.options.db ?? 0,
       serverAddress: address,
       serverPort: port,
     };
-    if (command.batchMode === "PIPELINE") {
-      return {
-        ...base,
-        batchMode: "PIPELINE",
-        batchSize: command.batchSize!,
-      };
-    }
-    return base;
   }
 
   _buildBatchContext(batchSize: number): BatchOperationContext {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -70,7 +70,6 @@ export type {
 // Tracing types for diagnostics_channel consumers
 export type {
   CommandTraceContext,
-  BatchCommandTraceContext,
   BatchOperationContext,
   ConnectTraceContext,
 } from "./tracing";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,7 +68,12 @@ export type {
 } from "./utils/RedisCommander";
 
 // Tracing types for diagnostics_channel consumers
-export type { CommandTraceContext, BatchCommandTraceContext, ConnectTraceContext } from "./tracing";
+export type {
+  CommandTraceContext,
+  BatchCommandTraceContext,
+  BatchOperationContext,
+  ConnectTraceContext,
+} from "./tracing";
 
 // No TS typings
 export const ReplyError = require("redis-errors").ReplyError;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -67,6 +67,9 @@ export type {
   ChainableCommander,
 } from "./utils/RedisCommander";
 
+// Tracing types for diagnostics_channel consumers
+export type { CommandContext, ConnectContext } from "./tracing";
+
 // No TS typings
 export const ReplyError = require("redis-errors").ReplyError;
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,7 +68,7 @@ export type {
 } from "./utils/RedisCommander";
 
 // Tracing types for diagnostics_channel consumers
-export type { CommandContext, ConnectContext } from "./tracing";
+export type { CommandTraceContext, BatchCommandTraceContext, ConnectTraceContext } from "./tracing";
 
 // No TS typings
 export const ReplyError = require("redis-errors").ReplyError;

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -1,0 +1,71 @@
+import type { CommandParameter } from "./types";
+
+// Context types for the two tracing channels
+export interface CommandContext {
+  command: string;
+  args: CommandParameter[];
+  database: number;
+  serverAddress: string;
+  serverPort: number | undefined;
+  batchMode?: "pipeline" | "multi";
+  batchSize?: number;
+}
+
+export interface ConnectContext {
+  serverAddress: string;
+  serverPort: number | undefined;
+}
+
+// Shim interface to fix @types/node gaps:
+// - hasSubscribers is missing on TracingChannel
+// - tracePromise is typed as returning void but returns the promise at runtime
+interface TracingChannel<ContextType> {
+  readonly hasSubscribers: boolean;
+  tracePromise<T>(
+    fn: () => Promise<T>,
+    context?: ContextType
+  ): Promise<T>;
+}
+
+// Load diagnostics_channel with Node 18 compatibility
+const dc: any = (() => {
+  try {
+    return ("getBuiltinModule" in process)
+      ? (process as any).getBuiltinModule("node:diagnostics_channel")
+      : require("node:diagnostics_channel");
+  } catch {
+    return undefined;
+  }
+})();
+
+const hasTracingChannel = dc && typeof dc.tracingChannel === "function";
+
+const commandChannel: TracingChannel<CommandContext> | undefined =
+  hasTracingChannel
+    ? (dc.tracingChannel("ioredis:command") as TracingChannel<CommandContext>)
+    : undefined;
+
+const connectChannel: TracingChannel<ConnectContext> | undefined =
+  hasTracingChannel
+    ? (dc.tracingChannel("ioredis:connect") as TracingChannel<ConnectContext>)
+    : undefined;
+
+export function traceCommand<T>(
+  fn: () => Promise<T>,
+  contextFactory: () => CommandContext
+): Promise<T> {
+  if (commandChannel?.hasSubscribers) {
+    return commandChannel.tracePromise(fn, contextFactory());
+  }
+  return fn();
+}
+
+export function traceConnect<T>(
+  fn: () => Promise<T>,
+  contextFactory: () => ConnectContext
+): Promise<T> {
+  if (connectChannel?.hasSubscribers) {
+    return connectChannel.tracePromise(fn, contextFactory());
+  }
+  return fn();
+}

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -1,20 +1,25 @@
 import type { CommandParameter } from "./types";
 
 // Context types for the two tracing channels
-export interface CommandContext {
+export interface CommandTraceContext {
   command: string;
   args: CommandParameter[];
   database: number;
   serverAddress: string;
   serverPort: number | undefined;
-  batchMode?: "pipeline" | "multi";
-  batchSize?: number;
 }
 
-export interface ConnectContext {
+export interface BatchCommandTraceContext extends CommandTraceContext {
+  batchMode: "pipeline" | "multi";
+  batchSize: number;
+}
+
+export interface ConnectTraceContext {
   serverAddress: string;
   serverPort: number | undefined;
 }
+
+type CommandContext = CommandTraceContext | BatchCommandTraceContext;
 
 // Shim interface to fix @types/node gaps:
 // - hasSubscribers is missing on TracingChannel
@@ -45,9 +50,9 @@ const commandChannel: TracingChannel<CommandContext> | undefined =
     ? (dc.tracingChannel("ioredis:command") as TracingChannel<CommandContext>)
     : undefined;
 
-const connectChannel: TracingChannel<ConnectContext> | undefined =
+const connectChannel: TracingChannel<ConnectTraceContext> | undefined =
   hasTracingChannel
-    ? (dc.tracingChannel("ioredis:connect") as TracingChannel<ConnectContext>)
+    ? (dc.tracingChannel("ioredis:connect") as TracingChannel<ConnectTraceContext>)
     : undefined;
 
 export function traceCommand<T>(
@@ -62,7 +67,7 @@ export function traceCommand<T>(
 
 export function traceConnect<T>(
   fn: () => Promise<T>,
-  contextFactory: () => ConnectContext
+  contextFactory: () => ConnectTraceContext
 ): Promise<T> {
   if (connectChannel?.hasSubscribers) {
     return connectChannel.tracePromise(fn, contextFactory());

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -58,13 +58,6 @@ export interface CommandTraceContext {
   serverPort: number | undefined;
 }
 
-export interface BatchCommandTraceContext extends CommandTraceContext {
-  batchMode: "PIPELINE";
-  batchSize: number;
-}
-
-// Context for the batch operation itself (MULTI as a whole).
-// Distinct from BatchCommandTraceContext which is a single command within a pipeline.
 export interface BatchOperationContext {
   batchMode: "MULTI";
   batchSize: number;
@@ -79,7 +72,7 @@ export interface ConnectTraceContext {
   connectionEpoch: number;
 }
 
-type CommandContext = CommandTraceContext | BatchCommandTraceContext;
+type CommandContext = CommandTraceContext;
 
 // Shim interface to fix @types/node gaps:
 // - hasSubscribers is missing on TracingChannel

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -62,12 +62,20 @@ function shouldTrace(
   return !!channel && channel.hasSubscribers !== false;
 }
 
+const noop = () => {};
+
 export function traceCommand<T>(
   fn: () => Promise<T>,
   contextFactory: () => CommandContext
 ): Promise<T> {
   if (shouldTrace(commandChannel)) {
-    return commandChannel.tracePromise(fn, contextFactory());
+    // tracePromise returns a wrapper promise that re-rejects on error.
+    // Silence the wrapper to prevent unhandled rejections when callers
+    // (e.g. Pipeline) discard the return value. Callers that await this
+    // promise still see the rejection through their own .then() chain.
+    const traced = commandChannel.tracePromise(fn, contextFactory());
+    traced.catch(noop);
+    return traced;
   }
   return fn();
 }

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -122,36 +122,33 @@ export function traceCommand<T>(
   fn: () => Promise<T>,
   contextFactory: () => CommandContext
 ): Promise<T> {
-  if (shouldTrace(commandChannel)) {
-    // tracePromise returns a wrapper promise that re-rejects on error.
-    // Silence the wrapper to prevent unhandled rejections when callers
-    // (e.g. Pipeline) discard the return value. Callers that await this
-    // promise still see the rejection through their own .then() chain.
-    const traced = commandChannel.tracePromise(fn, contextFactory());
-    traced.catch(noop);
-    return traced;
-  }
-  return fn();
+  if (!shouldTrace(commandChannel)) return fn();
+
+  // tracePromise returns a wrapper promise that re-rejects on error.
+  // Silence the wrapper to prevent unhandled rejections when callers
+  // (e.g. Pipeline) discard the return value. Callers that await this
+  // promise still see the rejection through their own .then() chain.
+  const traced = commandChannel.tracePromise(fn, contextFactory());
+  traced.catch(noop);
+  return traced;
 }
 
 export function traceBatch<T>(
   fn: () => Promise<T>,
   contextFactory: () => BatchOperationContext
 ): Promise<T> {
-  if (shouldTrace(batchChannel)) {
-    const traced = batchChannel.tracePromise(fn, contextFactory());
-    traced.catch(noop);
-    return traced;
-  }
-  return fn();
+  if (!shouldTrace(batchChannel)) return fn();
+
+  const traced = batchChannel.tracePromise(fn, contextFactory());
+  traced.catch(noop);
+  return traced;
 }
 
 export function traceConnect<T>(
   fn: () => Promise<T>,
   contextFactory: () => ConnectTraceContext
 ): Promise<T> {
-  if (shouldTrace(connectChannel)) {
-    return connectChannel.tracePromise(fn, contextFactory());
-  }
-  return fn();
+  if (!shouldTrace(connectChannel)) return fn();
+
+  return connectChannel.tracePromise(fn, contextFactory());
 }

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -49,8 +49,18 @@ export interface CommandTraceContext {
 }
 
 export interface BatchCommandTraceContext extends CommandTraceContext {
-  batchMode: "PIPELINE" | "MULTI";
+  batchMode: "PIPELINE";
   batchSize: number;
+}
+
+// Context for the batch operation itself (MULTI as a whole).
+// Distinct from BatchCommandTraceContext which is a single command within a pipeline.
+export interface BatchOperationContext {
+  batchMode: "MULTI";
+  batchSize: number;
+  database: number;
+  serverAddress: string;
+  serverPort: number | undefined;
 }
 
 export interface ConnectTraceContext {
@@ -90,6 +100,11 @@ const commandChannel: TracingChannel<CommandContext> | undefined =
     ? (dc.tracingChannel("ioredis:command") as TracingChannel<CommandContext>)
     : undefined;
 
+const batchChannel: TracingChannel<BatchOperationContext> | undefined =
+  hasTracingChannel
+    ? (dc.tracingChannel("ioredis:batch") as TracingChannel<BatchOperationContext>)
+    : undefined;
+
 const connectChannel: TracingChannel<ConnectTraceContext> | undefined =
   hasTracingChannel
     ? (dc.tracingChannel("ioredis:connect") as TracingChannel<ConnectTraceContext>)
@@ -113,6 +128,18 @@ export function traceCommand<T>(
     // (e.g. Pipeline) discard the return value. Callers that await this
     // promise still see the rejection through their own .then() chain.
     const traced = commandChannel.tracePromise(fn, contextFactory());
+    traced.catch(noop);
+    return traced;
+  }
+  return fn();
+}
+
+export function traceBatch<T>(
+  fn: () => Promise<T>,
+  contextFactory: () => BatchOperationContext
+): Promise<T> {
+  if (shouldTrace(batchChannel)) {
+    const traced = batchChannel.tracePromise(fn, contextFactory());
     traced.catch(noop);
     return traced;
   }

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -1,9 +1,48 @@
 import type { CommandParameter } from "./types";
 
+// Argument sanitization rules adapted from @opentelemetry/redis-common (Apache 2.0).
+// https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/packages/redis-common/src/index.ts
+//
+// Each entry specifies how many positional args (after the command name) are safe
+// to emit. -1 means all args are safe (read-only/structural commands).
+// Unlisted commands default to 0 (all args redacted) for safe-by-default behavior,
+// which covers AUTH, HELLO, and unknown/custom commands.
+const SERIALIZATION_SUBSETS: Array<{ regex: RegExp; args: number }> = [
+  { regex: /^ECHO/i, args: 0 },
+  { regex: /^(LPUSH|MSET|PFA|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i, args: 1 },
+  { regex: /^(HSET|HMSET|LSET|LINSERT)/i, args: 2 },
+  { regex: /^(ACL|BIT|B[LRZ]|CLIENT|CLUSTER|CONFIG|COMMAND|DECR|DEL|EVAL|EX|FUNCTION|GEO|GET|HINCR|HMGET|HSCAN|INCR|L[TRLM]|MEMORY|P[EFISTU]|RPOP|S[CDIMORSU]|XACK|X[CDGILPRT]|Z[CDILMPRS])/i, args: -1 },
+];
+
+export function sanitizeArgs(commandName: string, args: CommandParameter[]): string[] {
+  let allowedArgCount = 0;
+
+  for (const subset of SERIALIZATION_SUBSETS) {
+    if (subset.regex.test(commandName)) {
+      allowedArgCount = subset.args;
+      break;
+    }
+  }
+
+  if (allowedArgCount === -1) {
+    return args.map((a) => String(a));
+  }
+
+  const result: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (i < allowedArgCount) {
+      result.push(String(args[i]));
+    } else {
+      result.push("?");
+    }
+  }
+  return result;
+}
+
 // Context types for the two tracing channels
 export interface CommandTraceContext {
   command: string;
-  args: CommandParameter[];
+  args: string[];
   database: number;
   serverAddress: string;
   serverPort: number | undefined;

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -49,7 +49,7 @@ export function sanitizeArgs(
   return result;
 }
 
-// Context types for the two tracing channels
+// Context types for the tracing channels
 export interface CommandTraceContext {
   command: string;
   args: string[];

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -10,7 +10,7 @@ export interface CommandTraceContext {
 }
 
 export interface BatchCommandTraceContext extends CommandTraceContext {
-  batchMode: "pipeline" | "multi";
+  batchMode: "PIPELINE" | "MULTI";
   batchSize: number;
 }
 

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -17,6 +17,7 @@ export interface BatchCommandTraceContext extends CommandTraceContext {
 export interface ConnectTraceContext {
   serverAddress: string;
   serverPort: number | undefined;
+  connectionEpoch: number;
 }
 
 type CommandContext = CommandTraceContext | BatchCommandTraceContext;

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -9,12 +9,22 @@ import type { CommandParameter } from "./types";
 // which covers AUTH, HELLO, and unknown/custom commands.
 const SERIALIZATION_SUBSETS: Array<{ regex: RegExp; args: number }> = [
   { regex: /^ECHO/i, args: 0 },
-  { regex: /^(LPUSH|MSET|PFA|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i, args: 1 },
+  {
+    regex: /^(LPUSH|MSET|PFA|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i,
+    args: 1,
+  },
   { regex: /^(HSET|HMSET|LSET|LINSERT)/i, args: 2 },
-  { regex: /^(ACL|BIT|B[LRZ]|CLIENT|CLUSTER|CONFIG|COMMAND|DECR|DEL|EVAL|EX|FUNCTION|GEO|GET|HINCR|HMGET|HSCAN|INCR|L[TRLM]|MEMORY|P[EFISTU]|RPOP|S[CDIMORSU]|XACK|X[CDGILPRT]|Z[CDILMPRS])/i, args: -1 },
+  {
+    regex:
+      /^(ACL|BIT|B[LRZ]|CLIENT|CLUSTER|CONFIG|COMMAND|DECR|DEL|EVAL|EX|FUNCTION|GEO|GET|HINCR|HMGET|HSCAN|INCR|L[TRLM]|MEMORY|P[EFISTU]|RPOP|S[CDIMORSU]|XACK|X[CDGILPRT]|Z[CDILMPRS])/i,
+    args: -1,
+  },
 ];
 
-export function sanitizeArgs(commandName: string, args: CommandParameter[]): string[] {
+export function sanitizeArgs(
+  commandName: string,
+  args: CommandParameter[]
+): string[] {
   let allowedArgCount = 0;
 
   for (const subset of SERIALIZATION_SUBSETS) {
@@ -76,16 +86,13 @@ type CommandContext = CommandTraceContext | BatchCommandTraceContext;
 // - tracePromise is typed as returning void but returns the promise at runtime
 interface TracingChannel<ContextType> {
   readonly hasSubscribers: boolean;
-  tracePromise<T>(
-    fn: () => Promise<T>,
-    context?: ContextType
-  ): Promise<T>;
+  tracePromise<T>(fn: () => Promise<T>, context?: ContextType): Promise<T>;
 }
 
 // Load diagnostics_channel with Node 18 compatibility
 const dc: any = (() => {
   try {
-    return ("getBuiltinModule" in process)
+    return "getBuiltinModule" in process
       ? (process as any).getBuiltinModule("node:diagnostics_channel")
       : require("node:diagnostics_channel");
   } catch {
@@ -102,12 +109,16 @@ const commandChannel: TracingChannel<CommandContext> | undefined =
 
 const batchChannel: TracingChannel<BatchOperationContext> | undefined =
   hasTracingChannel
-    ? (dc.tracingChannel("ioredis:batch") as TracingChannel<BatchOperationContext>)
+    ? (dc.tracingChannel(
+        "ioredis:batch"
+      ) as TracingChannel<BatchOperationContext>)
     : undefined;
 
 const connectChannel: TracingChannel<ConnectTraceContext> | undefined =
   hasTracingChannel
-    ? (dc.tracingChannel("ioredis:connect") as TracingChannel<ConnectTraceContext>)
+    ? (dc.tracingChannel(
+        "ioredis:connect"
+      ) as TracingChannel<ConnectTraceContext>)
     : undefined;
 
 function shouldTrace(

--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -55,11 +55,17 @@ const connectChannel: TracingChannel<ConnectTraceContext> | undefined =
     ? (dc.tracingChannel("ioredis:connect") as TracingChannel<ConnectTraceContext>)
     : undefined;
 
+function shouldTrace(
+  channel: TracingChannel<any> | undefined
+): channel is TracingChannel<any> {
+  return !!channel && channel.hasSubscribers !== false;
+}
+
 export function traceCommand<T>(
   fn: () => Promise<T>,
   contextFactory: () => CommandContext
 ): Promise<T> {
-  if (commandChannel?.hasSubscribers) {
+  if (shouldTrace(commandChannel)) {
     return commandChannel.tracePromise(fn, contextFactory());
   }
   return fn();
@@ -69,7 +75,7 @@ export function traceConnect<T>(
   fn: () => Promise<T>,
   contextFactory: () => ConnectTraceContext
 ): Promise<T> {
-  if (connectChannel?.hasSubscribers) {
+  if (shouldTrace(connectChannel)) {
     return connectChannel.tracePromise(fn, contextFactory());
   }
   return fn();

--- a/lib/transaction.ts
+++ b/lib/transaction.ts
@@ -3,6 +3,7 @@ import asCallback from "standard-as-callback";
 import Pipeline from "./Pipeline";
 import { Callback } from "./types";
 import { ChainableCommander } from "./utils/RedisCommander";
+import { traceBatch } from "./tracing";
 
 export interface Transaction {
   pipeline(commands?: unknown[][]): ChainableCommander;
@@ -65,9 +66,12 @@ export function addTransactionSupport(redis) {
       if (this.nodeifiedPromise) {
         return exec.call(pipeline);
       }
-      const promise = exec.call(pipeline);
-      return asCallback(
-        promise.then(function (result: any[]): any[] | null {
+
+      // Count only user commands (exclude MULTI/EXEC wrappers).
+      const batchSize = Math.max(pipeline.length - 2, 0);
+
+      const execAndUnwrap = () =>
+        exec.call(pipeline).then(function (result: any[]): any[] | null {
           const execResult = result[result.length - 1];
           if (typeof execResult === "undefined") {
             throw new Error(
@@ -84,9 +88,17 @@ export function addTransactionSupport(redis) {
             throw execResult[0];
           }
           return wrapMultiResult(execResult[1]);
-        }),
-        callback
-      );
+        });
+
+      // Trace MULTI as a single batch operation on ioredis:batch.
+      const promise =
+        "_buildBatchContext" in this.redis
+          ? traceBatch(execAndUnwrap, () =>
+              (this.redis as any)._buildBatchContext(batchSize)
+            )
+          : execAndUnwrap();
+
+      return asCallback(promise, callback);
     };
 
     // @ts-expect-error

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -65,8 +65,6 @@ describeOrSkip("tracing", function () {
         expect(setStart.context.args).to.eql(["tracing-test-key", "?"]);
         expect(setStart.context.database).to.eql(0);
         expect(setStart.context.serverAddress).to.be.a("string");
-        expect(setStart.context.batchMode).to.be.undefined;
-        expect(setStart.context.batchSize).to.be.undefined;
 
         // Check GET context fields — all args visible (read-only command)
         const getStart = getEvents.find((e) => e.name === "start");
@@ -141,7 +139,7 @@ describeOrSkip("tracing", function () {
       }
     });
 
-    it("should trace pipeline commands with batchMode and batchSize", async function () {
+    it("should trace pipeline commands as individual command events", async function () {
       const events: any[] = [];
       const subscriber = {
         start(message: any) {
@@ -167,49 +165,19 @@ describeOrSkip("tracing", function () {
           .exec();
         redis.disconnect();
 
-        const pipelineEvents = events.filter((e) => e.batchMode === "PIPELINE");
-        expect(pipelineEvents.length).to.eql(3);
-        for (const evt of pipelineEvents) {
-          expect(evt.batchSize).to.eql(3);
-          expect(evt.batchMode).to.eql("PIPELINE");
+        // Pipeline commands are traced individually without batch metadata
+        const pipelineCommands = events.filter(
+          (e) =>
+            e.command === "set" &&
+            (e.args[0] === "pipe-key-1" || e.args[0] === "pipe-key-2")
+        );
+        expect(pipelineCommands.length).to.eql(2);
+        for (const evt of pipelineCommands) {
+          expect(evt.batchMode).to.be.undefined;
+          expect(evt.batchSize).to.be.undefined;
         }
       } finally {
         channel.unsubscribe(subscriber);
-      }
-    });
-
-    it("should not emit per-command events for MULTI commands", async function () {
-      const commandEvents: any[] = [];
-      const commandSubscriber = {
-        start(message: any) {
-          commandEvents.push(message);
-        },
-        end() {},
-        asyncStart() {},
-        asyncEnd() {},
-        error() {},
-      };
-
-      const channel = dc.tracingChannel("ioredis:command");
-      channel.subscribe(commandSubscriber);
-
-      try {
-        const redis = new Redis({ lazyConnect: true });
-        await redis.connect();
-        await redis
-          .multi()
-          .set("multi-key-1", "val1")
-          .get("multi-key-1")
-          .exec();
-        redis.disconnect();
-
-        // MULTI commands should NOT appear on ioredis:command
-        const multiEvents = commandEvents.filter(
-          (e) => e.batchMode === "MULTI"
-        );
-        expect(multiEvents.length).to.eql(0);
-      } finally {
-        channel.unsubscribe(commandSubscriber);
       }
     });
 
@@ -580,18 +548,15 @@ describeOrSkip("tracing", function () {
           .exec();
         redis.disconnect();
 
-        // MULTI is traced as a single batch, not per-command
+        // MULTI is traced as a single batch on ioredis:batch
         expect(batchEvents.length).to.eql(1);
         expect(batchEvents[0].batchMode).to.eql("MULTI");
         expect(batchEvents[0].batchSize).to.eql(3);
         expect(batchEvents[0].database).to.be.a("number");
         expect(batchEvents[0].serverAddress).to.be.a("string");
 
-        // No per-command traces for MULTI on ioredis:command
-        const multiCommandEvents = commandEvents.filter(
-          (e: any) => e.batchMode === "MULTI"
-        );
-        expect(multiCommandEvents.length).to.eql(0);
+        // Individual commands within MULTI also appear on ioredis:command
+        expect(commandEvents.length).to.be.greaterThan(0);
       } finally {
         batchChannel.unsubscribe(batchSubscriber);
         commandChannel.unsubscribe(commandSubscriber);

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -160,10 +160,10 @@ describeOrSkip("tracing", function () {
       }
     });
 
-    it("should trace MULTI/EXEC commands with batchMode 'MULTI'", async function () {
-      const events: any[] = [];
-      const subscriber = {
-        start(message: any) { events.push(message); },
+    it("should not emit per-command events for MULTI commands", async function () {
+      const commandEvents: any[] = [];
+      const commandSubscriber = {
+        start(message: any) { commandEvents.push(message); },
         end() {},
         asyncStart() {},
         asyncEnd() {},
@@ -171,7 +171,7 @@ describeOrSkip("tracing", function () {
       };
 
       const channel = dc.tracingChannel("ioredis:command");
-      channel.subscribe(subscriber);
+      channel.subscribe(commandSubscriber);
 
       try {
         const redis = new Redis({ lazyConnect: true });
@@ -183,15 +183,11 @@ describeOrSkip("tracing", function () {
           .exec();
         redis.disconnect();
 
-        const multiEvents = events.filter((e) => e.batchMode === "MULTI");
-        expect(multiEvents.length).to.be.greaterThan(0);
-        for (const evt of multiEvents) {
-          expect(evt.batchMode).to.eql("MULTI");
-          // batchSize should count only user commands (SET + GET), not MULTI/EXEC
-          expect(evt.batchSize).to.eql(2);
-        }
+        // MULTI commands should NOT appear on ioredis:command
+        const multiEvents = commandEvents.filter((e) => e.batchMode === "MULTI");
+        expect(multiEvents.length).to.eql(0);
       } finally {
-        channel.unsubscribe(subscriber);
+        channel.unsubscribe(commandSubscriber);
       }
     });
 
@@ -322,31 +318,104 @@ describeOrSkip("tracing", function () {
   });
 
   describe("sanitizeArgs", function () {
-    it("should redact values for SET (keep key only)", function () {
+    // args=0: command name only
+    it("should redact all args for ECHO", function () {
+      expect(sanitizeArgs("echo", ["hello world"])).to.eql(["?"]);
+      expect(sanitizeArgs("ECHO", ["hello world"])).to.eql(["?"]);
+    });
+
+    // args=1: key only
+    it("should keep key but redact value for SET", function () {
       expect(sanitizeArgs("set", ["mykey", "secret"])).to.eql(["mykey", "?"]);
       expect(sanitizeArgs("SET", ["mykey", "secret"])).to.eql(["mykey", "?"]);
-      expect(sanitizeArgs("setex", ["mykey", "60", "secret"])).to.eql(["mykey", "?", "?"]);
     });
 
-    it("should keep all args for read-only commands", function () {
-      expect(sanitizeArgs("get", ["mykey"])).to.eql(["mykey"]);
-      expect(sanitizeArgs("GET", ["mykey"])).to.eql(["mykey"]);
-      expect(sanitizeArgs("del", ["k1", "k2"])).to.eql(["k1", "k2"]);
-      expect(sanitizeArgs("exists", ["k1"])).to.eql(["k1"]);
+    it("should keep key but redact value for SET with flags", function () {
+      expect(sanitizeArgs("set", ["key", "secret", "EX", "300", "NX"])).to.eql(["key", "?", "?", "?", "?"]);
     });
 
-    it("should keep key + field for HSET (redact value)", function () {
+    it("should keep key but redact value for SETEX (prefix match on SET)", function () {
+      expect(sanitizeArgs("setex", ["key", "300", "secret"])).to.eql(["key", "?", "?"]);
+    });
+
+    it("should keep key but redact values for LPUSH with multiple elements", function () {
+      expect(sanitizeArgs("lpush", ["mylist", "a", "b", "c"])).to.eql(["mylist", "?", "?", "?"]);
+    });
+
+    it("should keep key but redact message for PUBLISH", function () {
+      expect(sanitizeArgs("publish", ["channel", "secret message"])).to.eql(["channel", "?"]);
+    });
+
+    it("should keep key but redact values for MSET", function () {
+      expect(sanitizeArgs("mset", ["k1", "v1", "k2", "v2"])).to.eql(["k1", "?", "?", "?"]);
+    });
+
+    it("should keep key but redact member and score for ZADD", function () {
+      expect(sanitizeArgs("zadd", ["myzset", "1", "member1"])).to.eql(["myzset", "?", "?"]);
+    });
+
+    it("should keep key but redact fields and values for XADD", function () {
+      expect(sanitizeArgs("xadd", ["stream", "*", "field", "value"])).to.eql(["stream", "?", "?", "?"]);
+    });
+
+    // args=2: key + field
+    it("should keep key and field but redact value for HSET", function () {
       expect(sanitizeArgs("hset", ["hash", "field", "secret"])).to.eql(["hash", "field", "?"]);
+    });
+
+    it("should keep key and field but redact remaining for HMSET", function () {
       expect(sanitizeArgs("hmset", ["hash", "f1", "v1", "f2", "v2"])).to.eql(["hash", "f1", "?", "?", "?"]);
     });
 
-    it("should redact all args for ECHO", function () {
-      expect(sanitizeArgs("echo", ["secret"])).to.eql(["?"]);
+    it("should keep key and index but redact value for LSET", function () {
+      expect(sanitizeArgs("lset", ["mylist", "0", "newvalue"])).to.eql(["mylist", "0", "?"]);
     });
 
-    it("should redact all args for unlisted commands (safe-by-default)", function () {
+    it("should keep key and pivot position for LINSERT", function () {
+      expect(sanitizeArgs("linsert", ["mylist", "BEFORE", "pivot", "newvalue"])).to.eql(["mylist", "BEFORE", "?", "?"]);
+    });
+
+    // args=-1: all args visible
+    it("should show all args for GET", function () {
+      expect(sanitizeArgs("get", ["mykey"])).to.eql(["mykey"]);
+      expect(sanitizeArgs("GET", ["mykey"])).to.eql(["mykey"]);
+    });
+
+    it("should show all args for DEL", function () {
+      expect(sanitizeArgs("del", ["k1", "k2", "k3"])).to.eql(["k1", "k2", "k3"]);
+    });
+
+    it("should show all args for SUBSCRIBE", function () {
+      expect(sanitizeArgs("subscribe", ["ch1", "ch2"])).to.eql(["ch1", "ch2"]);
+    });
+
+    it("should show all args for CONFIG GET", function () {
+      expect(sanitizeArgs("config", ["GET", "maxmemory"])).to.eql(["GET", "maxmemory"]);
+    });
+
+    it("should show all args for EVAL", function () {
+      expect(sanitizeArgs("eval", ["return 1", "0"])).to.eql(["return 1", "0"]);
+    });
+
+    it("should show all args for HMGET", function () {
+      expect(sanitizeArgs("hmget", ["hash", "f1", "f2"])).to.eql(["hash", "f1", "f2"]);
+    });
+
+    it("should show all args for EXISTS", function () {
+      expect(sanitizeArgs("exists", ["k1"])).to.eql(["k1"]);
+    });
+
+    // Default: unlisted commands fully redacted
+    it("should redact all args for AUTH (unlisted, falls to default)", function () {
       expect(sanitizeArgs("auth", ["password"])).to.eql(["?"]);
       expect(sanitizeArgs("AUTH", ["password"])).to.eql(["?"]);
+    });
+
+    it("should redact all args for AUTH with username", function () {
+      expect(sanitizeArgs("auth", ["user", "password123"])).to.eql(["?", "?"]);
+    });
+
+    it("should redact all args for HELLO with auth", function () {
       expect(sanitizeArgs("hello", ["3", "AUTH", "user", "pass"])).to.eql(["?", "?", "?", "?"]);
     });
 
@@ -354,13 +423,77 @@ describeOrSkip("tracing", function () {
       expect(sanitizeArgs("mycustomcmd", ["arg1", "arg2"])).to.eql(["?", "?"]);
     });
 
+    // Case insensitivity
+    it("should be case-insensitive for command matching", function () {
+      expect(sanitizeArgs("set", ["key", "value"])).to.eql(["key", "?"]);
+      expect(sanitizeArgs("get", ["key"])).to.eql(["key"]);
+      expect(sanitizeArgs("hSet", ["hash", "field", "value"])).to.eql(["hash", "field", "?"]);
+    });
+
+    // Edge cases
     it("should handle empty args", function () {
       expect(sanitizeArgs("ping", [])).to.eql([]);
     });
 
     it("should stringify non-string args", function () {
       expect(sanitizeArgs("get", [Buffer.from("key")])).to.eql(["key"]);
-      expect(sanitizeArgs("get", [123])).to.eql(["123"]);
+    });
+
+    it("should stringify numeric args", function () {
+      expect(sanitizeArgs("del", [42])).to.eql(["42"]);
+    });
+  });
+
+  describe("ioredis:batch", function () {
+    it("should trace MULTI as a single batch operation", async function () {
+      const batchEvents: any[] = [];
+      const commandEvents: any[] = [];
+
+      const batchSubscriber = {
+        start(message: any) { batchEvents.push(message); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {},
+      };
+      const commandSubscriber = {
+        start(message: any) { commandEvents.push(message); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {},
+      };
+
+      const batchChannel = dc.tracingChannel("ioredis:batch");
+      const commandChannel = dc.tracingChannel("ioredis:command");
+      batchChannel.subscribe(batchSubscriber);
+      commandChannel.subscribe(commandSubscriber);
+
+      try {
+        const redis = new Redis({ lazyConnect: true });
+        await redis.connect();
+        await redis
+          .multi()
+          .set("multi-key-1", "val1")
+          .set("multi-key-2", "val2")
+          .get("multi-key-1")
+          .exec();
+        redis.disconnect();
+
+        // MULTI is traced as a single batch, not per-command
+        expect(batchEvents.length).to.eql(1);
+        expect(batchEvents[0].batchMode).to.eql("MULTI");
+        expect(batchEvents[0].batchSize).to.eql(3);
+        expect(batchEvents[0].database).to.be.a("number");
+        expect(batchEvents[0].serverAddress).to.be.a("string");
+
+        // No per-command traces for MULTI on ioredis:command
+        const multiCommandEvents = commandEvents.filter((e: any) => e.batchMode === "MULTI");
+        expect(multiCommandEvents.length).to.eql(0);
+      } finally {
+        batchChannel.unsubscribe(batchSubscriber);
+        commandChannel.unsubscribe(commandSubscriber);
+      }
     });
   });
 

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -264,6 +264,7 @@ describeOrSkip("tracing", function () {
         expect(startEvents.length).to.eql(1);
         expect(startEvents[0].context.serverAddress).to.eql("localhost");
         expect(startEvents[0].context.serverPort).to.eql(6379);
+        expect(startEvents[0].context.connectionEpoch).to.eql(0);
 
         const asyncEndEvents = events.filter((e) => e.name === "asyncEnd");
         expect(asyncEndEvents.length).to.eql(1);

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -195,6 +195,55 @@ describeOrSkip("tracing", function () {
       }
     });
 
+    it("should not cause unhandled rejections for failed pipeline commands", async function () {
+      const errorEvents: any[] = [];
+      const subscriber = {
+        start() {},
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error(message: any) { errorEvents.push(message); },
+      };
+
+      const channel = dc.tracingChannel("ioredis:command");
+      channel.subscribe(subscriber);
+
+      // Track unhandled rejections — the bug would cause one here
+      const unhandledRejections: any[] = [];
+      const onUnhandled = (reason: any) => unhandledRejections.push(reason);
+      process.on("unhandledRejection", onUnhandled);
+
+      try {
+        const redis = new Redis({ lazyConnect: true });
+        await redis.connect();
+
+        // Set key as string, then pipeline an HSET on it to trigger WRONGTYPE
+        await redis.set("pipe-reject-key", "string-value");
+        const results = await redis
+          .pipeline()
+          .hset("pipe-reject-key", "field", "value")
+          .get("pipe-reject-key")
+          .exec();
+        redis.disconnect();
+
+        // Pipeline reports per-command errors in the results, not via rejection
+        expect(results[0][0]).to.be.instanceOf(Error);
+        expect(results[0][0].message).to.include("WRONGTYPE");
+
+        // Give the event loop a tick for any stray rejections to surface
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        expect(unhandledRejections).to.have.lengthOf(0);
+
+        // The error trace event should still have fired
+        const hsetErrors = errorEvents.filter((e) => e.command === "hset");
+        expect(hsetErrors.length).to.be.greaterThan(0);
+      } finally {
+        process.removeListener("unhandledRejection", onUnhandled);
+        channel.unsubscribe(subscriber);
+      }
+    });
+
     it("should not allocate context when no subscribers", async function () {
       // Just ensure the command works correctly without any subscriber
       const redis = new Redis({ lazyConnect: true });

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -275,6 +275,55 @@ describeOrSkip("tracing", function () {
       }
     });
 
+    it("should not produce duplicate trace events for resent unfulfilled commands", async function () {
+      const events: any[] = [];
+      const subscriber = {
+        start(message: any) {
+          events.push(message);
+        },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {},
+      };
+
+      const channel = dc.tracingChannel("ioredis:command");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({
+          lazyConnect: true,
+          autoResendUnfulfilledCommands: true,
+          retryStrategy() {
+            return 1;
+          },
+        });
+        await redis.connect();
+
+        // Send a command and immediately destroy the stream before
+        // the reply arrives, so it lands in prevCommandQueue.
+        const setPromise = redis.set(
+          "resend-test-key",
+          "resend-test-value"
+        );
+        redis.stream.destroy();
+
+        // Wait for reconnection and command re-send, then the result
+        const result = await setPromise;
+        expect(result).to.eql("OK");
+
+        redis.disconnect();
+
+        const setEvents = events.filter(
+          (e) => e.command === "set" && e.args[0] === "resend-test-key"
+        );
+        // Should trace exactly once, not twice
+        expect(setEvents.length).to.eql(1);
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+
     it("should trace errors on failed commands", async function () {
       const errorEvents: any[] = [];
       const subscriber = {

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -219,18 +219,20 @@ describeOrSkip("tracing", function () {
       try {
         const redis = new Redis({ lazyConnect: true });
         await redis.connect();
-        // HSET requires at least 3 arguments; calling with wrong type triggers an error
+        // Set key as string, then HSET on it to trigger WRONGTYPE error
+        await redis.set("tracing-error-key", "string-value");
         try {
-          // @ts-expect-error intentionally passing wrong args
-          await redis.hget("tracing-test-key"); // key was set as string, not hash
+          await redis.hset("tracing-error-key", "field", "value");
         } catch {
-          // Expected error
+          // Expected WRONGTYPE error
         }
         redis.disconnect();
 
-        // We should still get error events traced
-        // Note: some Redis servers may not error on hget of a string key,
-        // so we just verify the mechanism works without asserting on specific errors
+        expect(errorEvents.length).to.be.greaterThan(0);
+        const errorContext = errorEvents[0];
+        expect(errorContext).to.have.property("command");
+        expect(errorContext).to.have.property("serverAddress");
+        expect(errorContext).to.have.property("serverPort");
       } finally {
         channel.unsubscribe(subscriber);
       }

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -205,6 +205,37 @@ describeOrSkip("tracing", function () {
       redis.disconnect();
     });
 
+    it("should not produce duplicate trace events for offline-queued commands", async function () {
+      const events: any[] = [];
+      const subscriber = {
+        start(message: any) { events.push(message); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {},
+      };
+
+      const channel = dc.tracingChannel("ioredis:command");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({ lazyConnect: true });
+        // Start connecting but don't await — puts Redis in "connecting" state
+        const connectPromise = redis.connect();
+        // Issue command while still connecting — it goes to the offline queue
+        const setPromise = redis.set("offline-key", "offline-value");
+        await connectPromise;
+        await setPromise;
+        redis.disconnect();
+
+        const setEvents = events.filter((e) => e.command === "set");
+        // Should trace exactly once, not twice
+        expect(setEvents.length).to.eql(1);
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+
     it("should trace errors on failed commands", async function () {
       const errorEvents: any[] = [];
       const subscriber = {

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -4,7 +4,8 @@ import { sanitizeArgs } from "../../lib/tracing";
 
 // TracingChannel requires Node >= 20.13. Skip tests on older versions.
 const nodeVersion = process.versions.node.split(".").map(Number);
-const hasTracingChannel = nodeVersion[0] > 20 || (nodeVersion[0] === 20 && nodeVersion[1] >= 13);
+const hasTracingChannel =
+  nodeVersion[0] > 20 || (nodeVersion[0] === 20 && nodeVersion[1] >= 13);
 
 const describeOrSkip = hasTracingChannel ? describe : describe.skip;
 
@@ -12,20 +13,31 @@ describeOrSkip("tracing", function () {
   let dc: typeof import("node:diagnostics_channel");
 
   before(function () {
-    dc = ("getBuiltinModule" in process)
-      ? (process as any).getBuiltinModule("node:diagnostics_channel")
-      : require("node:diagnostics_channel");
+    dc =
+      "getBuiltinModule" in process
+        ? (process as any).getBuiltinModule("node:diagnostics_channel")
+        : require("node:diagnostics_channel");
   });
 
   describe("ioredis:command", function () {
     it("should trace a simple command", async function () {
       const events: { name: string; context: any }[] = [];
       const subscriber = {
-        start(message: any) { events.push({ name: "start", context: message }); },
-        end(message: any) { events.push({ name: "end", context: message }); },
-        asyncStart(message: any) { events.push({ name: "asyncStart", context: message }); },
-        asyncEnd(message: any) { events.push({ name: "asyncEnd", context: message }); },
-        error(message: any) { events.push({ name: "error", context: message }); },
+        start(message: any) {
+          events.push({ name: "start", context: message });
+        },
+        end(message: any) {
+          events.push({ name: "end", context: message });
+        },
+        asyncStart(message: any) {
+          events.push({ name: "asyncStart", context: message });
+        },
+        asyncEnd(message: any) {
+          events.push({ name: "asyncEnd", context: message });
+        },
+        error(message: any) {
+          events.push({ name: "error", context: message });
+        },
       };
 
       const channel = dc.tracingChannel("ioredis:command");
@@ -73,7 +85,9 @@ describeOrSkip("tracing", function () {
     it("should include serverPort for TCP connections", async function () {
       const events: any[] = [];
       const subscriber = {
-        start(message: any) { events.push(message); },
+        start(message: any) {
+          events.push(message);
+        },
         end() {},
         asyncStart() {},
         asyncEnd() {},
@@ -101,7 +115,9 @@ describeOrSkip("tracing", function () {
     it("should include database number", async function () {
       const events: any[] = [];
       const subscriber = {
-        start(message: any) { events.push(message); },
+        start(message: any) {
+          events.push(message);
+        },
         end() {},
         asyncStart() {},
         asyncEnd() {},
@@ -128,7 +144,9 @@ describeOrSkip("tracing", function () {
     it("should trace pipeline commands with batchMode and batchSize", async function () {
       const events: any[] = [];
       const subscriber = {
-        start(message: any) { events.push(message); },
+        start(message: any) {
+          events.push(message);
+        },
         end() {},
         asyncStart() {},
         asyncEnd() {},
@@ -163,7 +181,9 @@ describeOrSkip("tracing", function () {
     it("should not emit per-command events for MULTI commands", async function () {
       const commandEvents: any[] = [];
       const commandSubscriber = {
-        start(message: any) { commandEvents.push(message); },
+        start(message: any) {
+          commandEvents.push(message);
+        },
         end() {},
         asyncStart() {},
         asyncEnd() {},
@@ -184,7 +204,9 @@ describeOrSkip("tracing", function () {
         redis.disconnect();
 
         // MULTI commands should NOT appear on ioredis:command
-        const multiEvents = commandEvents.filter((e) => e.batchMode === "MULTI");
+        const multiEvents = commandEvents.filter(
+          (e) => e.batchMode === "MULTI"
+        );
         expect(multiEvents.length).to.eql(0);
       } finally {
         channel.unsubscribe(commandSubscriber);
@@ -198,7 +220,9 @@ describeOrSkip("tracing", function () {
         end() {},
         asyncStart() {},
         asyncEnd() {},
-        error(message: any) { errorEvents.push(message); },
+        error(message: any) {
+          errorEvents.push(message);
+        },
       };
 
       const channel = dc.tracingChannel("ioredis:command");
@@ -253,7 +277,9 @@ describeOrSkip("tracing", function () {
     it("should not produce duplicate trace events for offline-queued commands", async function () {
       const events: any[] = [];
       const subscriber = {
-        start(message: any) { events.push(message); },
+        start(message: any) {
+          events.push(message);
+        },
         end() {},
         asyncStart() {},
         asyncEnd() {},
@@ -288,7 +314,9 @@ describeOrSkip("tracing", function () {
         end() {},
         asyncStart() {},
         asyncEnd() {},
-        error(message: any) { errorEvents.push(message); },
+        error(message: any) {
+          errorEvents.push(message);
+        },
       };
 
       const channel = dc.tracingChannel("ioredis:command");
@@ -331,48 +359,96 @@ describeOrSkip("tracing", function () {
     });
 
     it("should keep key but redact value for SET with flags", function () {
-      expect(sanitizeArgs("set", ["key", "secret", "EX", "300", "NX"])).to.eql(["key", "?", "?", "?", "?"]);
+      expect(sanitizeArgs("set", ["key", "secret", "EX", "300", "NX"])).to.eql([
+        "key",
+        "?",
+        "?",
+        "?",
+        "?",
+      ]);
     });
 
     it("should keep key but redact value for SETEX (prefix match on SET)", function () {
-      expect(sanitizeArgs("setex", ["key", "300", "secret"])).to.eql(["key", "?", "?"]);
+      expect(sanitizeArgs("setex", ["key", "300", "secret"])).to.eql([
+        "key",
+        "?",
+        "?",
+      ]);
     });
 
     it("should keep key but redact values for LPUSH with multiple elements", function () {
-      expect(sanitizeArgs("lpush", ["mylist", "a", "b", "c"])).to.eql(["mylist", "?", "?", "?"]);
+      expect(sanitizeArgs("lpush", ["mylist", "a", "b", "c"])).to.eql([
+        "mylist",
+        "?",
+        "?",
+        "?",
+      ]);
     });
 
     it("should keep key but redact message for PUBLISH", function () {
-      expect(sanitizeArgs("publish", ["channel", "secret message"])).to.eql(["channel", "?"]);
+      expect(sanitizeArgs("publish", ["channel", "secret message"])).to.eql([
+        "channel",
+        "?",
+      ]);
     });
 
     it("should keep key but redact values for MSET", function () {
-      expect(sanitizeArgs("mset", ["k1", "v1", "k2", "v2"])).to.eql(["k1", "?", "?", "?"]);
+      expect(sanitizeArgs("mset", ["k1", "v1", "k2", "v2"])).to.eql([
+        "k1",
+        "?",
+        "?",
+        "?",
+      ]);
     });
 
     it("should keep key but redact member and score for ZADD", function () {
-      expect(sanitizeArgs("zadd", ["myzset", "1", "member1"])).to.eql(["myzset", "?", "?"]);
+      expect(sanitizeArgs("zadd", ["myzset", "1", "member1"])).to.eql([
+        "myzset",
+        "?",
+        "?",
+      ]);
     });
 
     it("should keep key but redact fields and values for XADD", function () {
-      expect(sanitizeArgs("xadd", ["stream", "*", "field", "value"])).to.eql(["stream", "?", "?", "?"]);
+      expect(sanitizeArgs("xadd", ["stream", "*", "field", "value"])).to.eql([
+        "stream",
+        "?",
+        "?",
+        "?",
+      ]);
     });
 
     // args=2: key + field
     it("should keep key and field but redact value for HSET", function () {
-      expect(sanitizeArgs("hset", ["hash", "field", "secret"])).to.eql(["hash", "field", "?"]);
+      expect(sanitizeArgs("hset", ["hash", "field", "secret"])).to.eql([
+        "hash",
+        "field",
+        "?",
+      ]);
     });
 
     it("should keep key and field but redact remaining for HMSET", function () {
-      expect(sanitizeArgs("hmset", ["hash", "f1", "v1", "f2", "v2"])).to.eql(["hash", "f1", "?", "?", "?"]);
+      expect(sanitizeArgs("hmset", ["hash", "f1", "v1", "f2", "v2"])).to.eql([
+        "hash",
+        "f1",
+        "?",
+        "?",
+        "?",
+      ]);
     });
 
     it("should keep key and index but redact value for LSET", function () {
-      expect(sanitizeArgs("lset", ["mylist", "0", "newvalue"])).to.eql(["mylist", "0", "?"]);
+      expect(sanitizeArgs("lset", ["mylist", "0", "newvalue"])).to.eql([
+        "mylist",
+        "0",
+        "?",
+      ]);
     });
 
     it("should keep key and pivot position for LINSERT", function () {
-      expect(sanitizeArgs("linsert", ["mylist", "BEFORE", "pivot", "newvalue"])).to.eql(["mylist", "BEFORE", "?", "?"]);
+      expect(
+        sanitizeArgs("linsert", ["mylist", "BEFORE", "pivot", "newvalue"])
+      ).to.eql(["mylist", "BEFORE", "?", "?"]);
     });
 
     // args=-1: all args visible
@@ -382,7 +458,11 @@ describeOrSkip("tracing", function () {
     });
 
     it("should show all args for DEL", function () {
-      expect(sanitizeArgs("del", ["k1", "k2", "k3"])).to.eql(["k1", "k2", "k3"]);
+      expect(sanitizeArgs("del", ["k1", "k2", "k3"])).to.eql([
+        "k1",
+        "k2",
+        "k3",
+      ]);
     });
 
     it("should show all args for SUBSCRIBE", function () {
@@ -390,7 +470,10 @@ describeOrSkip("tracing", function () {
     });
 
     it("should show all args for CONFIG GET", function () {
-      expect(sanitizeArgs("config", ["GET", "maxmemory"])).to.eql(["GET", "maxmemory"]);
+      expect(sanitizeArgs("config", ["GET", "maxmemory"])).to.eql([
+        "GET",
+        "maxmemory",
+      ]);
     });
 
     it("should show all args for EVAL", function () {
@@ -398,7 +481,11 @@ describeOrSkip("tracing", function () {
     });
 
     it("should show all args for HMGET", function () {
-      expect(sanitizeArgs("hmget", ["hash", "f1", "f2"])).to.eql(["hash", "f1", "f2"]);
+      expect(sanitizeArgs("hmget", ["hash", "f1", "f2"])).to.eql([
+        "hash",
+        "f1",
+        "f2",
+      ]);
     });
 
     it("should show all args for EXISTS", function () {
@@ -416,7 +503,12 @@ describeOrSkip("tracing", function () {
     });
 
     it("should redact all args for HELLO with auth", function () {
-      expect(sanitizeArgs("hello", ["3", "AUTH", "user", "pass"])).to.eql(["?", "?", "?", "?"]);
+      expect(sanitizeArgs("hello", ["3", "AUTH", "user", "pass"])).to.eql([
+        "?",
+        "?",
+        "?",
+        "?",
+      ]);
     });
 
     it("should redact all args for unknown custom commands", function () {
@@ -427,7 +519,11 @@ describeOrSkip("tracing", function () {
     it("should be case-insensitive for command matching", function () {
       expect(sanitizeArgs("set", ["key", "value"])).to.eql(["key", "?"]);
       expect(sanitizeArgs("get", ["key"])).to.eql(["key"]);
-      expect(sanitizeArgs("hSet", ["hash", "field", "value"])).to.eql(["hash", "field", "?"]);
+      expect(sanitizeArgs("hSet", ["hash", "field", "value"])).to.eql([
+        "hash",
+        "field",
+        "?",
+      ]);
     });
 
     // Edge cases
@@ -450,14 +546,18 @@ describeOrSkip("tracing", function () {
       const commandEvents: any[] = [];
 
       const batchSubscriber = {
-        start(message: any) { batchEvents.push(message); },
+        start(message: any) {
+          batchEvents.push(message);
+        },
         end() {},
         asyncStart() {},
         asyncEnd() {},
         error() {},
       };
       const commandSubscriber = {
-        start(message: any) { commandEvents.push(message); },
+        start(message: any) {
+          commandEvents.push(message);
+        },
         end() {},
         asyncStart() {},
         asyncEnd() {},
@@ -488,7 +588,9 @@ describeOrSkip("tracing", function () {
         expect(batchEvents[0].serverAddress).to.be.a("string");
 
         // No per-command traces for MULTI on ioredis:command
-        const multiCommandEvents = commandEvents.filter((e: any) => e.batchMode === "MULTI");
+        const multiCommandEvents = commandEvents.filter(
+          (e: any) => e.batchMode === "MULTI"
+        );
         expect(multiCommandEvents.length).to.eql(0);
       } finally {
         batchChannel.unsubscribe(batchSubscriber);
@@ -501,11 +603,21 @@ describeOrSkip("tracing", function () {
     it("should trace the connection", async function () {
       const events: { name: string; context: any }[] = [];
       const subscriber = {
-        start(message: any) { events.push({ name: "start", context: message }); },
-        end(message: any) { events.push({ name: "end", context: message }); },
-        asyncStart(message: any) { events.push({ name: "asyncStart", context: message }); },
-        asyncEnd(message: any) { events.push({ name: "asyncEnd", context: message }); },
-        error(message: any) { events.push({ name: "error", context: message }); },
+        start(message: any) {
+          events.push({ name: "start", context: message });
+        },
+        end(message: any) {
+          events.push({ name: "end", context: message });
+        },
+        asyncStart(message: any) {
+          events.push({ name: "asyncStart", context: message });
+        },
+        asyncEnd(message: any) {
+          events.push({ name: "asyncEnd", context: message });
+        },
+        error(message: any) {
+          events.push({ name: "error", context: message });
+        },
       };
 
       const channel = dc.tracingChannel("ioredis:connect");
@@ -532,11 +644,21 @@ describeOrSkip("tracing", function () {
     it("should trace connection failure", async function () {
       const events: { name: string; context: any }[] = [];
       const subscriber = {
-        start(message: any) { events.push({ name: "start", context: message }); },
-        end(message: any) { events.push({ name: "end", context: message }); },
-        asyncStart(message: any) { events.push({ name: "asyncStart", context: message }); },
-        asyncEnd(message: any) { events.push({ name: "asyncEnd", context: message }); },
-        error(message: any) { events.push({ name: "error", context: message }); },
+        start(message: any) {
+          events.push({ name: "start", context: message });
+        },
+        end(message: any) {
+          events.push({ name: "end", context: message });
+        },
+        asyncStart(message: any) {
+          events.push({ name: "asyncStart", context: message });
+        },
+        asyncEnd(message: any) {
+          events.push({ name: "asyncEnd", context: message });
+        },
+        error(message: any) {
+          events.push({ name: "error", context: message });
+        },
       };
 
       const channel = dc.tracingChannel("ioredis:connect");

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -149,18 +149,18 @@ describeOrSkip("tracing", function () {
           .exec();
         redis.disconnect();
 
-        const pipelineEvents = events.filter((e) => e.batchMode === "pipeline");
+        const pipelineEvents = events.filter((e) => e.batchMode === "PIPELINE");
         expect(pipelineEvents.length).to.eql(3);
         for (const evt of pipelineEvents) {
           expect(evt.batchSize).to.eql(3);
-          expect(evt.batchMode).to.eql("pipeline");
+          expect(evt.batchMode).to.eql("PIPELINE");
         }
       } finally {
         channel.unsubscribe(subscriber);
       }
     });
 
-    it("should trace MULTI/EXEC commands with batchMode 'multi'", async function () {
+    it("should trace MULTI/EXEC commands with batchMode 'MULTI'", async function () {
       const events: any[] = [];
       const subscriber = {
         start(message: any) { events.push(message); },
@@ -183,10 +183,10 @@ describeOrSkip("tracing", function () {
           .exec();
         redis.disconnect();
 
-        const multiEvents = events.filter((e) => e.batchMode === "multi");
+        const multiEvents = events.filter((e) => e.batchMode === "MULTI");
         expect(multiEvents.length).to.be.greaterThan(0);
         for (const evt of multiEvents) {
-          expect(evt.batchMode).to.eql("multi");
+          expect(evt.batchMode).to.eql("MULTI");
         }
       } finally {
         channel.unsubscribe(subscriber);

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -1,5 +1,6 @@
 import Redis from "../../lib/Redis";
 import { expect } from "chai";
+import { sanitizeArgs } from "../../lib/tracing";
 
 // TracingChannel requires Node >= 20.13. Skip tests on older versions.
 const nodeVersion = process.versions.node.split(".").map(Number);
@@ -45,22 +46,21 @@ describeOrSkip("tracing", function () {
         expect(setEvents.length).to.be.greaterThan(0);
         expect(getEvents.length).to.be.greaterThan(0);
 
-        // Check SET context fields
+        // Check SET context fields — value is sanitized, key is visible
         const setStart = setEvents.find((e) => e.name === "start");
         expect(setStart).to.exist;
         expect(setStart.context.command).to.eql("set");
-        expect(setStart.context.args).to.include("tracing-test-key");
-        expect(setStart.context.args).to.include("tracing-test-value");
+        expect(setStart.context.args).to.eql(["tracing-test-key", "?"]);
         expect(setStart.context.database).to.eql(0);
         expect(setStart.context.serverAddress).to.be.a("string");
         expect(setStart.context.batchMode).to.be.undefined;
         expect(setStart.context.batchSize).to.be.undefined;
 
-        // Check GET context fields
+        // Check GET context fields — all args visible (read-only command)
         const getStart = getEvents.find((e) => e.name === "start");
         expect(getStart).to.exist;
         expect(getStart.context.command).to.eql("get");
-        expect(getStart.context.args).to.include("tracing-test-key");
+        expect(getStart.context.args).to.eql(["tracing-test-key"]);
 
         // asyncEnd should fire for completed commands
         const setAsyncEnd = setEvents.find((e) => e.name === "asyncEnd");
@@ -318,6 +318,49 @@ describeOrSkip("tracing", function () {
       } finally {
         channel.unsubscribe(subscriber);
       }
+    });
+  });
+
+  describe("sanitizeArgs", function () {
+    it("should redact values for SET (keep key only)", function () {
+      expect(sanitizeArgs("set", ["mykey", "secret"])).to.eql(["mykey", "?"]);
+      expect(sanitizeArgs("SET", ["mykey", "secret"])).to.eql(["mykey", "?"]);
+      expect(sanitizeArgs("setex", ["mykey", "60", "secret"])).to.eql(["mykey", "?", "?"]);
+    });
+
+    it("should keep all args for read-only commands", function () {
+      expect(sanitizeArgs("get", ["mykey"])).to.eql(["mykey"]);
+      expect(sanitizeArgs("GET", ["mykey"])).to.eql(["mykey"]);
+      expect(sanitizeArgs("del", ["k1", "k2"])).to.eql(["k1", "k2"]);
+      expect(sanitizeArgs("exists", ["k1"])).to.eql(["k1"]);
+    });
+
+    it("should keep key + field for HSET (redact value)", function () {
+      expect(sanitizeArgs("hset", ["hash", "field", "secret"])).to.eql(["hash", "field", "?"]);
+      expect(sanitizeArgs("hmset", ["hash", "f1", "v1", "f2", "v2"])).to.eql(["hash", "f1", "?", "?", "?"]);
+    });
+
+    it("should redact all args for ECHO", function () {
+      expect(sanitizeArgs("echo", ["secret"])).to.eql(["?"]);
+    });
+
+    it("should redact all args for unlisted commands (safe-by-default)", function () {
+      expect(sanitizeArgs("auth", ["password"])).to.eql(["?"]);
+      expect(sanitizeArgs("AUTH", ["password"])).to.eql(["?"]);
+      expect(sanitizeArgs("hello", ["3", "AUTH", "user", "pass"])).to.eql(["?", "?", "?", "?"]);
+    });
+
+    it("should redact all args for unknown custom commands", function () {
+      expect(sanitizeArgs("mycustomcmd", ["arg1", "arg2"])).to.eql(["?", "?"]);
+    });
+
+    it("should handle empty args", function () {
+      expect(sanitizeArgs("ping", [])).to.eql([]);
+    });
+
+    it("should stringify non-string args", function () {
+      expect(sanitizeArgs("get", [Buffer.from("key")])).to.eql(["key"]);
+      expect(sanitizeArgs("get", [123])).to.eql(["123"]);
     });
   });
 

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -1,0 +1,311 @@
+import Redis from "../../lib/Redis";
+import { expect } from "chai";
+
+// TracingChannel requires Node >= 20.13. Skip tests on older versions.
+const nodeVersion = process.versions.node.split(".").map(Number);
+const hasTracingChannel = nodeVersion[0] > 20 || (nodeVersion[0] === 20 && nodeVersion[1] >= 13);
+
+const describeOrSkip = hasTracingChannel ? describe : describe.skip;
+
+describeOrSkip("tracing", function () {
+  let dc: typeof import("node:diagnostics_channel");
+
+  before(function () {
+    dc = ("getBuiltinModule" in process)
+      ? (process as any).getBuiltinModule("node:diagnostics_channel")
+      : require("node:diagnostics_channel");
+  });
+
+  describe("ioredis:command", function () {
+    it("should trace a simple command", async function () {
+      const events: { name: string; context: any }[] = [];
+      const subscriber = {
+        start(message: any) { events.push({ name: "start", context: message }); },
+        end(message: any) { events.push({ name: "end", context: message }); },
+        asyncStart(message: any) { events.push({ name: "asyncStart", context: message }); },
+        asyncEnd(message: any) { events.push({ name: "asyncEnd", context: message }); },
+        error(message: any) { events.push({ name: "error", context: message }); },
+      };
+
+      const channel = dc.tracingChannel("ioredis:command");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({ lazyConnect: true });
+        await redis.connect();
+        await redis.set("tracing-test-key", "tracing-test-value");
+        const result = await redis.get("tracing-test-key");
+        expect(result).to.eql("tracing-test-value");
+        redis.disconnect();
+
+        // Filter to only SET and GET (ignore handshake commands like auth, client, info, select)
+        const setEvents = events.filter((e) => e.context.command === "set");
+        const getEvents = events.filter((e) => e.context.command === "get");
+
+        expect(setEvents.length).to.be.greaterThan(0);
+        expect(getEvents.length).to.be.greaterThan(0);
+
+        // Check SET context fields
+        const setStart = setEvents.find((e) => e.name === "start");
+        expect(setStart).to.exist;
+        expect(setStart.context.command).to.eql("set");
+        expect(setStart.context.args).to.include("tracing-test-key");
+        expect(setStart.context.args).to.include("tracing-test-value");
+        expect(setStart.context.database).to.eql(0);
+        expect(setStart.context.serverAddress).to.be.a("string");
+        expect(setStart.context.batchMode).to.be.undefined;
+        expect(setStart.context.batchSize).to.be.undefined;
+
+        // Check GET context fields
+        const getStart = getEvents.find((e) => e.name === "start");
+        expect(getStart).to.exist;
+        expect(getStart.context.command).to.eql("get");
+        expect(getStart.context.args).to.include("tracing-test-key");
+
+        // asyncEnd should fire for completed commands
+        const setAsyncEnd = setEvents.find((e) => e.name === "asyncEnd");
+        expect(setAsyncEnd).to.exist;
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+
+    it("should include serverPort for TCP connections", async function () {
+      const events: any[] = [];
+      const subscriber = {
+        start(message: any) { events.push(message); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {},
+      };
+
+      const channel = dc.tracingChannel("ioredis:command");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({ lazyConnect: true });
+        await redis.connect();
+        await redis.ping();
+        redis.disconnect();
+
+        const pingEvent = events.find((e) => e.command === "ping");
+        expect(pingEvent).to.exist;
+        expect(pingEvent.serverPort).to.eql(6379);
+        expect(pingEvent.serverAddress).to.eql("localhost");
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+
+    it("should include database number", async function () {
+      const events: any[] = [];
+      const subscriber = {
+        start(message: any) { events.push(message); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {},
+      };
+
+      const channel = dc.tracingChannel("ioredis:command");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({ db: 3, lazyConnect: true });
+        await redis.connect();
+        await redis.ping();
+        redis.disconnect();
+
+        const pingEvent = events.find((e) => e.command === "ping");
+        expect(pingEvent).to.exist;
+        expect(pingEvent.database).to.eql(3);
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+
+    it("should trace pipeline commands with batchMode and batchSize", async function () {
+      const events: any[] = [];
+      const subscriber = {
+        start(message: any) { events.push(message); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {},
+      };
+
+      const channel = dc.tracingChannel("ioredis:command");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({ lazyConnect: true });
+        await redis.connect();
+        await redis
+          .pipeline()
+          .set("pipe-key-1", "val1")
+          .set("pipe-key-2", "val2")
+          .get("pipe-key-1")
+          .exec();
+        redis.disconnect();
+
+        const pipelineEvents = events.filter((e) => e.batchMode === "pipeline");
+        expect(pipelineEvents.length).to.eql(3);
+        for (const evt of pipelineEvents) {
+          expect(evt.batchSize).to.eql(3);
+          expect(evt.batchMode).to.eql("pipeline");
+        }
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+
+    it("should trace MULTI/EXEC commands with batchMode 'multi'", async function () {
+      const events: any[] = [];
+      const subscriber = {
+        start(message: any) { events.push(message); },
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error() {},
+      };
+
+      const channel = dc.tracingChannel("ioredis:command");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({ lazyConnect: true });
+        await redis.connect();
+        await redis
+          .multi()
+          .set("multi-key-1", "val1")
+          .get("multi-key-1")
+          .exec();
+        redis.disconnect();
+
+        const multiEvents = events.filter((e) => e.batchMode === "multi");
+        expect(multiEvents.length).to.be.greaterThan(0);
+        for (const evt of multiEvents) {
+          expect(evt.batchMode).to.eql("multi");
+        }
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+
+    it("should not allocate context when no subscribers", async function () {
+      // Just ensure the command works correctly without any subscriber
+      const redis = new Redis({ lazyConnect: true });
+      await redis.connect();
+      await redis.set("no-sub-key", "val");
+      const result = await redis.get("no-sub-key");
+      expect(result).to.eql("val");
+      redis.disconnect();
+    });
+
+    it("should trace errors on failed commands", async function () {
+      const errorEvents: any[] = [];
+      const subscriber = {
+        start() {},
+        end() {},
+        asyncStart() {},
+        asyncEnd() {},
+        error(message: any) { errorEvents.push(message); },
+      };
+
+      const channel = dc.tracingChannel("ioredis:command");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({ lazyConnect: true });
+        await redis.connect();
+        // HSET requires at least 3 arguments; calling with wrong type triggers an error
+        try {
+          // @ts-expect-error intentionally passing wrong args
+          await redis.hget("tracing-test-key"); // key was set as string, not hash
+        } catch {
+          // Expected error
+        }
+        redis.disconnect();
+
+        // We should still get error events traced
+        // Note: some Redis servers may not error on hget of a string key,
+        // so we just verify the mechanism works without asserting on specific errors
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+  });
+
+  describe("ioredis:connect", function () {
+    it("should trace the connection", async function () {
+      const events: { name: string; context: any }[] = [];
+      const subscriber = {
+        start(message: any) { events.push({ name: "start", context: message }); },
+        end(message: any) { events.push({ name: "end", context: message }); },
+        asyncStart(message: any) { events.push({ name: "asyncStart", context: message }); },
+        asyncEnd(message: any) { events.push({ name: "asyncEnd", context: message }); },
+        error(message: any) { events.push({ name: "error", context: message }); },
+      };
+
+      const channel = dc.tracingChannel("ioredis:connect");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({ lazyConnect: true });
+        await redis.connect();
+        redis.disconnect();
+
+        const startEvents = events.filter((e) => e.name === "start");
+        expect(startEvents.length).to.eql(1);
+        expect(startEvents[0].context.serverAddress).to.eql("localhost");
+        expect(startEvents[0].context.serverPort).to.eql(6379);
+
+        const asyncEndEvents = events.filter((e) => e.name === "asyncEnd");
+        expect(asyncEndEvents.length).to.eql(1);
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+
+    it("should trace connection failure", async function () {
+      const events: { name: string; context: any }[] = [];
+      const subscriber = {
+        start(message: any) { events.push({ name: "start", context: message }); },
+        end(message: any) { events.push({ name: "end", context: message }); },
+        asyncStart(message: any) { events.push({ name: "asyncStart", context: message }); },
+        asyncEnd(message: any) { events.push({ name: "asyncEnd", context: message }); },
+        error(message: any) { events.push({ name: "error", context: message }); },
+      };
+
+      const channel = dc.tracingChannel("ioredis:connect");
+      channel.subscribe(subscriber);
+
+      try {
+        const redis = new Redis({
+          port: 1, // unlikely to have a Redis server on port 1
+          lazyConnect: true,
+          retryStrategy: () => null, // don't retry
+          connectTimeout: 1000,
+        });
+
+        try {
+          await redis.connect();
+        } catch {
+          // Expected to fail
+        }
+
+        const startEvents = events.filter((e) => e.name === "start");
+        expect(startEvents.length).to.eql(1);
+        expect(startEvents[0].context.serverAddress).to.eql("localhost");
+        expect(startEvents[0].context.serverPort).to.eql(1);
+
+        // Should have error event
+        const errorEvents = events.filter((e) => e.name === "error");
+        expect(errorEvents.length).to.be.greaterThan(0);
+      } finally {
+        channel.unsubscribe(subscriber);
+      }
+    });
+  });
+});

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -187,6 +187,8 @@ describeOrSkip("tracing", function () {
         expect(multiEvents.length).to.be.greaterThan(0);
         for (const evt of multiEvents) {
           expect(evt.batchMode).to.eql("MULTI");
+          // batchSize should count only user commands (SET + GET), not MULTI/EXEC
+          expect(evt.batchSize).to.eql(2);
         }
       } finally {
         channel.unsubscribe(subscriber);

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -2,10 +2,10 @@ import Redis from "../../lib/Redis";
 import { expect } from "chai";
 import { sanitizeArgs } from "../../lib/tracing";
 
-// TracingChannel requires Node >= 20.13. Skip tests on older versions.
+// TracingChannel requires Node >= 18.19. Skip tests on older versions.
 const nodeVersion = process.versions.node.split(".").map(Number);
 const hasTracingChannel =
-  nodeVersion[0] > 20 || (nodeVersion[0] === 20 && nodeVersion[1] >= 13);
+  nodeVersion[0] > 18 || (nodeVersion[0] === 18 && nodeVersion[1] >= 19);
 
 const describeOrSkip = hasTracingChannel ? describe : describe.skip;
 


### PR DESCRIPTION
This PR implements tracing channels for `command` and `connect` operations. This allows APM libraries (OTEL, Datadog, Sentry) to instrument redis commands **without monkey-patching**.

It also enables users to setup their own custom instrumentations and analytics.

This is a port of redis/node-redis#3195 to ioredis, based on the proposal in redis/node-redis#2590.

### Tracing Channels

All channels in this PR use the Node.js [`TracingChannel`](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel) API, which provides `start`, `end`, `asyncStart`, `asyncEnd`, and `error` sub-channels automatically.

| TracingChannel | Tracks | Context fields |
|---|---|---|
| `ioredis:command` | Individual Redis command execution from queue to reply (standalone, MULTI, and pipeline) | `command`, `args`, `database`, `serverAddress`, `serverPort`, and optionally `batchMode`, `batchSize` for MULTI/pipeline commands |
| `ioredis:connect` | Client connection lifecycle (initial connections and reconnections) | `serverAddress`, `serverPort`, `connectionEpoch` |

### Context Properties

The payload sent in the trace events closely follows what OTEL currently extracts as attributes in their instrumentations:

| Field | Source | OTEL attribute it enables |
|---|---|---|
| `command` | command name | `db.operation.name` |
| `args` | full args array | `db.query.text` (APM serializes/sanitizes) |
| `database` | selected DB | `db.namespace` |
| `serverAddress` | socket options host (or `path` for IPC) | `server.address` |
| `serverPort` | socket options port (`undefined` for IPC) | `server.port` |

For batch commands we include these properties:

| Field | Source | OTEL attribute it enables |
|---|---|---|
| `batchMode` | `'PIPELINE'` or `'MULTI'` | `db.operation.name` prefix |
| `batchSize` | number of user commands (excludes MULTI/EXEC protocol wrappers) | `db.operation.batch.size` |

For connect events:

| Field | Source | Description |
|---|---|---|
| `connectionEpoch` | internal reconnection counter | `0` for initial connect, `1+` for reconnections. APMs can use this to distinguish initial connections, detect flapping, or correlate traces across reconnection cycles. |

### Backward Compatibility

Zero-cost when no subscribers are registered. Silently skipped on Node.js versions where `TracingChannel` is unavailable (e.g. Node 18).

```ts
const dc = ('getBuiltinModule' in process)
  ? process.getBuiltinModule('node:diagnostics_channel')
  : require('node:diagnostics_channel');
```

## Usage Examples

Consumers will be doing something like this:

```ts
  const dc = require('node:diagnostics_channel');

  // Trace individual Redis commands
  dc.tracingChannel('ioredis:command').subscribe({
    start(ctx) {
      console.log(`→ ${ctx.command}`, ctx.args, `db=${ctx.database}`);
      // APM: create span here
      // ctx.span = tracer.startSpan(`redis ${ctx.command}`, { attributes: {
      //   'db.system': 'redis',
      //   'db.operation.name': ctx.command,
      //   'db.namespace': String(ctx.database),
      //   'server.address': ctx.serverAddress,
      //   'server.port': ctx.serverPort,
      // }});
    },
    asyncEnd(ctx) {
      console.log(`✓ ${ctx.command} done`);
      // ctx.span?.end();
    },
    error(ctx) {
      console.error(`✗ ${ctx.command} failed:`, ctx.error?.message);
      // ctx.span?.setStatus({ code: SpanStatusCode.ERROR });
    },
  });

  // Trace connection
  dc.tracingChannel('ioredis:connect').subscribe({
    start(ctx) {
      console.log(`Connecting to ${ctx.serverAddress}:${ctx.serverPort} (epoch: ${ctx.connectionEpoch})`);
    },
    asyncEnd() {
      console.log('Connected');
    },
    error(ctx) {
      console.error('Connection failed:', ctx.error?.message);
    },
  });

  // Works with all ioredis operations — no monkey-patching needed
  const redis = new Redis();
  await redis.set('foo', 'bar');          // ioredis:command { command: 'SET', args: ['foo', 'bar'] }
  await redis.get('foo');                  // ioredis:command { command: 'GET', args: ['foo'] }

  // Pipeline/MULTI commands include batch metadata
  const pipeline = redis.pipeline();
  pipeline.set('a', '1');
  pipeline.set('b', '2');
  await pipeline.exec();                  // ioredis:command { command: 'SET', batchMode: 'PIPELINE', batchSize: 2 }
```

### Future Improvements

- **Offline queue tracing channel**: A dedicated `ioredis:command:queue` channel could emit events when commands enter the offline queue, allowing APMs to measure queue wait time separately from command execution time and track how many commands hit the offline queue (a signal of connection instability). Note that the existing OTEL monkey-patch instrumentation (`@opentelemetry/instrumentation-ioredis`) has the same gap — it doesn't distinguish queued vs. written commands either.
- **Sentinel-aware server address**: `_getServerAddress()` currently uses configured `host`/`port` options. For sentinel setups, the trace context could reflect the actual resolved endpoint rather than the configured defaults.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Redis.connect()` and `sendCommand()` paths to wrap operations in tracing helpers; while intended to be zero-overhead when unused, mistakes could affect command execution flow or error handling. Adds argument sanitization rules to avoid leaking secrets, but incorrect redaction logic could still expose or over-redact data.
> 
> **Overview**
> Adds Node.js `diagnostics_channel`/`TracingChannel` instrumentation for ioredis operations, emitting telemetry for **individual commands** (`ioredis:command`), **MULTI batches** (`ioredis:batch`), and **connection attempts** (`ioredis:connect`) when subscribers are present (silently no-op otherwise).
> 
> `Redis.connect()` is now traced via `traceConnect`, and `sendCommand()` wraps the written command promise with `traceCommand` exactly once per command (using a new `Command.isTraced` flag) to avoid duplicate events during offline-queue flushes or command resends after reconnect.
> 
> Introduces `lib/tracing.ts` with safe-by-default argument sanitization (redacting sensitive values via `sanitizeArgs`) and exported context types, updates docs with subscription examples, and adds comprehensive functional tests validating tracing behavior, deduplication, error tracing, and lack of unhandled rejections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79d3220c1406b0eb78688be2eff06c0e19593223. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->