### PR TITLE
fix(test): race condition in spub/ssub auto-resubscription test

### DIFF
--- a/test/functional/spub_ssub.ts
+++ b/test/functional/spub_ssub.ts
@@ -23,7 +23,7 @@ describe("spub/ssub", function () {
     redis.ssubscribe("foo", function () {
       redis.set("foo", "bar", function (err) {
         expect(err instanceof Error);
-        expect(err.message).to.match(/subscriber mode/);
+        expect(err?.message).to.match(/subscriber mode/);
         redis.disconnect();
         done();
       });
@@ -157,7 +157,7 @@ describe("spub/ssub", function () {
 
     const stub = sinon.stub(Redis.prototype, "ssubscribe");
 
-    subscriber.disconnect({ reconnect: true });
+    subscriber.disconnect(true);
 
     await new Promise((resolve) => {
       subscriber.once("ready", resolve);


### PR DESCRIPTION
## Summary

  Fixes a flaky test that intermittently fails with `TypeError: Cannot read properties of null (reading 'args')` at `spub_ssub.ts:168`.

  ## Root cause

  `subscriber.disconnect({ reconnect: true })` wasn't triggering proper reconnection, so the sinon stub didn't capture all 3 `ssubscribe` calls before the
  assertions ran.

  ## Fix

  Changed to `subscriber.disconnect(true)` which correctly triggers reconnection and auto-resubscription.

  ## Test plan

  - [x] `should call ssubscribe individually for each channel during auto-resubscription` passes consistently
  - [x] All 9 spub/ssub tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to functional tests and only adjust expectations and reconnection triggering to reduce flakiness.
> 
> **Overview**
> Fixes a flaky `spub/ssub` functional test by triggering reconnect via `subscriber.disconnect(true)` so auto-resubscription reliably replays the three `ssubscribe` calls before assertions run.
> 
> Also makes the subscriber-mode error assertion tolerant of a possibly undefined error object by matching on `err?.message`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4cb5e6e511b4edb132d1387e09f5cc53dc32cc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->