### PR TITLE
test: gate functional tests by redis version

### DIFF
--- a/test/functional/commands/hgetdel.ts
+++ b/test/functional/commands/hgetdel.ts
@@ -1,9 +1,14 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
-// TODO unskip once we have a mechanism to run only on specific versions
-// TODO as these tests can only work against 8.0 or higher
-describe.skip("hgetdel", () => {
+describe("hgetdel", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.0")) {
+      this.skip();
+    }
+  });
+
   it("should return values and null for missing field", async () => {
     const redis = new Redis();
     const key = `test_hgetdel_${Date.now()}`;

--- a/test/functional/commands/hgetex.ts
+++ b/test/functional/commands/hgetex.ts
@@ -1,9 +1,14 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
-// TODO unskip once we have a mechanism to run only on specific versions
-// TODO as these tests can only work against 8.0 or higher
-describe.skip("hgetex", () => {
+describe("hgetex", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.0")) {
+      this.skip();
+    }
+  });
+
   it("should return values and null for missing field", async () => {
     const redis = new Redis();
     const key = `test_hgetex_${Date.now()}`;

--- a/test/functional/commands/hsetex.ts
+++ b/test/functional/commands/hsetex.ts
@@ -1,9 +1,14 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
-// TODO unskip once we have a mechanism to run only on specific versions
-// TODO as these tests can only work against 8.0 or higher
-describe.skip("hsetex", () => {
+describe("hsetex", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.0")) {
+      this.skip();
+    }
+  });
+
   const hashKey = "test_hsetex_key";
 
   it("should return 1 when fields are set", async () => {

--- a/test/functional/commands/xdelex.ts
+++ b/test/functional/commands/xdelex.ts
@@ -1,5 +1,6 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
 const STREAM_DELETION_REPLY_CODES = {
   NOT_FOUND: -1,
@@ -7,9 +8,13 @@ const STREAM_DELETION_REPLY_CODES = {
   DANGLING_REFS: 2,
 } as const;
 
-// TODO unskip once we have a mechanism to run only on specific versions
-// TODO as these tests can only work against 8.2 or higher
-describe.skip("xdelex", () => {
+describe("xdelex", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.2")) {
+      this.skip();
+    }
+  });
+
   let redis: Redis;
 
   beforeEach(() => {

--- a/test/functional/commands/xtrim.ts
+++ b/test/functional/commands/xtrim.ts
@@ -1,5 +1,6 @@
 import Redis from "../../../lib/Redis";
 import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
 
 describe("xtrim", () => {
   let redis: Redis;
@@ -32,23 +33,32 @@ describe("xtrim", () => {
     expect(res).to.be.a("number");
   });
 
-  // TODO add a mechanism to skip tests based on server version
-  it.skip("xtrim with policy (DELREF) returns a number when supported", async function (this: any) {
-    const res = await redis.xtrim("{tag}key", "MAXLEN", 0, "DELREF");
-    expect(res).to.be.a("number");
-  });
+  describe("xtrim with policy", function () {
+    before(async function () {
+      if (await isRedisVersionLowerThan("8.2")) {
+        this.skip();
+      }
+    });
 
-  // TODO add a mechanism to skip tests based on server version
-  it.skip("xtrim with all options (MINID ~ LIMIT KEEPREF) returns a number when supported", async function (this: any) {
-    const res = await redis.xtrim(
-      "{tag}key",
-      "MINID",
-      "~",
-      0,
-      "LIMIT",
-      10,
-      "KEEPREF"
+    it("xtrim with policy (DELREF) returns a number when supported", async () => {
+      const res = await redis.xtrim("{tag}key", "MAXLEN", 0, "DELREF");
+      expect(res).to.be.a("number");
+    });
+
+    it(
+      "xtrim with all options (MINID ~ LIMIT KEEPREF) returns a number when supported",
+      async () => {
+        const res = await redis.xtrim(
+          "{tag}key",
+          "MINID",
+          "~",
+          0,
+          "LIMIT",
+          10,
+          "KEEPREF"
+        );
+        expect(res).to.be.a("number");
+      }
     );
-    expect(res).to.be.a("number");
   });
 });

--- a/test/helpers/util.ts
+++ b/test/helpers/util.ts
@@ -1,8 +1,50 @@
+import Redis from "../../lib/Redis";
+
 export function waitForMonitorReady() {
   // It takes a while for the monitor to be ready.
   // This is a hack to wait for it because the monitor command
   // does not have a response
   return new Promise((resolve) => setTimeout(resolve, 150));
+}
+
+function parseRedisVersion(version: string): number[] {
+  return version.match(/\d+/g)?.slice(0, 2).map(Number) ?? [0, 0];
+}
+
+function compareRedisVersions(left: string, right: string): number {
+  const leftParts = parseRedisVersion(left);
+  const rightParts = parseRedisVersion(right);
+  const length = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < length; index++) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+
+  return 0;
+}
+
+export async function isRedisVersionLowerThan(
+  minimumVersion: string
+): Promise<boolean> {
+  const redis = new Redis();
+
+  try {
+    const info = await redis.info("server");
+    const version = info.match(/^redis_version:(.+)$/m)?.[1]?.trim();
+
+    if (!version) {
+      throw new Error(
+        "Could not determine redis_version from INFO server response"
+      );
+    }
+
+    return compareRedisVersions(version, minimumVersion) < 0;
+  } finally {
+    redis.disconnect();
+  }
 }
 
 export async function getCommandsFromMonitor(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only changes; main risk is flakiness or false skipping if Redis version parsing/INFO output differs across environments.
> 
> **Overview**
> Functional tests for Redis 8.x-only commands are now conditionally executed instead of permanently skipped.
> 
> This introduces `isRedisVersionLowerThan()` in `test/helpers/util.ts` (parses `INFO server`’s `redis_version`) and uses it to gate `hgetdel`, `hgetex`, `hsetex` (>= 8.0) and `xdelex`/`xtrim` policy coverage (>= 8.2) via `before` hooks that call `this.skip()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8df92794527472ba60326871f72201cf4665aa25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->