### PR TITLE
feat: add typed GCRA command support and functional tests

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "unstable-24425681442-debian"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8-m02"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "unstable-23321515778-debian"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "unstable-24425681442-debian"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -127,6 +127,7 @@ module.exports = {
   failover: "'OK'",
   flushall: "'OK'",
   flushdb: "'OK'",
+  gcra: "[limited: 0 | 1, totalLimit: number, remaining: number, retryAfter: number, resetAfter: number]",
   geoadd: "number",
   geohash: "string[]",
   geopos: "([longitude: string, latitude: string] | null)[]",

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -3275,60 +3275,13 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
 
   /**
    * Rate limit via GCRA (Generic Cell Rate Algorithm).
-   * - _group_: string
+   * - _group_: rate_limit
    * - _complexity_: O(1)
    * - _since_: 8.8.0
    */
-  gcra(
-    key: RedisKey,
-    maxBurst: number | string,
-    tokensPerPeriod: number | string,
-    period: number | string,
-    callback?: Callback<
-      [
-        limited: 0 | 1,
-        totalLimit: number,
-        remaining: number,
-        retryAfter: number,
-        resetAfter: number,
-      ]
-    >,
-  ): Result<
-    [
-      limited: 0 | 1,
-      totalLimit: number,
-      remaining: number,
-      retryAfter: number,
-      resetAfter: number,
-    ],
-    Context
-  >;
-  gcra(
-    key: RedisKey,
-    maxBurst: number | string,
-    tokensPerPeriod: number | string,
-    period: number | string,
-    countToken: "TOKENS",
-    count: number | string,
-    callback?: Callback<
-      [
-        limited: 0 | 1,
-        totalLimit: number,
-        remaining: number,
-        retryAfter: number,
-        resetAfter: number,
-      ]
-    >,
-  ): Result<
-    [
-      limited: 0 | 1,
-      totalLimit: number,
-      remaining: number,
-      retryAfter: number,
-      resetAfter: number,
-    ],
-    Context
-  >;
+  gcra(key: RedisKey, maxBurst: number | string, tokensPerPeriod: number | string, period: number | string, callback?: Callback<[limited: 0 | 1, totalLimit: number, remaining: number, retryAfter: number, resetAfter: number]>): Result<[limited: 0 | 1, totalLimit: number, remaining: number, retryAfter: number, resetAfter: number], Context>;
+  gcra(key: RedisKey, maxBurst: number | string, tokensPerPeriod: number | string, period: number | string, countToken: 'TOKENS', count: number | string, callback?: Callback<[limited: 0 | 1, totalLimit: number, remaining: number, retryAfter: number, resetAfter: number]>): Result<[limited: 0 | 1, totalLimit: number, remaining: number, retryAfter: number, resetAfter: number], Context>;
+
 
   /**
    * Add one or more geospatial items in the geospatial index represented using a sorted set

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -3274,6 +3274,63 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   ): Result<unknown, Context>;
 
   /**
+   * Rate limit via GCRA (Generic Cell Rate Algorithm).
+   * - _group_: string
+   * - _complexity_: O(1)
+   * - _since_: 8.8.0
+   */
+  gcra(
+    key: RedisKey,
+    maxBurst: number | string,
+    requestsPerPeriod: number | string,
+    period: number | string,
+    callback?: Callback<
+      [
+        limited: 0 | 1,
+        totalLimit: number,
+        remaining: number,
+        retryAfter: number,
+        resetAfter: number,
+      ]
+    >,
+  ): Result<
+    [
+      limited: 0 | 1,
+      totalLimit: number,
+      remaining: number,
+      retryAfter: number,
+      resetAfter: number,
+    ],
+    Context
+  >;
+  gcra(
+    key: RedisKey,
+    maxBurst: number | string,
+    requestsPerPeriod: number | string,
+    period: number | string,
+    countToken: "NUM_REQUESTS",
+    count: number | string,
+    callback?: Callback<
+      [
+        limited: 0 | 1,
+        totalLimit: number,
+        remaining: number,
+        retryAfter: number,
+        resetAfter: number,
+      ]
+    >,
+  ): Result<
+    [
+      limited: 0 | 1,
+      totalLimit: number,
+      remaining: number,
+      retryAfter: number,
+      resetAfter: number,
+    ],
+    Context
+  >;
+
+  /**
    * Add one or more geospatial items in the geospatial index represented using a sorted set
    * - _group_: geo
    * - _complexity_: O(log(N)) for each item added, where N is the number of elements in the sorted set.

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -3282,7 +3282,7 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   gcra(
     key: RedisKey,
     maxBurst: number | string,
-    requestsPerPeriod: number | string,
+    tokensPerPeriod: number | string,
     period: number | string,
     callback?: Callback<
       [
@@ -3306,9 +3306,9 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   gcra(
     key: RedisKey,
     maxBurst: number | string,
-    requestsPerPeriod: number | string,
+    tokensPerPeriod: number | string,
     period: number | string,
-    countToken: "NUM_REQUESTS",
+    countToken: "TOKENS",
     count: number | string,
     callback?: Callback<
       [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.10.1",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "1.5.1",
+        "@ioredis/commands": "1.6.0",
         "cluster-key-slot": "1.1.1",
         "debug": "4.4.3",
         "denque": "2.1.0",
@@ -541,9 +541,9 @@
       "dev": true
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
-      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.6.0.tgz",
+      "integrity": "sha512-lNa3bQBsR2OQ+IopxlSydDNSPKD4TGUaSBBs+f68ugyTJBtXhcxQE8oqrDflRv2kKOT/QnBQcSPQ7/T2mSMLxQ==",
       "license": "MIT"
     },
     "node_modules/@ioredis/interface-generator": {
@@ -9906,9 +9906,9 @@
       "dev": true
     },
     "@ioredis/commands": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
-      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.6.0.tgz",
+      "integrity": "sha512-lNa3bQBsR2OQ+IopxlSydDNSPKD4TGUaSBBs+f68ugyTJBtXhcxQE8oqrDflRv2kKOT/QnBQcSPQ7/T2mSMLxQ=="
     },
     "@ioredis/interface-generator": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "https://opencollective.com/ioredis"
   },
   "dependencies": {
-    "@ioredis/commands": "1.5.1",
+    "@ioredis/commands": "1.6.0",
     "cluster-key-slot": "1.1.1",
     "debug": "4.4.3",
     "denque": "2.1.0",

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-unstable-24425681442-debian}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-8.8-m02}
 
 services:
   single:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-8.4-RC1-pre.2}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-unstable-24425681442-debian}
 
 services:
   single:

--- a/test/functional/commands/gcra.ts
+++ b/test/functional/commands/gcra.ts
@@ -40,13 +40,13 @@ describe("gcra", function () {
     expect(first.retryAfter >= 0 || second.retryAfter >= 0).to.equal(true);
   });
 
-  it("should support weighted requests using NUM_REQUESTS", async () => {
+  it("should support weighted requests using TOKENS", async () => {
     const key = `test_gcra_weighted_${Date.now()}`;
     const first = normalizeGcraReply(
-      await redis.gcra(key, 10, 10, 1, "NUM_REQUESTS", 10),
+      await redis.gcra(key, 10, 10, 1, "TOKENS", 10),
     );
     const second = normalizeGcraReply(
-      await redis.gcra(key, 10, 10, 1, "NUM_REQUESTS", 10),
+      await redis.gcra(key, 10, 10, 1, "TOKENS", 10),
     );
 
     expect(first.limited).to.not.equal(second.limited);

--- a/test/functional/commands/gcra.ts
+++ b/test/functional/commands/gcra.ts
@@ -1,0 +1,54 @@
+import Redis from "../../../lib/Redis";
+import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
+
+
+function normalizeGcraReply(reply: Awaited<ReturnType<Redis["gcra"]>>) {
+  return {
+    limited: reply[0],
+    totalLimit: reply[1],
+    remaining: reply[2],
+    retryAfter: reply[3],
+    resetAfter: reply[4]
+  };
+}
+
+describe("gcra", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.8")) {
+      this.skip();
+    }
+  });
+
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = new Redis();
+  });
+
+  afterEach(() => {
+    redis.disconnect();
+  });
+
+  it("should allow one request then limit the next with zero burst", async () => {
+    const key = `test_gcra_single_token_${Date.now()}`;
+    const first = normalizeGcraReply(await redis.gcra(key, 0, 1, 1));
+    const second = normalizeGcraReply(await redis.gcra(key, 0, 1, 1));
+
+    expect(first.limited).to.not.equal(second.limited);
+    expect(first.retryAfter === -1 || second.retryAfter === -1).to.equal(true);
+    expect(first.retryAfter >= 0 || second.retryAfter >= 0).to.equal(true);
+  });
+
+  it("should support weighted requests using NUM_REQUESTS", async () => {
+    const key = `test_gcra_weighted_${Date.now()}`;
+    const first = normalizeGcraReply(
+      await redis.gcra(key, 10, 10, 1, "NUM_REQUESTS", 10),
+    );
+    const second = normalizeGcraReply(
+      await redis.gcra(key, 10, 10, 1, "NUM_REQUESTS", 10),
+    );
+
+    expect(first.limited).to.not.equal(second.limited);
+  });
+});

--- a/test/functional/commands/gcra.ts
+++ b/test/functional/commands/gcra.ts
@@ -15,7 +15,7 @@ function normalizeGcraReply(reply: Awaited<ReturnType<Redis["gcra"]>>) {
 
 describe("gcra", function () {
   before(async function () {
-    if (await isRedisVersionLowerThan("8.8")) {
+    if (await isRedisVersionLowerThan("8.7")) {
       this.skip();
     }
   });

--- a/test/functional/commands/hgetdel.ts
+++ b/test/functional/commands/hgetdel.ts
@@ -1,9 +1,14 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
-// TODO unskip once we have a mechanism to run only on specific versions
-// TODO as these tests can only work against 8.0 or higher
-describe.skip("hgetdel", () => {
+describe("hgetdel", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.0")) {
+      this.skip();
+    }
+  });
+
   it("should return values and null for missing field", async () => {
     const redis = new Redis();
     const key = `test_hgetdel_${Date.now()}`;

--- a/test/functional/commands/hgetex.ts
+++ b/test/functional/commands/hgetex.ts
@@ -1,9 +1,14 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
-// TODO unskip once we have a mechanism to run only on specific versions
-// TODO as these tests can only work against 8.0 or higher
-describe.skip("hgetex", () => {
+describe("hgetex", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.0")) {
+      this.skip();
+    }
+  });
+
   it("should return values and null for missing field", async () => {
     const redis = new Redis();
     const key = `test_hgetex_${Date.now()}`;

--- a/test/functional/commands/hsetex.ts
+++ b/test/functional/commands/hsetex.ts
@@ -1,9 +1,14 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
-// TODO unskip once we have a mechanism to run only on specific versions
-// TODO as these tests can only work against 8.0 or higher
-describe.skip("hsetex", () => {
+describe("hsetex", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.0")) {
+      this.skip();
+    }
+  });
+
   const hashKey = "test_hsetex_key";
 
   it("should return 1 when fields are set", async () => {

--- a/test/functional/commands/xdelex.ts
+++ b/test/functional/commands/xdelex.ts
@@ -1,5 +1,6 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
 const STREAM_DELETION_REPLY_CODES = {
   NOT_FOUND: -1,
@@ -7,9 +8,13 @@ const STREAM_DELETION_REPLY_CODES = {
   DANGLING_REFS: 2,
 } as const;
 
-// TODO unskip once we have a mechanism to run only on specific versions
-// TODO as these tests can only work against 8.2 or higher
-describe.skip("xdelex", () => {
+describe("xdelex", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.2")) {
+      this.skip();
+    }
+  });
+
   let redis: Redis;
 
   beforeEach(() => {

--- a/test/functional/commands/xtrim.ts
+++ b/test/functional/commands/xtrim.ts
@@ -1,5 +1,6 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
 describe("xtrim", () => {
   let redis: Redis;
@@ -32,23 +33,32 @@ describe("xtrim", () => {
     expect(res).to.be.a("number");
   });
 
-  // TODO add a mechanism to skip tests based on server version
-  it.skip("xtrim with policy (DELREF) returns a number when supported", async function (this: any) {
-    const res = await redis.xtrim("{tag}key", "MAXLEN", 0, "DELREF");
-    expect(res).to.be.a("number");
-  });
+  describe("xtrim with policy", function () {
+    before(async function () {
+      if (await isRedisVersionLowerThan("8.2")) {
+        this.skip();
+      }
+    });
 
-  // TODO add a mechanism to skip tests based on server version
-  it.skip("xtrim with all options (MINID ~ LIMIT KEEPREF) returns a number when supported", async function (this: any) {
-    const res = await redis.xtrim(
-      "{tag}key",
-      "MINID",
-      "~",
-      0,
-      "LIMIT",
-      10,
-      "KEEPREF"
+    it("xtrim with policy (DELREF) returns a number when supported", async () => {
+      const res = await redis.xtrim("{tag}key", "MAXLEN", 0, "DELREF");
+      expect(res).to.be.a("number");
+    });
+
+    it(
+      "xtrim with all options (MINID ~ LIMIT KEEPREF) returns a number when supported",
+      async () => {
+        const res = await redis.xtrim(
+          "{tag}key",
+          "MINID",
+          "~",
+          0,
+          "LIMIT",
+          10,
+          "KEEPREF"
+        );
+        expect(res).to.be.a("number");
+      }
     );
-    expect(res).to.be.a("number");
   });
 });

--- a/test/helpers/util.ts
+++ b/test/helpers/util.ts
@@ -1,8 +1,50 @@
+import Redis from "../../lib/Redis";
+
 export function waitForMonitorReady() {
   // It takes a while for the monitor to be ready.
   // This is a hack to wait for it because the monitor command
   // does not have a response
   return new Promise((resolve) => setTimeout(resolve, 150));
+}
+
+function parseRedisVersion(version: string): number[] {
+  return version.match(/\d+/g)?.slice(0, 2).map(Number) ?? [0, 0];
+}
+
+function compareRedisVersions(left: string, right: string): number {
+  const leftParts = parseRedisVersion(left);
+  const rightParts = parseRedisVersion(right);
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index++) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+export async function isRedisVersionLowerThan(
+  minimumVersion: string
+): Promise<boolean> {
+  const redis = new Redis();
+
+  try {
+    const info = await redis.info("server");
+    const version = info.match(/^redis_version:(.+)$/m)?.[1]?.trim();
+
+    if (!version) {
+      throw new Error(
+        "Could not determine redis_version from INFO server response"
+      );
+    }
+
+    return compareRedisVersions(version, minimumVersion) < 0;
+  } finally {
+    redis.disconnect();
+  }
 }
 
 export async function getCommandsFromMonitor(

--- a/test/typing/commands.test-d.ts
+++ b/test/typing/commands.test-d.ts
@@ -95,6 +95,17 @@ expectType<Promise<Buffer | null>>(redis.zscoreBuffer("key", "member"));
 // GETRANGE
 expectType<Promise<Buffer>>(redis.getrangeBuffer("foo", 0, 1));
 
+// GCRA
+type GcraReply = [
+  limited: 0 | 1,
+  totalLimit: number,
+  remaining: number,
+  retryAfter: number,
+  resetAfter: number
+];
+expectType<Promise<GcraReply>>(redis.gcra("key", 0, 1, 1));
+expectType<Promise<GcraReply>>(redis.gcra("key", 10, 10, 1, "TOKENS", 10));
+
 // Callbacks
 redis.getBuffer("foo", (err, res) => {
   expectType<Error | null | undefined>(err);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Redis command surface (`gcra`) and updates CI/test Redis versions, which could introduce compatibility issues across Redis builds and affect test stability.
> 
> **Overview**
> Adds first-class, typed support for Redis `GCRA` rate-limiting via new `RedisCommander.gcra` overloads and corresponding return type wiring.
> 
> Updates the test matrix/docker image to use Redis `8.8-m02`, adds functional + typing tests for `gcra`, and replaces several previously skipped command tests (`hgetdel`, `hgetex`, `hsetex`, `xdelex`, `xtrim` policy options) with runtime version checks via a new `isRedisVersionLowerThan()` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d01fde49a8471970c91d099fc3a0b6f2462f75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->