### PR TITLE
refactor(utils): inline defaults and isArguments helpers

### DIFF
--- a/lib/utils/defaults.ts
+++ b/lib/utils/defaults.ts
@@ -1,0 +1,158 @@
+/*
+ * Derived from `src/compat/object/defaults.ts` in es-toolkit
+ * (https://github.com/toss/es-toolkit).
+ *
+ * Copyright (c) 2024 Viva Republica, Inc
+ * Copyright OpenJS Foundation and other contributors
+ *
+ * Parts of the compatibility layer in `es-toolkit/compat` are derived from
+ * Lodash (https://github.com/lodash/lodash) by the OpenJS Foundation
+ * (https://openjsf.org/) and Underscore.js by Jeremy Ashkenas, DocumentCloud
+ * and Investigative Reporters & Editors (http://underscorejs.org/).
+ *
+ * This file has been modified from the original source to create a standalone
+ * adaptation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const IS_UNSIGNED_INTEGER = /^(?:0|[1-9]\d*)$/;
+
+type DefaultSource = object | null | undefined;
+
+function isNil(value: unknown): value is null | undefined {
+  return value == null;
+}
+
+function eq(value: unknown, other: unknown): boolean {
+  return value === other || (Number.isNaN(value) && Number.isNaN(other));
+}
+
+function isLength(value?: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isArrayLike(value?: unknown): value is { length: number } {
+  return (
+    value != null &&
+    typeof value !== "function" &&
+    isLength((value as ArrayLike<unknown>).length)
+  );
+}
+
+function isObject(value?: unknown): value is object {
+  return (
+    value !== null && (typeof value === "object" || typeof value === "function")
+  );
+}
+
+function isIndex(
+  value: PropertyKey,
+  length = Number.MAX_SAFE_INTEGER,
+): boolean {
+  switch (typeof value) {
+    case "number":
+      return Number.isInteger(value) && value >= 0 && value < length;
+    case "symbol":
+      return false;
+    case "string":
+      return IS_UNSIGNED_INTEGER.test(value);
+  }
+}
+
+function isIterateeCall(
+  value: unknown,
+  index: unknown,
+  object: unknown,
+): boolean {
+  if (!isObject(object)) {
+    return false;
+  }
+
+  if (
+    (typeof index === "number" &&
+      isArrayLike(object) &&
+      isIndex(index) &&
+      index < object.length) ||
+    (typeof index === "string" && index in object)
+  ) {
+    return eq((object as any)[index], value);
+  }
+
+  return false;
+}
+
+export function defaults<T, S>(object: T, source: S): NonNullable<S & T>;
+export function defaults<T, S1, S2>(
+  object: T,
+  source1: S1,
+  source2: S2,
+): NonNullable<S2 & S1 & T>;
+export function defaults<T, S1, S2, S3>(
+  object: T,
+  source1: S1,
+  source2: S2,
+  source3: S3,
+): NonNullable<S3 & S2 & S1 & T>;
+export function defaults<T, S1, S2, S3, S4>(
+  object: T,
+  source1: S1,
+  source2: S2,
+  source3: S3,
+  source4: S4,
+): NonNullable<S4 & S3 & S2 & S1 & T>;
+export function defaults<T>(object: T): NonNullable<T>;
+export function defaults(object: any, ...sources: any[]): any;
+export function defaults<T extends object, S extends object>(
+  object: T,
+  ...sources: DefaultSource[]
+): object {
+  object = Object(object);
+  const objectProto = Object.prototype;
+
+  let length = sources.length;
+  const guard = length > 2 ? sources[2] : undefined;
+  if (guard && isIterateeCall(sources[0], sources[1], guard)) {
+    length = 1;
+  }
+
+  for (let i = 0; i < length; i++) {
+    if (isNil(sources[i])) {
+      continue;
+    }
+
+    const source = sources[i] as Record<string, unknown>;
+    const keys = Object.keys(source);
+
+    for (let j = 0; j < keys.length; j++) {
+      const key = keys[j];
+      const value = (object as any)[key];
+
+      if (
+        value === undefined ||
+        (!objectProto.hasOwnProperty.call(object, key) &&
+          eq(value, objectProto[key as keyof typeof objectProto]))
+      ) {
+        (object as any)[key] = source[key];
+      }
+    }
+  }
+
+  return object;
+}

--- a/lib/utils/defaults.ts
+++ b/lib/utils/defaults.ts
@@ -138,10 +138,8 @@ export function defaults<T extends object, S extends object>(
     }
 
     const source = sources[i] as Record<string, unknown>;
-    const keys = Object.keys(source);
 
-    for (let j = 0; j < keys.length; j++) {
-      const key = keys[j];
+    for (const key in source) {
       const value = (object as any)[key];
 
       if (

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,6 +1,6 @@
 import { promises as fsPromises } from "fs";
 import { resolve } from "path";
-import { defaults, noop } from "./lodash";
+import { defaults, isArguments, noop } from "./lodash";
 import { Callback } from "../types";
 import Debug from "./debug";
 
@@ -399,4 +399,4 @@ export async function getPackageMeta() {
   }
 }
 
-export { Debug, defaults, noop };
+export { Debug, defaults, isArguments, noop };

--- a/lib/utils/isArguments.ts
+++ b/lib/utils/isArguments.ts
@@ -1,0 +1,49 @@
+/*
+ * Derived from `src/compat/predicate/isArguments.ts` in es-toolkit
+ * (https://github.com/toss/es-toolkit).
+ *
+ * Copyright (c) 2024 Viva Republica, Inc
+ * Copyright OpenJS Foundation and other contributors
+ *
+ * Parts of the compatibility layer in `es-toolkit/compat` are derived from
+ * Lodash (https://github.com/lodash/lodash) by the OpenJS Foundation
+ * (https://openjsf.org/) and Underscore.js by Jeremy Ashkenas, DocumentCloud
+ * and Investigative Reporters & Editors (http://underscorejs.org/).
+ *
+ * This file has been modified from the original source to create a standalone
+ * adaptation.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+function getTag(value: unknown) {
+  if (value == null) {
+    return value === undefined ? "[object Undefined]" : "[object Null]";
+  }
+
+  return Object.prototype.toString.call(value);
+}
+
+export function isArguments(value?: unknown): value is IArguments {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    getTag(value) === "[object Arguments]"
+  );
+}

--- a/lib/utils/lodash.ts
+++ b/lib/utils/lodash.ts
@@ -1,6 +1,4 @@
-import defaults = require("lodash.defaults");
-import isArguments = require("lodash.isarguments");
-
 export function noop() {}
 
-export { defaults, isArguments };
+export * from "./defaults";
+export * from "./isArguments";

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,6 @@
         "cluster-key-slot": "1.1.1",
         "debug": "4.4.3",
         "denque": "2.1.0",
-        "lodash.defaults": "4.2.0",
-        "lodash.isarguments": "3.1.0",
         "redis-errors": "1.2.0",
         "redis-parser": "3.0.0",
         "standard-as-callback": "2.1.0"
@@ -27,8 +25,6 @@
         "@types/chai": "^4.3.0",
         "@types/chai-as-promised": "^7.1.5",
         "@types/debug": "^4.1.5",
-        "@types/lodash.defaults": "^4.2.7",
-        "@types/lodash.isarguments": "^3.1.7",
         "@types/mocha": "^9.1.0",
         "@types/node": "^14.18.12",
         "@types/redis-errors": "^1.2.1",
@@ -1280,30 +1276,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.179",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
-      "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==",
-      "dev": true
-    },
-    "node_modules/@types/lodash.defaults": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.defaults/-/lodash.defaults-4.2.7.tgz",
-      "integrity": "sha512-u7sEFKHVbS66OUD3aThUos6vSjYIddRmVrvKuh16darllgOLD8nbs6XpYkNM6Jwq7D2izws9wt7g04iP0Syg8A==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.isarguments": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isarguments/-/lodash.isarguments-3.1.7.tgz",
-      "integrity": "sha512-LmK49uKPqv0c//PA9F1yea9D+cRrYz8GeKwX/Dm1ttreBpq7gD6iebbuMIx2JeSzyVXL/7qW6M6myVB6rZgoqQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -4119,6 +4091,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
@@ -4149,6 +4122,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.ismatch": {
@@ -10720,30 +10694,6 @@
       "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.179",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.179.tgz",
-      "integrity": "sha512-uwc1x90yCKqGcIOAT6DwOSuxnrAbpkdPsUOZtwrXb4D/6wZs+6qG7QnIawDuZWg0sWpxl+ltIKCaLoMlna678w==",
-      "dev": true
-    },
-    "@types/lodash.defaults": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.defaults/-/lodash.defaults-4.2.7.tgz",
-      "integrity": "sha512-u7sEFKHVbS66OUD3aThUos6vSjYIddRmVrvKuh16darllgOLD8nbs6XpYkNM6Jwq7D2izws9wt7g04iP0Syg8A==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.isarguments": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isarguments/-/lodash.isarguments-3.1.7.tgz",
-      "integrity": "sha512-LmK49uKPqv0c//PA9F1yea9D+cRrYz8GeKwX/Dm1ttreBpq7gD6iebbuMIx2JeSzyVXL/7qW6M6myVB6rZgoqQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -12831,7 +12781,8 @@
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
@@ -12860,7 +12811,8 @@
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "dev": true
     },
     "lodash.ismatch": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "cluster-key-slot": "1.1.1",
     "debug": "4.4.3",
     "denque": "2.1.0",
-    "lodash.defaults": "4.2.0", 
-    "lodash.isarguments": "3.1.0",
     "redis-errors": "1.2.0",
     "redis-parser": "3.0.0",
     "standard-as-callback": "2.1.0"
@@ -61,8 +59,6 @@
     "@types/chai": "^4.3.0",
     "@types/chai-as-promised": "^7.1.5",
     "@types/debug": "^4.1.5",
-    "@types/lodash.defaults": "^4.2.7",
-    "@types/lodash.isarguments": "^3.1.7",
     "@types/mocha": "^9.1.0",
     "@types/node": "^14.18.12",
     "@types/redis-errors": "^1.2.1",

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -118,6 +118,133 @@ describe("utils", () => {
     });
   });
 
+  describe(".defaults", () => {
+    it("should assign source properties if missing on `object`", () => {
+      const actual = utils.defaults({ a: 1 }, { a: 2, b: 2 });
+
+      expect(actual).to.eql({ a: 1, b: 2 });
+    });
+
+    it("should accept multiple sources", () => {
+      const expected = { a: 1, b: 2, c: 3 };
+      let actual = utils.defaults({ a: 1, b: 2 }, { b: 3 }, { c: 3 });
+
+      expect(actual).to.eql(expected);
+
+      actual = utils.defaults({ a: 1, b: 2 }, { b: 3, c: 3 }, { c: 2 });
+      expect(actual).to.eql(expected);
+    });
+
+    it("should not overwrite `null` values", () => {
+      const actual = utils.defaults({ a: null }, { a: 1 });
+
+      expect((actual as any).a).to.eql(null);
+    });
+
+    it("should overwrite `undefined` values", () => {
+      const actual = utils.defaults({ a: undefined }, { a: 1 });
+
+      expect((actual as any).a).to.eql(1);
+    });
+
+    it("should assign `undefined` values", () => {
+      const source = { a: undefined, b: 1 };
+      const actual = utils.defaults({}, source);
+
+      expect(actual).to.eql({ a: undefined, b: 1 });
+    });
+
+    it("should assign properties that shadow those on `Object.prototype`", () => {
+      const objectProto = Object.prototype;
+      const object = {
+        constructor: objectProto.constructor,
+        hasOwnProperty: objectProto.hasOwnProperty,
+        isPrototypeOf: objectProto.isPrototypeOf,
+        propertyIsEnumerable: objectProto.propertyIsEnumerable,
+        toLocaleString: objectProto.toLocaleString,
+        toString: objectProto.toString,
+        valueOf: objectProto.valueOf,
+      };
+
+      const source = {
+        constructor: 1,
+        hasOwnProperty: 2,
+        isPrototypeOf: 3,
+        propertyIsEnumerable: 4,
+        toLocaleString: 5,
+        toString: 6,
+        valueOf: 7,
+      };
+
+      expect(utils.defaults({}, source)).to.eql({ ...source });
+      expect(utils.defaults({}, object, source)).to.eql({ ...object });
+    });
+
+    it("should be used as a iteratee", () => {
+      const array = [{ b: 1 }, { c: 2 }, { d: 3 }];
+      const source = { a: 4 };
+
+      array.forEach((...args: any[]) => utils.defaults(source, ...args));
+
+      expect(source).to.eql({ a: 4, b: 1, c: 2, d: 3 });
+    });
+
+    it("should not throw an error when a source is `undefined`", () => {
+      const source = undefined;
+      const actual = utils.defaults({ a: 1 }, source);
+
+      expect(actual).to.eql({ a: 1 });
+    });
+
+    it("should not throw an error when a source is `null`", () => {
+      const source = null;
+      const actual = utils.defaults({ a: 1 }, source);
+
+      expect(actual).to.eql({ a: 1 });
+    });
+  });
+
+  describe(".isArguments", () => {
+    it("should return `true` for `arguments` objects", () => {
+      const args = (function () {
+        return arguments;
+      })();
+
+      const strictArgs = (function () {
+        "use strict";
+        return arguments;
+      })();
+
+      expect(utils.isArguments(args)).to.eql(true);
+      expect(utils.isArguments(strictArgs)).to.eql(true);
+    });
+
+    it("should return `false` for non `arguments` objects", () => {
+      const symbol = Symbol("test-symbol");
+      const slice = Array.prototype.slice;
+      const falsey = [undefined, null, false, 0, NaN, ""];
+      const stubFalse = () => false;
+      const expected = falsey.map(stubFalse);
+      const actual = falsey.map((value, index) =>
+        index ? utils.isArguments(value) : utils.isArguments()
+      );
+
+      expect(actual).to.eql(expected);
+
+      expect(utils.isArguments([1, 2, 3])).to.eql(false);
+      expect(utils.isArguments(true)).to.eql(false);
+      expect(utils.isArguments(new Date())).to.eql(false);
+      expect(utils.isArguments(new Error())).to.eql(false);
+      expect(utils.isArguments(slice)).to.eql(false);
+      expect(utils.isArguments({ 0: 1, callee: utils.noop, length: 1 })).to.eql(false);
+      expect(utils.isArguments(1)).to.eql(false);
+      expect(utils.isArguments(/x/)).to.eql(false);
+      expect(utils.isArguments("a")).to.eql(false);
+      expect(utils.isArguments(symbol)).to.eql(false);
+    });
+
+  });
+
   describe(".toArg", () => {
     it("should return correctly", () => {
       expect(utils.toArg(null)).to.eql("");

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -154,6 +154,15 @@ describe("utils", () => {
       expect(actual).to.eql({ a: undefined, b: 1 });
     });
 
+    it("should assign inherited enumerable source properties", () => {
+      const source = Object.create({ a: 1 });
+      source.b = 2;
+
+      const actual = utils.defaults({}, source);
+
+      expect(actual).to.eql({ a: 1, b: 2 });
+    });
+
     it("should assign properties that shadow those on `Object.prototype`", () => {
       const objectProto = Object.prototype;
       const object = {


### PR DESCRIPTION
Fixes #2106 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior must stay compatible with lodash.defaults/isarguments across connection parsing, option merging, and auto-pipelining; regressions would affect many code paths, though new unit tests reduce that risk.
> 
> **Overview**
> Replaces the runtime dependencies **`lodash.defaults`** and **`lodash.isarguments`** with **in-repo implementations** under `lib/utils/defaults.ts` and `lib/utils/isArguments.ts` (adapted from es-toolkit compat / Lodash-style behavior, with license headers). **`lib/utils/lodash.ts`** now re-exports those modules instead of `require`ing the npm packages, and **`isArguments`** is also exported from **`lib/utils/index.ts`**.
> 
> **`package.json`** drops the two lodash packages and their `@types/*` devDependencies; **`package-lock.json`** reflects the slimmer tree. **Unit tests** in `test/unit/utils.ts` lock in lodash-like semantics for `defaults` and `isArguments` (multi-source merge, null vs undefined, iteratee guard, `arguments` detection).
> 
> Call sites (`Redis`, `parseURL`, cluster helpers, auto-pipelining) keep importing from `./utils/lodash`—this is primarily a **dependency footprint / vendoring** change, not a new feature API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee0b744aa641cc3e315900f00310c99345af8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->