### PR TITLE
feat: add MSETEX support

### DIFF
--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -216,6 +216,7 @@ module.exports = {
   migrate: "'OK'",
   move: "number",
   mset: "'OK'",
+  msetex: "number",
   msetnx: "number",
   persist: "number",
   pexpire: "number",

--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -1,7 +1,7 @@
 import { isArguments, noop } from "./utils/lodash";
 import * as calculateSlot from "cluster-key-slot";
 import asCallback from "standard-as-callback";
-import { exists, hasFlag } from "@ioredis/commands";
+import { exists, getKeyIndexes, hasFlag } from "@ioredis/commands";
 import { ArgumentType } from "./Command";
 
 export const kExec = Symbol("exec");
@@ -113,6 +113,24 @@ export function getFirstValueInFlattenedArray(
   return undefined;
 }
 
+function getFirstKeyForCommand(
+  commandName: string,
+  args: ArgumentType[]
+): string | Buffer | number | null | undefined {
+  if (exists(commandName, { caseInsensitive: true })) {
+    const flattenedArgs = args.flat() as (string | Buffer | number)[];
+    const keyIndexes = getKeyIndexes(commandName, flattenedArgs, {
+      nameCaseInsensitive: true,
+    });
+
+    if (keyIndexes.length) {
+      return flattenedArgs[keyIndexes[0]];
+    }
+  }
+
+  return getFirstValueInFlattenedArray(args);
+}
+
 export function executeWithAutoPipelining(
   client,
   functionName: string,
@@ -145,12 +163,10 @@ export function executeWithAutoPipelining(
   }
 
   // If we have slot information, we can improve routing by grouping slots served by the same subset of nodes
-  // Note that the first value in args may be a (possibly empty) array.
-  // ioredis will only flatten one level of the array, in the Command constructor.
   const prefix = client.options.keyPrefix || "";
   let slotKey = client.isCluster
     ? client.slots[
-        calculateSlot(`${prefix}${getFirstValueInFlattenedArray(args)}`)
+        calculateSlot(`${prefix}${getFirstKeyForCommand(commandName, args)}`)
       ].join(",")
     : "main";
 

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -5512,6 +5512,49 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   ): Result<"OK", Context>;
 
   /**
+   * Atomically sets multiple string keys with a shared expiration in a single operation. Supports flexible argument parsing where condition and expiration flags can appear in any order.
+   * - _group_: string
+   * - _complexity_: O(N) where N is the number of keys to set.
+   * - _since_: 8.4.0
+   */
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[]]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], secondsToken: 'EX', seconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], secondsToken: 'EX', seconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], millisecondsToken: 'PX', milliseconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], millisecondsToken: 'PX', milliseconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], keepttl: 'KEEPTTL', callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], keepttl: 'KEEPTTL']): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX']): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', secondsToken: 'EX', seconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', secondsToken: 'EX', seconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', millisecondsToken: 'PX', milliseconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', millisecondsToken: 'PX', milliseconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', keepttl: 'KEEPTTL', callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], nx: 'NX', keepttl: 'KEEPTTL']): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX']): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', secondsToken: 'EX', seconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', secondsToken: 'EX', seconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', millisecondsToken: 'PX', milliseconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', millisecondsToken: 'PX', milliseconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', unixTimeSecondsToken: 'EXAT', unixTimeSeconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string, callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', unixTimeMillisecondsToken: 'PXAT', unixTimeMilliseconds: number | string]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', keepttl: 'KEEPTTL', callback: Callback<number>]): Result<number, Context>;
+  msetex(...args: [numkeys: number | string, ...data: (RedisKey | string | Buffer | number)[], xx: 'XX', keepttl: 'KEEPTTL']): Result<number, Context>;
+
+  /**
    * Set multiple keys to multiple values, only if none of the keys exist
    * - _group_: string
    * - _complexity_: O(N) where N is the number of keys to set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.10.1",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "1.7.0",
+        "@ioredis/commands": "1.8.0",
         "cluster-key-slot": "1.1.1",
         "debug": "4.4.3",
         "denque": "2.1.0",
@@ -541,9 +541,9 @@
       "dev": true
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.7.0.tgz",
-      "integrity": "sha512-5E3KP12g1Po3xMdaym6N3VBibWAH/vv7XxGl8M20KQyPfZWB7sAhLb90+9IX/WJWFHuRFai5caz+DXKQbLI51g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.8.0.tgz",
+      "integrity": "sha512-Ob1312jHRB7PH0aFum1gJp0561dEU/EgZYl2vxNO8N02b0ML0tQJfmJHhufH3BbSA7D8OywnG7ntdYssVhPXvw==",
       "license": "MIT"
     },
     "node_modules/@ioredis/interface-generator": {
@@ -9906,9 +9906,9 @@
       "dev": true
     },
     "@ioredis/commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.7.0.tgz",
-      "integrity": "sha512-5E3KP12g1Po3xMdaym6N3VBibWAH/vv7XxGl8M20KQyPfZWB7sAhLb90+9IX/WJWFHuRFai5caz+DXKQbLI51g=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.8.0.tgz",
+      "integrity": "sha512-Ob1312jHRB7PH0aFum1gJp0561dEU/EgZYl2vxNO8N02b0ML0tQJfmJHhufH3BbSA7D8OywnG7ntdYssVhPXvw=="
     },
     "@ioredis/interface-generator": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "https://opencollective.com/ioredis"
   },
   "dependencies": {
-    "@ioredis/commands": "1.7.0",
+    "@ioredis/commands": "1.8.0",
     "cluster-key-slot": "1.1.1",
     "debug": "4.4.3",
     "denque": "2.1.0",

--- a/test/functional/cluster/autopipelining.ts
+++ b/test/functional/cluster/autopipelining.ts
@@ -32,6 +32,10 @@ describe("autoPipelining for cluster", () => {
         return "bar2";
       }
 
+      if (argv[0] === "msetex" && argv[1] === "1" && argv[2] === "foo2") {
+        return 1;
+      }
+
       if (argv[0] === "get" && argv[1] === "foo6") {
         return "bar6";
       }
@@ -66,6 +70,10 @@ describe("autoPipelining for cluster", () => {
 
       if (argv[0] === "get" && argv[1] === "foo1") {
         return "bar1";
+      }
+
+      if (argv[0] === "msetex" && argv[1] === "1" && argv[2] === "foo1") {
+        return 1;
       }
 
       if (argv[0] === "get" && argv[1] === "foo5") {
@@ -197,6 +205,20 @@ describe("autoPipelining for cluster", () => {
         cluster.get("foo1"),
       ])
     ).to.eql(["bar1", "bar5", "bar1", "bar5", "bar1"]);
+
+    cluster.disconnect();
+  });
+
+  it("should bucket MSETEX by its first key", async () => {
+    const cluster = new Cluster(hosts, { enableAutoPipelining: true });
+    await new Promise((resolve) => cluster.once("connect", resolve));
+
+    const result = await Promise.all([
+      cluster.msetex(1, "foo1", "bar1"),
+      cluster.msetex(1, "foo2", "bar2"),
+    ]);
+
+    expect(result).to.eql([1, 1]);
 
     cluster.disconnect();
   });

--- a/test/functional/commands/msetex.ts
+++ b/test/functional/commands/msetex.ts
@@ -1,0 +1,126 @@
+import Redis from "../../../lib/Redis";
+import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
+
+describe("msetex", function () {
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.4")) {
+      this.skip();
+    }
+  });
+
+  let redis: Redis;
+
+  beforeEach(() => {
+    redis = new Redis();
+  });
+
+  afterEach(() => {
+    redis.disconnect();
+  });
+
+  it("should set a single key and return 1", async () => {
+    const key = `test_msetex_single_${Date.now()}`;
+
+    const result = await redis.msetex(1, key, "value1");
+
+    expect(result).to.equal(1);
+  });
+
+  it("should set multiple keys and return 1", async () => {
+    const ts = Date.now();
+    const key1 = `test_msetex_multi_1_${ts}`;
+    const key2 = `test_msetex_multi_2_${ts}`;
+
+    const result = await redis.msetex(2, key1, "value1", key2, "value2");
+
+    expect(result).to.equal(1);
+  });
+
+  it("should return 1 with NX when none of the keys exist", async () => {
+    const key = `test_msetex_nx_new_${Date.now()}`;
+
+    const result = await redis.msetex(1, key, "value1", "NX");
+
+    expect(result).to.equal(1);
+  });
+
+  it("should return 0 with NX when any key already exists", async () => {
+    const key = `test_msetex_nx_exists_${Date.now()}`;
+
+    await redis.set(key, "existing");
+    const result = await redis.msetex(1, key, "value1", "NX");
+
+    expect(result).to.equal(0);
+  });
+
+  it("should return 0 with XX when keys do not exist", async () => {
+    const key = `test_msetex_xx_missing_${Date.now()}`;
+
+    const result = await redis.msetex(1, key, "value1", "XX");
+
+    expect(result).to.equal(0);
+  });
+
+  it("should return 1 with XX when all keys already exist", async () => {
+    const key = `test_msetex_xx_exists_${Date.now()}`;
+
+    await redis.set(key, "existing");
+    const result = await redis.msetex(1, key, "updated", "XX");
+
+    expect(result).to.equal(1);
+  });
+
+  it("should set a TTL with EX option", async () => {
+    const key = `test_msetex_ex_${Date.now()}`;
+
+    const result = await redis.msetex(1, key, "value1", "EX", 120);
+
+    expect(result).to.equal(1);
+  });
+
+  it("should set a TTL with PX option", async () => {
+    const key = `test_msetex_px_${Date.now()}`;
+
+    const result = await redis.msetex(1, key, "value1", "PX", 120_000);
+
+    expect(result).to.equal(1);
+  });
+
+  it("should set a TTL with EXAT option", async () => {
+    const key = `test_msetex_exat_${Date.now()}`;
+    const expiresAt = Math.floor(Date.now() / 1000) + 300;
+
+    const result = await redis.msetex(1, key, "value1", "EXAT", expiresAt);
+
+    expect(result).to.equal(1);
+  });
+
+  it("should set a TTL with PXAT option", async () => {
+    const key = `test_msetex_pxat_${Date.now()}`;
+    const expiresAt = Date.now() + 300_000;
+
+    const result = await redis.msetex(1, key, "value1", "PXAT", expiresAt);
+
+    expect(result).to.equal(1);
+  });
+
+  it("should support KEEPTTL option", async () => {
+    const key = `test_msetex_keepttl_${Date.now()}`;
+
+    await redis.msetex(1, key, "original", "EX", 120);
+    const result = await redis.msetex(1, key, "updated", "KEEPTTL");
+
+    expect(result).to.equal(1);
+  });
+
+  it("should support combined NX + EX options", async () => {
+    const key = `test_msetex_nx_ex_${Date.now()}`;
+
+    const first = await redis.msetex(1, key, "value1", "NX", "EX", 120);
+    const second = await redis.msetex(1, key, "value2", "NX", "EX", 120);
+
+    expect(first).to.equal(1);
+    expect(second).to.equal(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes cluster auto-pipelining slot bucketing logic (now using command key metadata) and bumps `@ioredis/commands`, which could affect command routing behavior in clustered deployments.
> 
> **Overview**
> Adds Redis 8.4 `MSETEX` support across the client: updates return type mapping (`bin/returnTypes.js`) and adds TypeScript overloads for `RedisCommander.msetex` (including `NX`/`XX`, `EX`/`PX`/`EXAT`/`PXAT`, and `KEEPTTL`).
> 
> Improves cluster auto-pipelining slot selection by deriving the first key via `@ioredis/commands.getKeyIndexes` instead of assuming the first argument is the key, and includes a new cluster test to ensure `MSETEX` is bucketed by its first key.
> 
> Bumps `@ioredis/commands` from `1.7.0` to `1.8.0` and adds functional tests validating `msetex` behavior (skipped on Redis < 8.4).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a0b706654e800c56a14b6016776d4c4348d1d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->