### PR TITLE
chore(ci): bump Redis test image to 8.8-m02

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "unstable-24425681442-debian"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8-m02"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "unstable-23321515778-debian"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "unstable-24425681442-debian"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-unstable-24425681442-debian}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-8.8-m02}
 
 services:
   single:

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-8.4-RC1-pre.2}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-unstable-24425681442-debian}
 
 services:
   single:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk CI-only change that updates the Redis test image/version used in workflows and local docker-compose; primary risk is test compatibility/behavior changes due to the newer Redis build.
> 
> **Overview**
> CI and test infrastructure now run against Redis `8.8-m02` by **replacing** the prior unstable/older Redis entry in the GitHub Actions matrix (`.github/workflows/test_with_cov.yml`) and **updating** the default `REDIS_VERSION` for `redislabs/client-libs-test` in `test/docker-compose.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 834bfc535968383e7bf2bb64137b9f2235772dfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->