### PR TITLE
docs: fix nullable return types in generated typedoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "sinon": "^13.0.1",
         "ts-node": "^10.4.0",
         "tsd": "^0.19.1",
-        "typedoc": "^0.22.18",
+        "typedoc": "^0.25.13",
         "typescript": "^4.6.3",
         "uuid": "^9.0.0"
       },
@@ -1568,6 +1568,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.3.tgz",
+      "integrity": "sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -3926,10 +3933,11 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-      "dev": true
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -4224,10 +4232,11 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.8.tgz",
-      "integrity": "sha512-GRuocLXG+3iqLmZYW+8JKDrNFTfBzQ7Kbdl70nhjQRUg2H4hzda5Aq0ZWSQM68tAfxiQV03P8PyplXwuVKvfEA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8485,14 +8494,16 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "node_modules/signal-exit": {
@@ -9142,65 +9153,51 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.10.1"
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.10.0"
+        "node": ">= 16"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/typedoc/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typedoc/node_modules/minimatch": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/typescript": {
@@ -9306,13 +9303,15 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
       "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
-      "dev": true
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -10712,6 +10711,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-sequence-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.3.tgz",
+      "integrity": "sha512-+fksAx9eG3Ab6LDnLs3ZqZa8KVJ/jYnX+D4Qe1azX+LFGFAXqynCQLOdLpNYN/l9e7l6hMWwZbrnctqr6eSQSw==",
       "dev": true
     },
     "ansi-styles": {
@@ -12482,9 +12487,9 @@
       "dev": true
     },
     "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true
     },
     "jsonfile": {
@@ -12726,9 +12731,9 @@
       "dev": true
     },
     "marked": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.8.tgz",
-      "integrity": "sha512-GRuocLXG+3iqLmZYW+8JKDrNFTfBzQ7Kbdl70nhjQRUg2H4hzda5Aq0ZWSQM68tAfxiQV03P8PyplXwuVKvfEA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true
     },
     "marked-terminal": {
@@ -15751,14 +15756,15 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.7.tgz",
+      "integrity": "sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==",
       "dev": true,
       "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "signal-exit": {
@@ -16264,47 +16270,33 @@
       }
     },
     "typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.25.13.tgz",
+      "integrity": "sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==",
       "dev": true,
       "requires": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.10.1"
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.3",
+        "shiki": "^0.14.7"
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+          "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0"
           }
         },
-        "glob": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
-          }
-        },
         "minimatch": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
-          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "version": "9.0.9",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+          "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^2.0.1"
+            "brace-expansion": "^2.0.2"
           }
         }
       }
@@ -16393,9 +16385,9 @@
       "dev": true
     },
     "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
       "dev": true
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:cluster": "TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha --no-experimental-strip-types \"test/cluster/**/*.ts\"",
     "test": "npm run test:js && npm run test:tsd",
     "lint": "eslint --ext .js,.ts ./lib",
-    "docs": "npx typedoc --logLevel Error --excludeExternals --excludeProtected --excludePrivate --readme none lib/index.ts",
+    "docs": "npx typedoc --tsconfig ./tsconfig.docs.json --skipErrorChecking --logLevel Error --excludeExternals --excludeProtected --excludePrivate --readme none lib/index.ts",
     "format": "prettier --write \"{,!(node_modules)/**/}*.{js,ts}\"",
     "format-check": "prettier --check \"{,!(node_modules)/**/}*.{js,ts}\"",
     "build": "rm -rf built && tsc",
@@ -81,7 +81,7 @@
     "sinon": "^13.0.1",
     "ts-node": "^10.4.0",
     "tsd": "^0.19.1",
-    "typedoc": "^0.22.18",
+    "typedoc": "^0.25.13",
     "typescript": "^4.6.3",
     "uuid": "^9.0.0"
   },

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
## Summary

The generated TypeDoc documentation strips `| null` from every command that can return `null`. For example, `redis.get()` is rendered as `Promise<string>` even though its declared signature is `Promise<string | null>`. The same issue affects 70+ commands across `Redis`, `Cluster`, and `ChainableCommander` (e.g. `get`, `getex`, `getdel`, `mget`, `hmget`, `zscore`, `zrank`, `bzpopmin`, `blpop`, `lpop`, `spop`, `geopos`, ...).

## Root cause

`strictNullChecks` is off in `tsconfig.json`. With it disabled, TypeScript treats `null` as assignable to every type, so `string | null` collapses to `string` during type resolution. TypeDoc reads the collapsed type from the compiler and renders it as `Promise<string>`.

## Fix

Generate docs with `strictNullChecks` enabled, without affecting the main build:

1. Add `tsconfig.docs.json` that extends `tsconfig.json` and sets `strictNullChecks: true`.
2. Update the `docs` script to pass `--tsconfig ./tsconfig.docs.json` and `--skipErrorChecking` (existing source has pre-existing `strictNullChecks` violations that are unrelated to docs generation).
3. Bump `typedoc` from `^0.22.18` to `^0.25.13`. `0.25` is the newest TypeDoc line that still supports TypeScript `4.6.x`, and it's the minimum version providing `--skipErrorChecking`.

No runtime code, build output, or public type declarations are changed.

## Before / after

`redis.get(key)` signature in `docs/classes/Redis.html`:

- **Before**: `get(key, callback?): Promise<string>`
- **After**:  `get(key, callback?): Promise<null | string>`

The same correction applies to all nullable-return commands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it upgrades `typedoc` and its dependency chain and changes the docs build to use a separate tsconfig, which may impact contributors/CI environments (notably Node version requirements) but does not affect runtime code.
> 
> **Overview**
> Fixes TypeDoc output for nullable return types by generating docs with a dedicated `tsconfig.docs.json` that enables `strictNullChecks`.
> 
> Updates the `docs` script to use that tsconfig and `--skipErrorChecking`, and bumps `typedoc` to `^0.25.13` (with corresponding lockfile dependency updates such as `shiki`/`marked`/`minimatch`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2104c1e3fb74b14511087310bf572f4e8efc4229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->