### PR TITLE
fix(cluster): reconnect to nodes that restart without slot changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage
 benchmarks/fixtures/*.txt
 
 *.rdb
+.history

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 benchmarks/fixtures/*.txt
 
 *.rdb
+.history

--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,14 @@ cluster.get("foo", (err, res) => {
       }
       ```
 
+    - `clusterNodeRetryStrategy`: Per-node retry strategy. By default, ioredis won't try to reconnect to a lost node and just waits for a `MOVED` error to refresh slots. If you pass a function here, it's used as the `retryStrategy` for each node — return a number to reconnect after that many ms, or anything else to drop the node from the pool. Handy for replica nodes that restart without slot changes (e.g. maintenance). Example:
+
+      ```javascript
+      function (times) {
+        return Math.min(100 * times, 2000);
+      }
+      ```
+
     - `dnsLookup`: Alternative DNS lookup function (`dns.lookup()` is used by default). It may be useful to override this in special cases, such as when AWS ElastiCache used with TLS enabled.
     - `enableOfflineQueue`: Similar to the `enableOfflineQueue` option of `Redis` class.
     - `enableReadyCheck`: When enabled, "ready" event will only be emitted when `CLUSTER INFO` command

--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -237,6 +237,7 @@ export interface ClusterOptions extends CommanderOptions {
 
 export const DEFAULT_CLUSTER_OPTIONS: ClusterOptions = {
   clusterRetryStrategy: (times) => Math.min(100 + times * 2, 2000),
+  clusterNodeRetryStrategy: null,
   enableOfflineQueue: true,
   enableReadyCheck: true,
   scaleReads: "master",

--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -40,6 +40,7 @@ export interface ClusterOptions extends CommanderOptions {
    */
   clusterRetryStrategy?:
     | ((times: number, reason?: Error) => number | void | null)
+    | null
     | undefined;
 
   /**
@@ -133,6 +134,26 @@ export interface ClusterOptions extends CommanderOptions {
    * @default false
    */
   shardedSubscribers?: boolean | undefined;
+
+  /**
+   * When a cluster node connection is closed, this function will be called
+   * to determine the retry delay (in ms). Returning `null` or a non-number
+   * disables reconnection for that node.
+   *
+   * By default this is `null`, meaning cluster nodes will NOT automatically
+   * reconnect — the cluster relies on `MOVED` errors to refresh topology.
+   * Set this to enable reconnection, e.g. for replica nodes that restart
+   * without any slot changes.
+   *
+   * @example
+   * clusterNodeRetryStrategy: (times) => Math.min(times * 100, 3000)
+   *
+   * @default null
+   */
+  clusterNodeRetryStrategy?:
+    | ((times: number) => number | void | null)
+    | null
+    | undefined;
 
   /**
    * Passed to the constructor of `Redis`

--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -1,5 +1,5 @@
 import { SrvRecord, resolveSrv, lookup } from "dns";
-import { RedisOptions } from "../redis/RedisOptions";
+import { RedisOptions, RetryStrategy } from "../redis/RedisOptions";
 import { CommanderOptions } from "../utils/Commander";
 import { NodeRole } from "./util";
 
@@ -28,6 +28,8 @@ export type NatMap =
       [key: string]: { host: string; port: number };
     }
   | NatMapFunction;
+
+export type ClusterNodeRetryStrategy = RetryStrategy;
 
 /**
  * Options for Cluster constructor
@@ -150,10 +152,7 @@ export interface ClusterOptions extends CommanderOptions {
    *
    * @default null
    */
