### PR TITLE
fix(test): fully resolve spub/ssub auto-resubscription  
  race condition

### DIFF
--- a/test/functional/spub_ssub.ts
+++ b/test/functional/spub_ssub.ts
@@ -84,6 +84,7 @@ describe("spub/ssub", function () {
       expect(channel).to.eql("foo");
       expect(message).to.eql("bar");
       if (!--pending) {
+        pub.disconnect();
         redis.disconnect();
         done();
       }
@@ -94,6 +95,7 @@ describe("spub/ssub", function () {
       expect(message).to.be.instanceof(Buffer);
       expect(message.toString()).to.eql("bar");
       if (!--pending) {
+        pub.disconnect();
         redis.disconnect();
         done();
       }
@@ -115,15 +117,10 @@ describe("spub/ssub", function () {
     });
   });
 
-  // TODO ready reconnect in redis stand
   it("should restore subscription after reconnecting(ssubscribe)", (done) => {
-    const redis = new Redis({ port: 6379, host: "127.0.0.1" });
-    const pub = new Redis({ port: 6379, host: "127.0.0.1" });
-    // redis.ping(function (err, result) {
-    //   // redis.on("message", function (channel, message) {
-    //   console.log(`${err}-${result}`);
-    //   // });
-    // });
+    // It defaults to port: 6379, host: 127.0.0.1
+    const redis = new Redis();
+    const pub = new Redis();
     redis.ssubscribe("foo", "bar", function () {
       redis.on("ready", function () {
         // Execute a random command to make sure that `subscribe`
@@ -158,30 +155,28 @@ describe("spub/ssub", function () {
     await subscriber.ssubscribe("shard2");
     await subscriber.ssubscribe("shard3");
 
-    const stub = sinon.stub(Redis.prototype, "ssubscribe");
+    type SsubscribeArgs = (string | Buffer)[];
+    const calls: SsubscribeArgs[] = [];
+    let resolveAllCalls: () => void;
+    const allCalls = new Promise<void>((resolve) => {
+      resolveAllCalls = resolve;
+    });
+
+    const stub = sinon
+      .stub(Redis.prototype, "ssubscribe")
+      .callsFake((...args: SsubscribeArgs) => {
+        calls.push(args);
+        if (calls.length === 3) resolveAllCalls();
+        return Promise.resolve(calls.length);
+      });
 
     subscriber.disconnect(true);
 
-    await new Promise((resolve) => {
-      subscriber.once("ready", resolve);
-    });
+    await allCalls;
 
-    await subscriber.ping();
-
-    // ping() flushes the command queue but auto-resubscription is async and
-    // may not have fired all 3 ssubscribe calls yet. Poll until the stub
-    // records all 3 calls; Mocha's test timeout handles the failure case.
-    await new Promise<void>((resolve) => {
-      const check = () => {
-        if (stub.callCount >= 3) return resolve();
-        setTimeout(check, 50);
-      };
-      check();
-    });
-
-    expect(stub.getCall(0).args).to.deep.equal(["shard1"]);
-    expect(stub.getCall(1).args).to.deep.equal(["shard2"]);
-    expect(stub.getCall(2).args).to.deep.equal(["shard3"]);
+    expect(calls[0]).to.deep.equal(["shard1"]);
+    expect(calls[1]).to.deep.equal(["shard2"]);
+    expect(calls[2]).to.deep.equal(["shard3"]);
 
     stub.restore();
     subscriber.disconnect();

--- a/test/functional/spub_ssub.ts
+++ b/test/functional/spub_ssub.ts
@@ -151,9 +151,12 @@ describe("spub/ssub", function () {
 
     await subscriber.ping();
 
-    subscriber.ssubscribe("shard1");
-    subscriber.ssubscribe("shard2");
-    subscriber.ssubscribe("shard3");
+    // Await each subscription so all 3 channels are registered on the server
+    // before we stub and disconnect; without this, disconnect can fire before
+    // subscriptions complete, leaving the auto-resubscribe list incomplete.
+    await subscriber.ssubscribe("shard1");
+    await subscriber.ssubscribe("shard2");
+    await subscriber.ssubscribe("shard3");
 
     const stub = sinon.stub(Redis.prototype, "ssubscribe");
 
@@ -164,6 +167,17 @@ describe("spub/ssub", function () {
     });
 
     await subscriber.ping();
+
+    // ping() flushes the command queue but auto-resubscription is async and
+    // may not have fired all 3 ssubscribe calls yet. Poll until the stub
+    // records all 3 calls; Mocha's test timeout handles the failure case.
+    await new Promise<void>((resolve) => {
+      const check = () => {
+        if (stub.callCount >= 3) return resolve();
+        setTimeout(check, 50);
+      };
+      check();
+    });
 
     expect(stub.getCall(0).args).to.deep.equal(["shard1"]);
     expect(stub.getCall(1).args).to.deep.equal(["shard2"]);

--- a/test/functional/spub_ssub.ts
+++ b/test/functional/spub_ssub.ts
@@ -155,28 +155,21 @@ describe("spub/ssub", function () {
     await subscriber.ssubscribe("shard2");
     await subscriber.ssubscribe("shard3");
 
-    type SsubscribeArgs = (string | Buffer)[];
-    const calls: SsubscribeArgs[] = [];
-    let resolveAllCalls: () => void;
-    const allCalls = new Promise<void>((resolve) => {
-      resolveAllCalls = resolve;
-    });
-
-    const stub = sinon
-      .stub(Redis.prototype, "ssubscribe")
-      .callsFake((...args: SsubscribeArgs) => {
-        calls.push(args);
-        if (calls.length === 3) resolveAllCalls();
-        return Promise.resolve(calls.length);
-      });
+    const stub = sinon.stub(Redis.prototype, "ssubscribe");
 
     subscriber.disconnect(true);
 
-    await allCalls;
+    // Auto-resubscribe iterates channels synchronously before "ready" emits
+    // (see lib/redis/event_handler.ts), so by the time we observe "ready",
+    // all ssubscribe calls are already recorded on the stub. No wait needed.
+    await new Promise<void>((resolve) => {
+      subscriber.once("ready", resolve);
+    });
 
-    expect(calls[0]).to.deep.equal(["shard1"]);
-    expect(calls[1]).to.deep.equal(["shard2"]);
-    expect(calls[2]).to.deep.equal(["shard3"]);
+    expect(stub.callCount).to.equal(3);
+    expect(stub.getCall(0).args).to.deep.equal(["shard1"]);
+    expect(stub.getCall(1).args).to.deep.equal(["shard2"]);
+    expect(stub.getCall(2).args).to.deep.equal(["shard3"]);
 
     stub.restore();
     subscriber.disconnect();


### PR DESCRIPTION
## Summary
  - Follow-up to #2092                                                                               
  - Await initial ssubscribe calls so channels are registered before disconnect
  - Poll for stub.callCount >= 3 instead of relying on ping() as a barrier

  ## Test plan
  - [x] All 555 tests passing, 0 failures
  - [x] Stable under nyc coverage overhead

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to functional tests, mainly addressing timing/race issues around async `ssubscribe` and reconnect handling.
> 
> **Overview**
> Fixes `spub/ssub` functional test flakiness by ensuring the publisher connection is always disconnected when both `smessage` and `smessageBuffer` handlers complete.
> 
> Stabilizes the auto-resubscribe test by `await`ing initial `ssubscribe` calls before forcing a reconnect and by asserting the expected `ssubscribe` stub calls after the `ready` event (instead of using extra commands as a timing barrier).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54097d9f463cdaed1199ec5e374c42f535b0771f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->