### PR TITLE
fix: add SNI servername for TLS connection from host field

### DIFF
--- a/lib/connectors/StandaloneConnector.ts
+++ b/lib/connectors/StandaloneConnector.ts
@@ -1,4 +1,4 @@
-import { createConnection, IpcNetConnectOpts, TcpNetConnectOpts } from "net";
+import { createConnection, IpcNetConnectOpts, TcpNetConnectOpts, isIP } from "net";
 import { connect as createTLSConnection, ConnectionOptions } from "tls";
 import { NetStream } from "../types";
 import { CONNECTION_CLOSED_ERROR_MSG } from "../utils";
@@ -42,7 +42,10 @@ export default class StandaloneConnector extends AbstractConnector {
     if (options.tls) {
       Object.assign(connectionOptions, options.tls);
       if ("host" in connectionOptions && !("servername" in connectionOptions)) {
-        (connectionOptions as any).servername = (connectionOptions as TcpOptions).host;
+        const host = (connectionOptions as TcpOptions).host;
+        if (host && !isIP(host)) {
+          (connectionOptions as any).servername = host;
+        }
       }
     }
 

--- a/lib/connectors/StandaloneConnector.ts
+++ b/lib/connectors/StandaloneConnector.ts
@@ -41,6 +41,9 @@ export default class StandaloneConnector extends AbstractConnector {
 
     if (options.tls) {
       Object.assign(connectionOptions, options.tls);
+      if ("host" in connectionOptions && !("servername" in connectionOptions)) {
+        (connectionOptions as any).servername = (connectionOptions as TcpOptions).host;
+      }
     }
 
     // TODO:

--- a/test/unit/connectors/connector.ts
+++ b/test/unit/connectors/connector.ts
@@ -44,5 +44,40 @@ describe("StandaloneConnector", () => {
       });
       connector.disconnect();
     });
+
+    it("uses host as tls servername when not explicitly provided", async () => {
+      const spy = sinon.spy(tls, "connect");
+      const connector = new StandaloneConnector({
+        host: "cache.internal",
+        port: 6379,
+        tls: { rejectUnauthorized: false },
+      });
+      await connector.connect(() => {});
+      expect(spy.calledOnce).to.eql(true);
+      expect(spy.firstCall.args[0]).to.eql({
+        host: "cache.internal",
+        port: 6379,
+        rejectUnauthorized: false,
+        servername: "cache.internal",
+      });
+      connector.disconnect();
+    });
+
+    it("does not set tls servername from host when host is an IP", async () => {
+      const spy = sinon.spy(tls, "connect");
+      const connector = new StandaloneConnector({
+        host: "127.0.0.1",
+        port: 6379,
+        tls: { rejectUnauthorized: false },
+      });
+      await connector.connect(() => {});
+      expect(spy.calledOnce).to.eql(true);
+      expect(spy.firstCall.args[0]).to.eql({
+        host: "127.0.0.1",
+        port: 6379,
+        rejectUnauthorized: false,
+      });
+      connector.disconnect();
+    });
   });
 });


### PR DESCRIPTION
 If  `servername` field is not explicitly set then use `host` field for SNI identification. 
This allows TLS terminating proxies to determine which cert to serve.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to connection option construction plus targeted tests; behavior only changes when TLS is used without an explicit `servername`.
> 
> **Overview**
> `StandaloneConnector` now auto-populates TLS `servername` from the configured `host` when TLS is enabled and `servername` isn’t explicitly provided, while *skipping IP hosts* to avoid invalid SNI.
> 
> Unit tests were extended to cover the new SNI defaulting behavior for hostname vs IP `host` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61db0c1a89936d35720c2d427c2e05fed1f696b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->