-  clusterNodeRetryStrategy?:
-    | ((times: number) => number | void | null)
-    | null
-    | undefined;
+  clusterNodeRetryStrategy?: ClusterNodeRetryStrategy;
 
   /**
    * Passed to the constructor of `Redis`

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -65,10 +65,15 @@ export default class ConnectionPool extends EventEmitter {
     const redis = new Redis(
         defaults(
             {
-              // Never try to reconnect when a node is lose,
-              // instead, waiting for a `MOVED` error and
-              // fetch the slots again.
-              retryStrategy: null,
+              // By default, never try to reconnect when a node is lost,
+              // instead, waiting for a `MOVED` error and fetching slots again.
+              // When `clusterNodeRetryStrategy` is set, use it to allow
+              // reconnection (e.g. for replica nodes that restart without
+              // any slot changes).
+              retryStrategy:
+                typeof this.redisOptions.clusterNodeRetryStrategy === "function"
+                  ? this.redisOptions.clusterNodeRetryStrategy
+                  : null,
               // Offline queue should be enabled so that
               // we don't need to wait for the `ready` event
               // before sending commands to the node.

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import { sample, Debug, noop, defaults } from "../utils";
 import { RedisOptions, getNodeKey, NodeKey, NodeRole } from "./util";
+import { ClusterOptions, ClusterNodeRetryStrategy } from "./ClusterOptions";
 import Redis from "../Redis";
 
 const debug = Debug("cluster:connectionPool");
@@ -17,7 +18,10 @@ export default class ConnectionPool extends EventEmitter {
 
   private specifiedOptions: { [key: string]: any } = {};
 
-  constructor(private redisOptions) {
+  constructor(
+    private redisOptions: NonNullable<ClusterOptions["redisOptions"]>,
+    private clusterNodeRetryStrategy: ClusterNodeRetryStrategy = null
+  ) {
     super();
   }
 
@@ -71,8 +75,8 @@ export default class ConnectionPool extends EventEmitter {
               // reconnection (e.g. for replica nodes that restart without
               // any slot changes).
               retryStrategy:
-                typeof this.redisOptions.clusterNodeRetryStrategy === "function"
-                  ? this.redisOptions.clusterNodeRetryStrategy
+                typeof this.clusterNodeRetryStrategy === "function"
+                  ? this.clusterNodeRetryStrategy
                   : null,
               // Offline queue should be enabled so that
               // we don't need to wait for the `ready` event

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -138,7 +138,7 @@ export default class ConnectionPool extends EventEmitter {
 
       this.emit("+node", redis, key);
 
-      redis.on("error", function (error) {
+      redis.on("error", (error) => {
         this.emit("nodeError", error, key);
       });
     }

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -150,7 +150,10 @@ class Cluster extends Commander {
       );
     }
 
-    this.connectionPool = new ConnectionPool(this.options.redisOptions);
+    this.connectionPool = new ConnectionPool({
+      ...this.options.redisOptions,
+      clusterNodeRetryStrategy: this.options.clusterNodeRetryStrategy,
+    });
 
     this.connectionPool.on("-node", (redis, key) => {
       this.emit("-node", redis);
@@ -669,7 +672,23 @@ class Cluster extends Commander {
         }
       }
       if (redis) {
-        redis.sendCommand(command, stream);
+        // When enableOfflineQueue is false at the cluster level, reject
+        // commands going to a reconnecting node instead of queuing them
+        // on the node's internal offline queue.
+        if (
+          !_this.options.enableOfflineQueue &&
+          redis.status !== "ready" &&
+          redis.status !== "connect" &&
+          redis.status !== "wait"
+        ) {
+          command.reject(
+            new Error(
+              "Cluster node is not ready and enableOfflineQueue options is false"
+            )
+          );
+        } else {
+          redis.sendCommand(command, stream);
+        }
       } else if (_this.options.enableOfflineQueue) {
         _this.offlineQueue.push({
           command: command,

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -680,7 +680,7 @@ class Cluster extends Commander {
         return;
       }
 
-      if (!redis || (!_this.options.enableOfflineQueue && redis.status === "reconnecting")) {
+      if (!redis || (!_this.options.enableOfflineQueue && redis.status !== "ready" && redis.status !== "wait")) {
         command.reject(
           new Error(
             "Cluster isn't ready and enableOfflineQueue options is false"

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -150,10 +150,10 @@ class Cluster extends Commander {
       );
     }
 
-    this.connectionPool = new ConnectionPool({
-      ...(this.options.redisOptions ?? {}),
-      clusterNodeRetryStrategy: this.options.clusterNodeRetryStrategy,
-    });
+    this.connectionPool = new ConnectionPool(
+      this.options.redisOptions ?? {},
+      this.options.clusterNodeRetryStrategy
+    );
 
     this.connectionPool.on("-node", (redis, key) => {
       this.emit("-node", redis);
@@ -671,35 +671,25 @@ class Cluster extends Commander {
           node.redis = redis;
         }
       }
-      if (redis) {
-        // When enableOfflineQueue is false at the cluster level, reject
-        // commands going to a reconnecting node instead of queuing them
-        // on the node's internal offline queue.
-        if (
-          !_this.options.enableOfflineQueue &&
-          redis.status !== "ready"
-        ) {
-          command.reject(
-            new Error(
-              "Cluster isn't ready and enableOfflineQueue options is false"
-            )
-          );
-        } else {
-          redis.sendCommand(command, stream);
-        }
-      } else if (_this.options.enableOfflineQueue) {
+      if (!redis && _this.options.enableOfflineQueue) {
         _this.offlineQueue.push({
           command: command,
           stream: stream,
           node: node,
         });
-      } else {
+        return;
+      }
+
+      if (!redis || (!_this.options.enableOfflineQueue && redis.status !== "ready")) {
         command.reject(
           new Error(
             "Cluster isn't ready and enableOfflineQueue options is false"
           )
         );
+        return;
       }
+
+      redis.sendCommand(command, stream);
     }
     return command.promise;
   }

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -680,12 +680,17 @@ class Cluster extends Commander {
         return;
       }
 
-      if (!redis || (!_this.options.enableOfflineQueue && redis.status !== "ready" && redis.status !== "wait")) {
+      if (!redis) {
         command.reject(
           new Error(
             "Cluster isn't ready and enableOfflineQueue options is false"
           )
         );
+        return;
+      }
+
+      if (!_this.options.enableOfflineQueue && redis.status !== "ready" && redis.status !== "wait") {
+        command.reject(new Error(CONNECTION_CLOSED_ERROR_MSG));
         return;
       }
 

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -683,7 +683,7 @@ class Cluster extends Commander {
         ) {
           command.reject(
             new Error(
-              "Cluster node is not ready and enableOfflineQueue options is false"
+              "Cluster isn't ready and enableOfflineQueue options is false"
             )
           );
         } else {

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -680,7 +680,7 @@ class Cluster extends Commander {
         return;
       }
 
-      if (!redis || (!_this.options.enableOfflineQueue && redis.status !== "ready")) {
+      if (!redis || (!_this.options.enableOfflineQueue && redis.status === "reconnecting")) {
         command.reject(
           new Error(
             "Cluster isn't ready and enableOfflineQueue options is false"

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -151,7 +151,7 @@ class Cluster extends Commander {
     }
 
     this.connectionPool = new ConnectionPool({
-      ...this.options.redisOptions,
+      ...(this.options.redisOptions ?? {}),
       clusterNodeRetryStrategy: this.options.clusterNodeRetryStrategy,
     });
 
@@ -677,9 +677,7 @@ class Cluster extends Commander {
         // on the node's internal offline queue.
         if (
           !_this.options.enableOfflineQueue &&
-          redis.status !== "ready" &&
-          redis.status !== "connect" &&
-          redis.status !== "wait"
+          redis.status !== "ready"
         ) {
           command.reject(
             new Error(

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -666,6 +666,15 @@ class Cluster extends Commander {
                 : _this.connectionPool.getSampleInstance(to)) ||
               _this.connectionPool.getSampleInstance("all");
           }
+          if (
+            redis &&
+            !_this.options.enableOfflineQueue &&
+            redis.status !== "ready" &&
+            redis.status !== "wait"
+          ) {
+            command.reject(new Error(CONNECTION_CLOSED_ERROR_MSG));
+            return;
+          }
         }
         if (node && !node.redis) {
           node.redis = redis;
@@ -686,11 +695,6 @@ class Cluster extends Commander {
             "Cluster isn't ready and enableOfflineQueue options is false"
           )
         );
-        return;
-      }
-
-      if (!_this.options.enableOfflineQueue && redis.status !== "ready" && redis.status !== "wait") {
-        command.reject(new Error(CONNECTION_CLOSED_ERROR_MSG));
         return;
       }
 

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -4,10 +4,14 @@ import { SentinelConnectionOptions } from "../connectors/SentinelConnector";
 import { StandaloneConnectionOptions } from "../connectors/StandaloneConnector";
 
 export type ReconnectOnError = (err: Error) => boolean | 1 | 2;
+export type RetryStrategy =
+  | ((times: number) => number | void | null)
+  | null
+  | undefined;
 
 export interface CommonRedisOptions extends CommanderOptions {
   Connector?: ConnectorConstructor | undefined;
-  retryStrategy?: ((times: number) => number | void | null) | undefined;
+  retryStrategy?: RetryStrategy;
 
   /**
    * If a command does not return a reply within a set number of milliseconds,

--- a/test/functional/cluster/node_reconnect.ts
+++ b/test/functional/cluster/node_reconnect.ts
@@ -63,27 +63,36 @@ describe("cluster:node_reconnect", () => {
     });
   });
 
-  it("rejects commands immediately when node is reconnecting and enableOfflineQueue is false", (done) => {
+  it("retries command on another node when target node is reconnecting and enableOfflineQueue is false", (done) => {
     const node1 = new MockServer(30001, argvHandler);
-    new MockServer(30002, argvHandler);
+    new MockServer(30002, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") return slotTable;
+      if (argv[0] === "get" && argv[1] === "foo") return "bar";
+    });
     new MockServer(30003, argvHandler);
 
     const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
       clusterNodeRetryStrategy: () => 10,
-      clusterRetryStrategy: null,
       enableOfflineQueue: false,
     });
 
-    cluster.get("foo", () => {
-      node1.disconnect(() => {
-        // Node is now reconnecting; next command should be rejected immediately
-        cluster.get("foo", (err) => {
-          expect(err).to.exist;
-          expect(err.message).to.eql(
-            "Cluster isn't ready and enableOfflineQueue options is false"
-          );
-          cluster.disconnect();
-          done();
+    cluster.once("ready", () => {
+      const node1Redis = cluster
+        .nodes("master")
+        .find((n) => n.options.port === 30001);
+
+      cluster.get("foo", () => {
+        node1.disconnect();
+
+        // Wait for the node to enter "reconnecting" state, then verify
+        // the command is retried on another node (not permanently rejected)
+        node1Redis.once("reconnecting", () => {
+          cluster.get("foo", (err, result) => {
+            expect(err).to.be.null;
+            expect(result).to.eql("bar");
+            cluster.disconnect();
+            done();
+          });
         });
       });
     });

--- a/test/functional/cluster/node_reconnect.ts
+++ b/test/functional/cluster/node_reconnect.ts
@@ -78,7 +78,9 @@ describe("cluster:node_reconnect", () => {
         // Node is now reconnecting; next command should be rejected immediately
         cluster.get("foo", (err) => {
           expect(err).to.exist;
-          expect(err.message).to.match(/enableOfflineQueue options is false/);
+          expect(err.message).to.eql(
+            "Cluster isn't ready and enableOfflineQueue options is false"
+          );
           cluster.disconnect();
           done();
         });

--- a/test/functional/cluster/node_reconnect.ts
+++ b/test/functional/cluster/node_reconnect.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import * as calculateSlot from "cluster-key-slot";
 import MockServer from "../../helpers/mock_server";
 import { Cluster } from "../../../lib";
 
@@ -84,6 +85,41 @@ describe("cluster:node_reconnect", () => {
           cluster.disconnect();
           done();
         });
+      });
+    });
+  });
+
+  it("MOVED redirect to an unknown node succeeds with enableOfflineQueue: false", (done) => {
+    new MockServer(30001, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return [[0, 16383, ["127.0.0.1", 30001]]];
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        return new Error("MOVED " + calculateSlot("foo") + " 127.0.0.1:30002");
+      }
+    });
+    new MockServer(30002, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return [[0, 16383, ["127.0.0.1", 30001]]];
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        return "bar";
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      clusterRetryStrategy: null,
+      enableOfflineQueue: false,
+    });
+
+    // Wait for the cluster to be ready before sending the command,
+    // since enableOfflineQueue: false rejects commands before "ready".
+    cluster.once("ready", () => {
+      cluster.get("foo", (err, result) => {
+        expect(err).to.be.null;
+        expect(result).to.eql("bar");
+        cluster.disconnect();
+        done();
       });
     });
   });

--- a/test/functional/cluster/node_reconnect.ts
+++ b/test/functional/cluster/node_reconnect.ts
@@ -3,7 +3,7 @@ import MockServer from "../../helpers/mock_server";
 import { Cluster } from "../../../lib";
 
 describe("cluster:node_reconnect", () => {
-  // "foo" hashes to slot 9201, which falls in [0, 16381] → node1 (30001)
+  // "foo" hashes to slot 12182, which falls in [0, 16381] → node1 (30001)
   const slotTable = [
     [0, 16381, ["127.0.0.1", 30001], ["127.0.0.1", 30003]],
     [16382, 16383, ["127.0.0.1", 30002]],

--- a/test/functional/cluster/node_reconnect.ts
+++ b/test/functional/cluster/node_reconnect.ts
@@ -25,7 +25,7 @@ describe("cluster:node_reconnect", () => {
       clusterRetryStrategy: null,
     });
 
-    // cluster.get("foo") routes to node1 (slot 9201), ensuring it is connected
+    // cluster.get("foo") routes to node1 (slot 12182), ensuring it is connected
     cluster.get("foo", () => {
       cluster.once("-node", (removedNode) => {
         expect(removedNode.options.port).to.eql(30001);

--- a/test/functional/cluster/node_reconnect.ts
+++ b/test/functional/cluster/node_reconnect.ts
@@ -1,0 +1,111 @@
+import { expect } from "chai";
+import MockServer from "../../helpers/mock_server";
+import { Cluster } from "../../../lib";
+
+describe("cluster:node_reconnect", () => {
+  // "foo" hashes to slot 9201, which falls in [0, 16381] → node1 (30001)
+  const slotTable = [
+    [0, 16381, ["127.0.0.1", 30001], ["127.0.0.1", 30003]],
+    [16382, 16383, ["127.0.0.1", 30002]],
+  ];
+
+  function argvHandler(argv: string[]) {
+    if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+      return slotTable;
+    }
+  }
+
+  it("fires -node when node disconnects and clusterNodeRetryStrategy is null", (done) => {
+    const node1 = new MockServer(30001, argvHandler);
+    new MockServer(30002, argvHandler);
+    new MockServer(30003, argvHandler);
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      clusterNodeRetryStrategy: null,
+      clusterRetryStrategy: null,
+    });
+
+    // cluster.get("foo") routes to node1 (slot 9201), ensuring it is connected
+    cluster.get("foo", () => {
+      cluster.once("-node", (removedNode) => {
+        expect(removedNode.options.port).to.eql(30001);
+        cluster.disconnect();
+        done();
+      });
+      node1.disconnect();
+    });
+  });
+
+  it("keeps node in pool when clusterNodeRetryStrategy is a function", (done) => {
+    const node1 = new MockServer(30001, argvHandler);
+    new MockServer(30002, argvHandler);
+    new MockServer(30003, argvHandler);
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      clusterNodeRetryStrategy: () => 10,
+      clusterRetryStrategy: null,
+    });
+
+    cluster.get("foo", () => {
+      let nodeRemovedFired = false;
+      cluster.once("-node", () => {
+        nodeRemovedFired = true;
+      });
+
+      node1.disconnect(() => {
+        setTimeout(() => {
+          expect(nodeRemovedFired).to.be.false;
+          cluster.disconnect();
+          done();
+        }, 100);
+      });
+    });
+  });
+
+  it("rejects commands immediately when node is reconnecting and enableOfflineQueue is false", (done) => {
+    const node1 = new MockServer(30001, argvHandler);
+    new MockServer(30002, argvHandler);
+    new MockServer(30003, argvHandler);
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      clusterNodeRetryStrategy: () => 10,
+      clusterRetryStrategy: null,
+      enableOfflineQueue: false,
+    });
+
+    cluster.get("foo", () => {
+      node1.disconnect(() => {
+        // Node is now reconnecting; next command should be rejected immediately
+        cluster.get("foo", (err) => {
+          expect(err).to.exist;
+          expect(err.message).to.match(/enableOfflineQueue options is false/);
+          cluster.disconnect();
+          done();
+        });
+      });
+    });
+  });
+
+  it("reconnects to a node after it restarts", (done) => {
+    const node1 = new MockServer(30001, argvHandler);
+    new MockServer(30002, argvHandler);
+    new MockServer(30003, argvHandler);
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      clusterNodeRetryStrategy: () => 10,
+      clusterRetryStrategy: null,
+    });
+
+    cluster.get("foo", () => {
+      node1.disconnect(() => {
+        setTimeout(() => {
+          node1.connect();
+          node1.once("connect", () => {
+            cluster.disconnect();
+            done();
+          });
+        }, 30);
+      });
+    });
+  });
+});

--- a/test/functional/cluster/node_reconnect.ts
+++ b/test/functional/cluster/node_reconnect.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import * as calculateSlot from "cluster-key-slot";
+import * as sinon from "sinon";
 import MockServer from "../../helpers/mock_server";
 import { Cluster } from "../../../lib";
 
@@ -130,6 +131,33 @@ describe("cluster:node_reconnect", () => {
         cluster.disconnect();
         done();
       });
+    });
+  });
+
+  it("does not reject subscriber commands when subscriber is not ready and enableOfflineQueue is false", (done: (err?: unknown) => void) => {
+    new MockServer(30001, argvHandler);
+    new MockServer(30002, argvHandler);
+    new MockServer(30003, argvHandler);
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }], {
+      clusterRetryStrategy: null,
+      enableOfflineQueue: false,
+    });
+
+    cluster.once("ready", () => {
+      const sendCommand = sinon.spy((command) => {
+        command.resolve(Buffer.from("OK"));
+      });
+      sinon
+        .stub(cluster["subscriber"], "getInstance")
+        .returns({ status: "connecting", sendCommand } as never);
+
+      cluster.subscribe("channel").then(() => {
+        expect(sendCommand.called).to.be.true;
+        sinon.restore();
+        cluster.disconnect();
+        done();
+      }, done);
     });
   });
 

--- a/test/unit/clusters/ConnectionPool.ts
+++ b/test/unit/clusters/ConnectionPool.ts
@@ -24,6 +24,21 @@ describe("ConnectionPool", () => {
     });
   });
 
+  describe("nodeError event", () => {
+    it("emits nodeError on the pool when a node emits an error", (done) => {
+      const pool = new ConnectionPool({});
+      const redis = pool.findOrCreate({ host: "127.0.0.1", port: 30001 });
+
+      pool.on("nodeError", (error, key) => {
+        expect(error.message).to.eql("test error");
+        expect(key).to.eql("127.0.0.1:30001");
+        done();
+      });
+
+      redis.emit("error", new Error("test error"));
+    });
+  });
+
   describe("#reset", () => {
     it("prefers to master if there are two same node for a slot", () => {
       const pool = new ConnectionPool({});

--- a/test/unit/clusters/ConnectionPool.ts
+++ b/test/unit/clusters/ConnectionPool.ts
@@ -3,6 +3,27 @@ import { expect } from "chai";
 import ConnectionPool from "../../../lib/cluster/ConnectionPool";
 
 describe("ConnectionPool", () => {
+  describe("clusterNodeRetryStrategy", () => {
+    it("sets retryStrategy to null when clusterNodeRetryStrategy is not provided", () => {
+      const pool = new ConnectionPool({});
+      const redis = pool.findOrCreate({ host: "127.0.0.1", port: 30001 });
+      expect(redis.options.retryStrategy).to.be.null;
+    });
+
+    it("sets retryStrategy to null when clusterNodeRetryStrategy is null", () => {
+      const pool = new ConnectionPool({ clusterNodeRetryStrategy: null });
+      const redis = pool.findOrCreate({ host: "127.0.0.1", port: 30001 });
+      expect(redis.options.retryStrategy).to.be.null;
+    });
+
+    it("uses clusterNodeRetryStrategy as retryStrategy when it is a function", () => {
+      const strategy = (times: number) => times * 100;
+      const pool = new ConnectionPool({ clusterNodeRetryStrategy: strategy });
+      const redis = pool.findOrCreate({ host: "127.0.0.1", port: 30001 });
+      expect(redis.options.retryStrategy).to.equal(strategy);
+    });
+  });
+
   describe("#reset", () => {
     it("prefers to master if there are two same node for a slot", () => {
       const pool = new ConnectionPool({});

--- a/test/unit/clusters/ConnectionPool.ts
+++ b/test/unit/clusters/ConnectionPool.ts
@@ -11,14 +11,14 @@ describe("ConnectionPool", () => {
     });
 
     it("sets retryStrategy to null when clusterNodeRetryStrategy is null", () => {
-      const pool = new ConnectionPool({ clusterNodeRetryStrategy: null });
+      const pool = new ConnectionPool({}, null);
       const redis = pool.findOrCreate({ host: "127.0.0.1", port: 30001 });
       expect(redis.options.retryStrategy).to.be.null;
     });
 
     it("uses clusterNodeRetryStrategy as retryStrategy when it is a function", () => {
       const strategy = (times: number) => times * 100;
-      const pool = new ConnectionPool({ clusterNodeRetryStrategy: strategy });
+      const pool = new ConnectionPool({}, strategy);
       const redis = pool.findOrCreate({ host: "127.0.0.1", port: 30001 });
       expect(redis.options.retryStrategy).to.equal(strategy);
     });


### PR DESCRIPTION


Closes:
https://github.com/redis/ioredis/issues/587
https://github.com/redis/ioredis/issues/1732

## Problem

When a cluster node (typically a replica) restarts without any slot changes,
ioredis permanently removes it from the connection pool and never reconnects.
This happens because `retryStrategy` is hardcoded to `null` for every node in
the pool — by design, to force MOVED-based topology refresh. However, MOVED
errors are never triggered when slots don't move, so the node is lost forever.

This causes two downstream issues:
- `scaleReads: "slave"` silently drops replicas, degrading read throughput
- With `enableOfflineQueue: false`, commands fail with
  `"Cluster isn't ready and enableOfflineQueue options is false"` because
  `getInstanceByKey()` returns `undefined` for the removed node

Common in Kubernetes environments during rolling restarts.

## Changes

**`clusterNodeRetryStrategy`** — new option (mirrors `clusterRetryStrategy`)
that controls the `retryStrategy` for individual cluster node connections.
When set, a node that loses its connection stays in the pool and retries
instead of being permanently removed. If the node is later removed from the
cluster topology via `reset()` (triggered by MOVED or `slotsRefreshInterval`),
it is still cleaned up correctly.

```ts
new Cluster(nodes, {
  clusterNodeRetryStrategy: (times) => Math.min(100 + times * 2, 2000),
})
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster command routing and connection lifecycle for all cluster users; default behavior stays the same unless `clusterNodeRetryStrategy` is set, but the `sendCommand` refactor affects failover and offline-queue edge cases.
> 
> **Overview**
> Adds **`clusterNodeRetryStrategy`**, a per-node `retryStrategy` for cluster member connections (default **`null`**, preserving MOVED-driven topology refresh). When set, restarted replicas can stay in the pool and reconnect instead of being dropped until slots move.
> 
> **`ConnectionPool`** wires that option into each node `Redis` instance; **`Cluster#sendCommand`** is refactored so commands with **`enableOfflineQueue: false`** fail fast with a closed-connection error when the chosen node isn’t `ready`/`wait` (enabling failover retries), while subscriber commands can still run when the subscriber is only `connecting`.
> 
> Docs, shared **`RetryStrategy`** typing, **`.gitignore`** for `.history`, and functional/unit tests cover reconnect, MOVED to new nodes, and subscribe behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0ecafe79a651cc713922bfee591717d6daee26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->