### PR TITLE
feat: add array commands, typings and tests

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8-rc1"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "custom-26235535976-debian"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/bin/overrides.js
+++ b/bin/overrides.js
@@ -30,6 +30,17 @@ module.exports = {
       "$1(key: RedisKey, map: Map<string | Buffer | number, string | Buffer | number>, callback?: Callback<'OK'>): Result<'OK', Context>",
     ],
   },
+  argrep: {
+    overwrite: true,
+    defs: [
+      "$1(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;",
+      "$1(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | (number | string)[]>]): Result<number[] | (number | string)[], Context>;",
+      "$1<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? (number | string)[] : number[], Context>;",
+      "$1Buffer(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;",
+      "$1Buffer(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | (number | Buffer)[]>]): Result<number[] | (number | Buffer)[], Context>;",
+      "$1Buffer<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? (number | Buffer)[] : number[], Context>;",
+    ],
+  },
   exec: {
     overwrite: true,
     defs: [

--- a/bin/overrides.js
+++ b/bin/overrides.js
@@ -34,11 +34,11 @@ module.exports = {
     overwrite: true,
     defs: [
       "$1(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;",
-      "$1(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | (number | string)[]>]): Result<number[] | (number | string)[], Context>;",
-      "$1<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? (number | string)[] : number[], Context>;",
+      "$1(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | Array<[index: number, value: string]>>]): Result<number[] | Array<[index: number, value: string]>, Context>;",
+      "$1<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? Array<[index: number, value: string]> : number[], Context>;",
       "$1Buffer(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;",
-      "$1Buffer(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | (number | Buffer)[]>]): Result<number[] | (number | Buffer)[], Context>;",
-      "$1Buffer<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? (number | Buffer)[] : number[], Context>;",
+      "$1Buffer(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | Array<[index: number, value: Buffer]>>]): Result<number[] | Array<[index: number, value: Buffer]>, Context>;",
+      "$1Buffer<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? Array<[index: number, value: Buffer]> : number[], Context>;",
     ],
   },
   exec: {

--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -100,7 +100,9 @@ module.exports = {
   arget: "string | null",
   argetrange: "(string | null)[]",
   argrep: (types) => {
-    return hasToken(types, "WITHVALUES") ? "(number | string)[]" : "number[]";
+    return hasToken(types, "WITHVALUES")
+      ? "Array<[index: number, value: string]>"
+      : "number[]";
   },
   arinfo: "(string | number)[]",
   arinsert: "number",
@@ -115,7 +117,7 @@ module.exports = {
     if (hasToken(types, ["MATCH", "USED"])) return "number";
   },
   arring: "number",
-  arscan: "(number | string)[]",
+  arscan: "Array<[index: number, value: string]>",
   arseek: "number",
   arset: "number",
   asking: "'OK'",

--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -94,6 +94,30 @@ module.exports = {
     }
   },
   append: "number",
+  arcount: "number",
+  ardel: "number",
+  ardelrange: "number",
+  arget: "string | null",
+  argetrange: "(string | null)[]",
+  argrep: (types) => {
+    return hasToken(types, "WITHVALUES") ? "(number | string)[]" : "number[]";
+  },
+  arinfo: "(string | number)[]",
+  arinsert: "number",
+  arlastitems: "(string | null)[]",
+  arlen: "number",
+  armget: "(string | null)[]",
+  armset: "number",
+  arnext: "number | null",
+  arop: (types) => {
+    if (hasToken(types, ["SUM", "MIN", "MAX"])) return "string | null";
+    if (hasToken(types, ["AND", "OR", "XOR"])) return "number | null";
+    if (hasToken(types, ["MATCH", "USED"])) return "number";
+  },
+  arring: "number",
+  arscan: "(number | string)[]",
+  arseek: "number",
+  arset: "number",
   asking: "'OK'",
   auth: "'OK'",
   bgrewriteaof: "string",

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -385,11 +385,11 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _since_: 8.8.0
    */
   argrep(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;
-  argrep(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | (number | string)[]>]): Result<number[] | (number | string)[], Context>;
-  argrep<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? (number | string)[] : number[], Context>;
+  argrep(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | Array<[index: number, value: string]>>]): Result<number[] | Array<[index: number, value: string]>, Context>;
+  argrep<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? Array<[index: number, value: string]> : number[], Context>;
   argrepBuffer(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;
-  argrepBuffer(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | (number | Buffer)[]>]): Result<number[] | (number | Buffer)[], Context>;
-  argrepBuffer<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? (number | Buffer)[] : number[], Context>;
+  argrepBuffer(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | Array<[index: number, value: Buffer]>>]): Result<number[] | Array<[index: number, value: Buffer]>, Context>;
+  argrepBuffer<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? Array<[index: number, value: Buffer]> : number[], Context>;
 
   /**
    * Returns metadata about an array.
@@ -491,10 +491,10 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.
    * - _since_: 8.8.0
    */
-  arscan(key: RedisKey, start: number | string, end: number | string, callback?: Callback<(number | string)[]>): Result<(number | string)[], Context>;
-  arscanBuffer(key: RedisKey, start: number | string, end: number | string, callback?: Callback<(number | Buffer)[]>): Result<(number | Buffer)[], Context>;
-  arscan(key: RedisKey, start: number | string, end: number | string, limitToken: 'LIMIT', limit: number | string, callback?: Callback<(number | string)[]>): Result<(number | string)[], Context>;
-  arscanBuffer(key: RedisKey, start: number | string, end: number | string, limitToken: 'LIMIT', limit: number | string, callback?: Callback<(number | Buffer)[]>): Result<(number | Buffer)[], Context>;
+  arscan(key: RedisKey, start: number | string, end: number | string, callback?: Callback<Array<[index: number, value: string]>>): Result<Array<[index: number, value: string]>, Context>;
+  arscanBuffer(key: RedisKey, start: number | string, end: number | string, callback?: Callback<Array<[index: number, value: Buffer]>>): Result<Array<[index: number, value: Buffer]>, Context>;
+  arscan(key: RedisKey, start: number | string, end: number | string, limitToken: 'LIMIT', limit: number | string, callback?: Callback<Array<[index: number, value: string]>>): Result<Array<[index: number, value: string]>, Context>;
+  arscanBuffer(key: RedisKey, start: number | string, end: number | string, limitToken: 'LIMIT', limit: number | string, callback?: Callback<Array<[index: number, value: Buffer]>>): Result<Array<[index: number, value: Buffer]>, Context>;
 
   /**
    * Sets the ARINSERT / ARRING cursor to a specific index.

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -332,14 +332,189 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
    * - _complexity_: O(1). The amortized time complexity is O(1) assuming the appended value is small and the already present value is of any size, since the dynamic string library used by Redis will double the free space available on every reallocation.
    * - _since_: 2.0.0
    */
-  append(
-    key: RedisKey,
-    value: string | Buffer | number,
-    callback?: Callback<number>
-  ): Result<number, Context>;
+  append(key: RedisKey, value: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
 
   /**
-   * Sent by cluster clients after an -ASK redirect
+   * Returns the number of non-empty elements in an array.
+   * - _group_: array
+   * - _complexity_: O(1)
+   * - _since_: 8.8.0
+   */
+  arcount(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Deletes elements at the specified indices in an array.
+   * - _group_: array
+   * - _complexity_: O(N) where N is the number of indices to delete
+   * - _since_: 8.8.0
+   */
+  ardel(...args: [key: RedisKey, ...indices: (number | string)[], callback: Callback<number>]): Result<number, Context>;
+  ardel(...args: [key: RedisKey, ...indices: (number | string)[]]): Result<number, Context>;
+
+  /**
+   * Deletes elements in one or more ranges.
+   * - _group_: array
+   * - _complexity_: Proportional to the number of existing elements / slices touched, not to the numeric span of the requested ranges
+   * - _since_: 8.8.0
+   */
+  ardelrange(...args: [key: RedisKey, ...ranges: (string | number)[], callback: Callback<number>]): Result<number, Context>;
+  ardelrange(...args: [key: RedisKey, ...ranges: (string | number)[]]): Result<number, Context>;
+
+  /**
+   * Gets the value at an index in an array.
+   * - _group_: array
+   * - _complexity_: O(1)
+   * - _since_: 8.8.0
+   */
+  arget(key: RedisKey, index: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
+  argetBuffer(key: RedisKey, index: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+
+  /**
+   * Gets values in a range of indices.
+   * - _group_: array
+   * - _complexity_: O(N) where N is the range length
+   * - _since_: 8.8.0
+   */
+  argetrange(key: RedisKey, start: number | string, end: number | string, callback?: Callback<(string | null)[]>): Result<(string | null)[], Context>;
+  argetrangeBuffer(key: RedisKey, start: number | string, end: number | string, callback?: Callback<(Buffer | null)[]>): Result<(Buffer | null)[], Context>;
+
+  /**
+   * Searches array elements in a range using textual predicates.
+   * - _group_: array
+   * - _complexity_: O(P * C) where P is the number of visited positions in touched slices and C is the cost of evaluating the predicates on one existing element.
+   * - _since_: 8.8.0
+   */
+  argrep(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;
+  argrep(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | (number | string)[]>]): Result<number[] | (number | string)[], Context>;
+  argrep<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? (number | string)[] : number[], Context>;
+  argrepBuffer(key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, callback: Callback<number[]>): Result<number[], Context>;
+  argrepBuffer(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: RedisValue[], callback: Callback<number[] | (number | Buffer)[]>]): Result<number[] | (number | Buffer)[], Context>;
+  argrepBuffer<T extends RedisValue[]>(...args: [key: RedisKey, start: number | string, end: number | string, predicate: 'EXACT' | 'MATCH' | 'GLOB' | 'RE', value: RedisValue, ...args: T]): Result<'WITHVALUES' extends T[number] ? (number | Buffer)[] : number[], Context>;
+
+  /**
+   * Returns metadata about an array.
+   * - _group_: array
+   * - _complexity_: O(1), or O(N) with FULL option where N is the number of slices.
+   * - _since_: 8.8.0
+   */
+  arinfo(key: RedisKey, callback?: Callback<(string | number)[]>): Result<(string | number)[], Context>;
+  arinfoBuffer(key: RedisKey, callback?: Callback<(Buffer | number)[]>): Result<(Buffer | number)[], Context>;
+  arinfo(key: RedisKey, full: 'FULL', callback?: Callback<(string | number)[]>): Result<(string | number)[], Context>;
+  arinfoBuffer(key: RedisKey, full: 'FULL', callback?: Callback<(Buffer | number)[]>): Result<(Buffer | number)[], Context>;
+
+  /**
+   * Inserts one or more values at consecutive indices.
+   * - _group_: array
+   * - _complexity_: O(N) where N is the number of values
+   * - _since_: 8.8.0
+   */
+  arinsert(...args: [key: RedisKey, ...values: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
+  arinsert(...args: [key: RedisKey, ...values: (string | Buffer | number)[]]): Result<number, Context>;
+
+  /**
+   * Returns the most recently inserted elements.
+   * - _group_: array
+   * - _complexity_: O(N) where N is the count
+   * - _since_: 8.8.0
+   */
+  arlastitems(key: RedisKey, count: number | string, callback?: Callback<(string | null)[]>): Result<(string | null)[], Context>;
+  arlastitemsBuffer(key: RedisKey, count: number | string, callback?: Callback<(Buffer | null)[]>): Result<(Buffer | null)[], Context>;
+  arlastitems(key: RedisKey, count: number | string, rev: 'REV', callback?: Callback<(string | null)[]>): Result<(string | null)[], Context>;
+  arlastitemsBuffer(key: RedisKey, count: number | string, rev: 'REV', callback?: Callback<(Buffer | null)[]>): Result<(Buffer | null)[], Context>;
+
+  /**
+   * Returns the length of an array (max index + 1).
+   * - _group_: array
+   * - _complexity_: O(1)
+   * - _since_: 8.8.0
+   */
+  arlen(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Gets values at multiple indices in an array.
+   * - _group_: array
+   * - _complexity_: O(N) where N is the number of indices
+   * - _since_: 8.8.0
+   */
+  armget(...args: [key: RedisKey, ...indices: (number | string)[], callback: Callback<(string | null)[]>]): Result<(string | null)[], Context>;
+  armgetBuffer(...args: [key: RedisKey, ...indices: (number | string)[], callback: Callback<(Buffer | null)[]>]): Result<(Buffer | null)[], Context>;
+  armget(...args: [key: RedisKey, ...indices: (number | string)[]]): Result<(string | null)[], Context>;
+  armgetBuffer(...args: [key: RedisKey, ...indices: (number | string)[]]): Result<(Buffer | null)[], Context>;
+
+  /**
+   * Sets multiple index-value pairs in an array.
+   * - _group_: array
+   * - _complexity_: O(N) where N is the number of pairs
+   * - _since_: 8.8.0
+   */
+  armset(...args: [key: RedisKey, ...data: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
+  armset(...args: [key: RedisKey, ...data: (string | Buffer | number)[]]): Result<number, Context>;
+
+  /**
+   * Returns the next index ARINSERT would use.
+   * - _group_: array
+   * - _complexity_: O(1)
+   * - _since_: 8.8.0
+   */
+  arnext(key: RedisKey, callback?: Callback<number | null>): Result<number | null, Context>;
+
+  /**
+   * Performs aggregate operations on array elements in a range.
+   * - _group_: array
+   * - _complexity_: O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.
+   * - _since_: 8.8.0
+   */
+  arop(key: RedisKey, start: number | string, end: number | string, sum: 'SUM', callback?: Callback<string | null>): Result<string | null, Context>;
+  aropBuffer(key: RedisKey, start: number | string, end: number | string, sum: 'SUM', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  arop(key: RedisKey, start: number | string, end: number | string, min: 'MIN', callback?: Callback<string | null>): Result<string | null, Context>;
+  aropBuffer(key: RedisKey, start: number | string, end: number | string, min: 'MIN', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  arop(key: RedisKey, start: number | string, end: number | string, max: 'MAX', callback?: Callback<string | null>): Result<string | null, Context>;
+  aropBuffer(key: RedisKey, start: number | string, end: number | string, max: 'MAX', callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  arop(key: RedisKey, start: number | string, end: number | string, and: 'AND', callback?: Callback<number | null>): Result<number | null, Context>;
+  arop(key: RedisKey, start: number | string, end: number | string, or: 'OR', callback?: Callback<number | null>): Result<number | null, Context>;
+  arop(key: RedisKey, start: number | string, end: number | string, xor: 'XOR', callback?: Callback<number | null>): Result<number | null, Context>;
+  arop(key: RedisKey, start: number | string, end: number | string, match: 'MATCH', value: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+  arop(key: RedisKey, start: number | string, end: number | string, used: 'USED', callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Inserts values into a ring buffer of specified size, wrapping and truncating as needed.
+   * - _group_: array
+   * - _complexity_: O(M) normally, O(N+M) on ring resize, where N is the maximum of the old and new ring size and M is the number of inserted values
+   * - _since_: 8.8.0
+   */
+  arring(...args: [key: RedisKey, size: number | string, ...values: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
+  arring(...args: [key: RedisKey, size: number | string, ...values: (string | Buffer | number)[]]): Result<number, Context>;
+
+  /**
+   * Iterates existing elements in a range, returning index-value pairs.
+   * - _group_: array
+   * - _complexity_: O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.
+   * - _since_: 8.8.0
+   */
+  arscan(key: RedisKey, start: number | string, end: number | string, callback?: Callback<(number | string)[]>): Result<(number | string)[], Context>;
+  arscanBuffer(key: RedisKey, start: number | string, end: number | string, callback?: Callback<(number | Buffer)[]>): Result<(number | Buffer)[], Context>;
+  arscan(key: RedisKey, start: number | string, end: number | string, limitToken: 'LIMIT', limit: number | string, callback?: Callback<(number | string)[]>): Result<(number | string)[], Context>;
+  arscanBuffer(key: RedisKey, start: number | string, end: number | string, limitToken: 'LIMIT', limit: number | string, callback?: Callback<(number | Buffer)[]>): Result<(number | Buffer)[], Context>;
+
+  /**
+   * Sets the ARINSERT / ARRING cursor to a specific index.
+   * - _group_: array
+   * - _complexity_: O(1)
+   * - _since_: 8.8.0
+   */
+  arseek(key: RedisKey, index: number | string, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Sets one or more contiguous values starting at an index in an array.
+   * - _group_: array
+   * - _complexity_: O(N) where N is the number of values
+   * - _since_: 8.8.0
+   */
+  arset(...args: [key: RedisKey, index: number | string, ...values: (string | Buffer | number)[], callback: Callback<number>]): Result<number, Context>;
+  arset(...args: [key: RedisKey, index: number | string, ...values: (string | Buffer | number)[]]): Result<number, Context>;
+
+  /**
+   * Signals that a cluster client is following an -ASK redirect.
    * - _group_: cluster
    * - _complexity_: O(1)
    * - _since_: 3.0.0

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-8.8-rc1}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-custom-26235535976-debian}
 
 services:
   single:

--- a/test/functional/commands/array.ts
+++ b/test/functional/commands/array.ts
@@ -1,0 +1,647 @@
+import Redis from "../../../lib/Redis";
+import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
+
+describe("array commands", () => {
+  let redis: Redis;
+
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.8")) {
+      this.skip();
+    }
+  });
+
+  beforeEach(() => {
+    redis = new Redis();
+  });
+
+  afterEach(() => {
+    redis.disconnect();
+  });
+
+  const key = (name: string) =>
+    `array_${name}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+
+  const toInfoRecord = (reply: unknown) => {
+    const record: Record<string, unknown> = {};
+    if (!Array.isArray(reply)) {
+      return reply as Record<string, unknown>;
+    }
+
+    for (let index = 0; index < reply.length; index += 2) {
+      const rawKey = reply[index];
+      const field = Buffer.isBuffer(rawKey)
+        ? rawKey.toString()
+        : String(rawKey);
+      record[field] = reply[index + 1];
+    }
+    return record;
+  };
+
+  describe("arcount", () => {
+    it("returns the populated element count and 0 for missing keys", async () => {
+      const arrayKey = key("arcount");
+
+      expect(await redis.arcount(arrayKey)).to.eql(0);
+      await redis.arset(arrayKey, 0, "zero");
+      await redis.arset(arrayKey, 3, "three");
+
+      expect(await redis.arcount(arrayKey)).to.eql(2);
+    });
+  });
+
+  describe("ardel", () => {
+    it("deletes one index", async () => {
+      const arrayKey = key("ardel_one");
+
+      await redis.arset(arrayKey, 0, "zero", "one", "two");
+
+      expect(await redis.ardel(arrayKey, "1")).to.eql(1);
+      expect(await redis.argetrange(arrayKey, 0, 2)).to.eql([
+        "zero",
+        null,
+        "two",
+      ]);
+    });
+
+    it("deletes multiple indexes and ignores missing indexes", async () => {
+      const arrayKey = key("ardel_many");
+
+      await redis.arset(arrayKey, 0, "zero", "one", "two", "three");
+
+      expect(await redis.ardel(arrayKey, 0, 2, "99")).to.eql(2);
+      expect(await redis.arcount(arrayKey)).to.eql(2);
+    });
+  });
+
+  describe("ardelrange", () => {
+    it("deletes a forward range", async () => {
+      const arrayKey = key("ardelrange_forward");
+
+      await redis.arset(arrayKey, 0, "zero", "one", "two", "three");
+
+      expect(await redis.ardelrange(arrayKey, 1, 2)).to.eql(2);
+      expect(await redis.argetrange(arrayKey, 0, 3)).to.eql([
+        "zero",
+        null,
+        null,
+        "three",
+      ]);
+    });
+
+    it("deletes a reversed range", async () => {
+      const arrayKey = key("ardelrange_reversed");
+
+      await redis.arset(arrayKey, 0, "zero", "one", "two", "three");
+
+      expect(await redis.ardelrange(arrayKey, 2, 1)).to.eql(2);
+      expect(await redis.arcount(arrayKey)).to.eql(2);
+    });
+
+    it("deletes multiple ranges and counts overlapping elements once", async () => {
+      const arrayKey = key("ardelrange_many");
+
+      await redis.arset(arrayKey, 0, "zero", "one", "two", "three", "four");
+
+      expect(await redis.ardelrange(arrayKey, 0, 2, 2, 4)).to.eql(5);
+      expect(await redis.arcount(arrayKey)).to.eql(0);
+    });
+
+    it("returns 0 for missing keys", async () => {
+      expect(await redis.ardelrange(key("ardelrange_missing"), 0, 3)).to.eql(0);
+    });
+  });
+
+  describe("arget", () => {
+    it("returns a value or null", async () => {
+      const arrayKey = key("arget");
+
+      await redis.arset(arrayKey, 1, "one");
+
+      expect(await redis.arget(arrayKey, 1)).to.eql("one");
+      expect(await redis.arget(arrayKey, "0")).to.eql(null);
+      expect(await redis.arget(key("arget_missing"), 1)).to.eql(null);
+    });
+
+    it("supports Buffer replies", async () => {
+      const arrayKey = key("arget_buffer");
+
+      await redis.arset(arrayKey, 0, Buffer.from("zero"));
+
+      expect(await redis.argetBuffer(arrayKey, 0)).to.eql(Buffer.from("zero"));
+      expect(await redis.argetBuffer(arrayKey, 1)).to.eql(null);
+    });
+  });
+
+  describe("argetrange", () => {
+    it("returns forward ranges including empty slots", async () => {
+      const arrayKey = key("argetrange_forward");
+
+      await redis.arset(arrayKey, 1, "one", "two");
+
+      expect(await redis.argetrange(arrayKey, 0, 3)).to.eql([
+        null,
+        "one",
+        "two",
+        null,
+      ]);
+      expect(await redis.argetrange(key("argetrange_missing"), 0, 2)).to.eql([
+        null,
+        null,
+        null,
+      ]);
+    });
+
+    it("returns reversed ranges", async () => {
+      const arrayKey = key("argetrange_reversed");
+
+      await redis.arset(arrayKey, 1, "one", "two");
+
+      expect(await redis.argetrange(arrayKey, 3, 0)).to.eql([
+        null,
+        "two",
+        "one",
+        null,
+      ]);
+    });
+
+    it("supports Buffer replies", async () => {
+      const arrayKey = key("argetrange_buffer");
+
+      await redis.arset(arrayKey, 1, "one", Buffer.from("two"));
+
+      expect(await redis.argetrangeBuffer(arrayKey, 0, 2)).to.eql([
+        null,
+        Buffer.from("one"),
+        Buffer.from("two"),
+      ]);
+    });
+  });
+
+  describe("argrep", () => {
+    it("supports every predicate type", async () => {
+      const arrayKey = key("argrep_predicates");
+
+      await redis.arset(arrayKey, 0, "Alpha", "beta", "alphabet", "gamma");
+
+      expect(await redis.argrep(arrayKey, 0, 3, "EXACT", "beta")).to.eql([1]);
+      expect(await redis.argrep(arrayKey, 0, 3, "MATCH", "alp")).to.eql([2]);
+      expect(await redis.argrep(arrayKey, 0, 3, "GLOB", "a*")).to.eql([2]);
+      expect(await redis.argrep(arrayKey, 0, 3, "RE", "^g")).to.eql([3]);
+    });
+
+    it("supports AND, OR, LIMIT, WITHVALUES, NOCASE, and reversed traversal", async () => {
+      const arrayKey = key("argrep_options");
+
+      await redis.arset(arrayKey, 0, "Alpha", "beta", "alphabet", "gamma");
+
+      expect(
+        await redis.argrep(arrayKey, 0, 3, "MATCH", "alpha", "NOCASE")
+      ).to.eql([0, 2]);
+      expect(
+        await redis.argrep(arrayKey, 0, 3, "MATCH", "a", "LIMIT", 2)
+      ).to.eql([0, 1]);
+      expect(
+        await redis.argrep(
+          arrayKey,
+          0,
+          3,
+          "MATCH",
+          "alpha",
+          "WITHVALUES",
+          "NOCASE"
+        )
+      ).to.eql([0, "Alpha", 2, "alphabet"]);
+      expect(
+        await redis.argrep(
+          arrayKey,
+          0,
+          3,
+          "MATCH",
+          "alpha",
+          "MATCH",
+          "bet",
+          "AND"
+        )
+      ).to.eql([2]);
+      expect(
+        await redis.argrep(
+          arrayKey,
+          0,
+          3,
+          "EXACT",
+          "beta",
+          "EXACT",
+          "gamma",
+          "OR"
+        )
+      ).to.eql([1, 3]);
+      expect(await redis.argrep(arrayKey, 3, 0, "MATCH", "a")).to.eql([
+        3, 2, 1, 0,
+      ]);
+    });
+
+    it("returns empty arrays for missing keys or no matches", async () => {
+      const arrayKey = key("argrep_empty");
+
+      await redis.arset(arrayKey, 0, "zero");
+
+      expect(await redis.argrep(arrayKey, 0, 2, "MATCH", "missing")).to.eql([]);
+      expect(
+        await redis.argrep(key("argrep_missing"), 0, 2, "MATCH", "z")
+      ).to.eql([]);
+    });
+
+    it("supports Buffer replies", async () => {
+      const arrayKey = key("argrep_buffer");
+
+      await redis.arset(arrayKey, 0, "Alpha", "beta");
+
+      expect(await redis.argrepBuffer(arrayKey, 0, 1, "EXACT", "beta")).to.eql([
+        1,
+      ]);
+      expect(
+        await redis.argrepBuffer(arrayKey, 0, 1, "EXACT", "beta", "WITHVALUES")
+      ).to.eql([1, Buffer.from("beta")]);
+    });
+  });
+
+  describe("arinfo", () => {
+    it("returns top-level metadata", async () => {
+      const arrayKey = key("arinfo");
+
+      await redis.arset(arrayKey, 0, "zero", "one");
+
+      const info = toInfoRecord(await redis.arinfo(arrayKey));
+      expect(info.count).to.eql(2);
+      expect(info.len).to.eql(2);
+      expect(info["next-insert-index"]).to.eql(0);
+      expect(info).to.have.property("slice-size");
+    });
+
+    it("supports FULL metadata", async () => {
+      const arrayKey = key("arinfo_full");
+
+      await redis.arset(arrayKey, 0, "zero", "one");
+
+      const info = toInfoRecord(await redis.arinfo(arrayKey, "FULL"));
+      expect(info).to.have.property("dense-slices");
+      expect(info).to.have.property("sparse-slices");
+    });
+
+    it("supports Buffer replies", async () => {
+      const arrayKey = key("arinfo_buffer");
+
+      await redis.arset(arrayKey, 0, "zero");
+
+      const info = toInfoRecord(await redis.arinfoBuffer(arrayKey, "FULL"));
+      expect(info.count).to.eql(1);
+      expect(info).to.have.property("dense-slices");
+    });
+
+    it("raises a server error for missing keys", async () => {
+      let error: Error | undefined;
+
+      try {
+        await redis.arinfo(key("arinfo_missing"));
+      } catch (err) {
+        error = err as Error;
+      }
+      expect(error?.message).to.include("no such key");
+    });
+  });
+
+  describe("arinsert", () => {
+    it("inserts one value at the current cursor", async () => {
+      const arrayKey = key("arinsert_one");
+
+      expect(await redis.arinsert(arrayKey, "zero")).to.eql(0);
+      expect(await redis.arget(arrayKey, 0)).to.eql("zero");
+      expect(await redis.arnext(arrayKey)).to.eql(1);
+    });
+
+    it("inserts multiple string, Buffer, and number values", async () => {
+      const arrayKey = key("arinsert_many");
+
+      expect(
+        await redis.arinsert(arrayKey, "zero", Buffer.from("one"), 2)
+      ).to.eql(2);
+      expect(await redis.argetrange(arrayKey, 0, 2)).to.eql([
+        "zero",
+        "one",
+        "2",
+      ]);
+    });
+  });
+
+  describe("arlastitems", () => {
+    it("returns the latest items in chronological order", async () => {
+      const arrayKey = key("arlastitems");
+
+      await redis.arinsert(arrayKey, "a", "b", "c");
+
+      expect(await redis.arlastitems(arrayKey, 2)).to.eql(["b", "c"]);
+      expect(await redis.arlastitems(arrayKey, 10)).to.eql(["a", "b", "c"]);
+      expect(await redis.arlastitems(key("arlastitems_missing"), 2)).to.eql([]);
+    });
+
+    it("supports REV", async () => {
+      const arrayKey = key("arlastitems_rev");
+
+      await redis.arinsert(arrayKey, "a", "b", "c");
+
+      expect(await redis.arlastitems(arrayKey, 2, "REV")).to.eql(["c", "b"]);
+    });
+
+    it("returns null sparse slots and supports Buffer replies", async () => {
+      const arrayKey = key("arlastitems_buffer");
+
+      await redis.arinsert(arrayKey, "a", "b");
+      await redis.arseek(arrayKey, 5);
+      await redis.arinsert(arrayKey, "f");
+
+      expect(await redis.arlastitems(arrayKey, 2)).to.eql([null, "f"]);
+      expect(await redis.arlastitemsBuffer(arrayKey, 2, "REV")).to.eql([
+        Buffer.from("f"),
+        null,
+      ]);
+    });
+  });
+
+  describe("arlen", () => {
+    it("returns max index plus one or 0 for missing keys", async () => {
+      const arrayKey = key("arlen");
+
+      expect(await redis.arlen(arrayKey)).to.eql(0);
+      await redis.arset(arrayKey, 3, "three");
+
+      expect(await redis.arlen(arrayKey)).to.eql(4);
+    });
+  });
+
+  describe("armget", () => {
+    it("returns values in requested order with nulls for missing slots", async () => {
+      const arrayKey = key("armget");
+
+      await redis.arset(arrayKey, 1, "one", "two");
+
+      expect(await redis.armget(arrayKey, 2, "0", 1)).to.eql([
+        "two",
+        null,
+        "one",
+      ]);
+      expect(await redis.armget(key("armget_missing"), 0, 2)).to.eql([
+        null,
+        null,
+      ]);
+    });
+
+    it("supports Buffer replies", async () => {
+      const arrayKey = key("armget_buffer");
+
+      await redis.arset(arrayKey, 0, "zero", Buffer.from("one"));
+
+      expect(await redis.armgetBuffer(arrayKey, 1, 0, 9)).to.eql([
+        Buffer.from("one"),
+        Buffer.from("zero"),
+        null,
+      ]);
+    });
+  });
+
+  describe("armset", () => {
+    it("sets one index-value pair", async () => {
+      const arrayKey = key("armset_one");
+
+      expect(await redis.armset(arrayKey, 1, "one")).to.eql(1);
+      expect(await redis.argetrange(arrayKey, 0, 1)).to.eql([null, "one"]);
+    });
+
+    it("sets multiple non-contiguous pairs with string, Buffer, and number values", async () => {
+      const arrayKey = key("armset_many");
+
+      expect(
+        await redis.armset(arrayKey, 3, Buffer.from("three"), 1, "one", 5, 5)
+      ).to.eql(3);
+      expect(await redis.armget(arrayKey, 1, 3, 5)).to.eql([
+        "one",
+        "three",
+        "5",
+      ]);
+    });
+
+    it("counts only newly populated slots", async () => {
+      const arrayKey = key("armset_existing");
+
+      await redis.armset(arrayKey, 0, "zero", 2, "two");
+      expect(await redis.armset(arrayKey, 0, "ZERO", 1, "one")).to.eql(1);
+    });
+  });
+
+  describe("arnext", () => {
+    it("returns 0 for missing keys and the next insert cursor", async () => {
+      const arrayKey = key("arnext");
+
+      expect(await redis.arnext(arrayKey)).to.eql(0);
+      await redis.arinsert(arrayKey, "zero", "one");
+
+      expect(await redis.arnext(arrayKey)).to.eql(2);
+    });
+
+    it("reflects ARSEEK cursor changes", async () => {
+      const arrayKey = key("arnext_seek");
+
+      await redis.arinsert(arrayKey, "zero");
+      await redis.arseek(arrayKey, 5);
+
+      expect(await redis.arnext(arrayKey)).to.eql(5);
+    });
+  });
+
+  describe("arop", () => {
+    it("returns string aggregates for SUM, MIN, and MAX", async () => {
+      const arrayKey = key("arop_strings");
+
+      await redis.arset(arrayKey, 0, 1, 2, 3);
+
+      expect(await redis.arop(arrayKey, 0, 2, "SUM")).to.eql("6");
+      expect(await redis.arop(arrayKey, 2, 0, "SUM")).to.eql("6");
+      expect(await redis.arop(arrayKey, 0, 2, "MIN")).to.eql("1");
+      expect(await redis.arop(arrayKey, 0, 2, "MAX")).to.eql("3");
+    });
+
+    it("supports Buffer replies for string aggregates", async () => {
+      const arrayKey = key("arop_buffer");
+
+      await redis.arset(arrayKey, 0, 1, 2, 3);
+
+      expect(await redis.aropBuffer(arrayKey, 0, 2, "SUM")).to.eql(
+        Buffer.from("6")
+      );
+      expect(await redis.aropBuffer(arrayKey, 0, 2, "MIN")).to.eql(
+        Buffer.from("1")
+      );
+      expect(await redis.aropBuffer(arrayKey, 0, 2, "MAX")).to.eql(
+        Buffer.from("3")
+      );
+    });
+
+    it("returns integer or null aggregates for AND, OR, XOR, MATCH, and USED", async () => {
+      const arrayKey = key("arop_numbers");
+
+      await redis.arset(arrayKey, 0, 1, 2, 3);
+
+      expect(await redis.arop(arrayKey, 0, 2, "AND")).to.eql(0);
+      expect(await redis.arop(arrayKey, 0, 2, "OR")).to.eql(3);
+      expect(await redis.arop(arrayKey, 0, 2, "XOR")).to.eql(0);
+      expect(await redis.arop(arrayKey, 0, 2, "MATCH", 2)).to.eql(1);
+      expect(await redis.arop(arrayKey, 0, 2, "MATCH", "missing")).to.eql(0);
+      expect(await redis.arop(arrayKey, 0, 2, "USED")).to.eql(3);
+    });
+
+    it("returns null or 0 for empty aggregate ranges", async () => {
+      const arrayKey = key("arop_empty");
+
+      await redis.arset(arrayKey, 0, "not-a-number");
+
+      expect(await redis.arop(arrayKey, 0, 0, "SUM")).to.eql(null);
+      expect(await redis.arop(key("arop_missing"), 0, 2, "AND")).to.eql(null);
+      expect(await redis.arop(key("arop_missing"), 0, 2, "USED")).to.eql(0);
+    });
+  });
+
+  describe("arring", () => {
+    it("inserts one or more values and returns the last index", async () => {
+      const arrayKey = key("arring");
+
+      expect(await redis.arring(arrayKey, 3, "a")).to.eql(0);
+      expect(await redis.arring(arrayKey, 3, "b", "c")).to.eql(2);
+      expect(await redis.argetrange(arrayKey, 0, 2)).to.eql(["a", "b", "c"]);
+    });
+
+    it("wraps, overwrites, and shrinks the ring window", async () => {
+      const arrayKey = key("arring_wrap");
+
+      await redis.arring(arrayKey, 3, "a", "b", "c");
+      expect(await redis.arring(arrayKey, 3, "d")).to.eql(0);
+      expect(await redis.argetrange(arrayKey, 0, 2)).to.eql(["d", "b", "c"]);
+      expect(await redis.arlastitems(arrayKey, 3)).to.eql(["b", "c", "d"]);
+
+      expect(await redis.arring(arrayKey, 2, "e")).to.eql(0);
+      expect(await redis.arlen(arrayKey)).to.eql(2);
+      expect(await redis.arlastitems(arrayKey, 3)).to.eql(["d", "e"]);
+    });
+
+    it("accepts Buffer and number values", async () => {
+      const arrayKey = key("arring_values");
+
+      expect(await redis.arring(arrayKey, 2, Buffer.from("a"), 1)).to.eql(1);
+      expect(await redis.argetrange(arrayKey, 0, 1)).to.eql(["a", "1"]);
+    });
+  });
+
+  describe("arscan", () => {
+    it("returns populated index-value pairs and skips sparse slots", async () => {
+      const arrayKey = key("arscan");
+
+      await redis.arset(arrayKey, 0, "zero");
+      await redis.arset(arrayKey, 3, "three");
+
+      expect(await redis.arscan(arrayKey, 0, 5)).to.eql([
+        0,
+        "zero",
+        3,
+        "three",
+      ]);
+      expect(await redis.arscan(key("arscan_missing"), 0, 5)).to.eql([]);
+    });
+
+    it("supports reversed traversal and LIMIT", async () => {
+      const arrayKey = key("arscan_options");
+
+      await redis.arset(arrayKey, 0, "zero");
+      await redis.arset(arrayKey, 3, "three");
+
+      expect(await redis.arscan(arrayKey, 5, 0)).to.eql([
+        3,
+        "three",
+        0,
+        "zero",
+      ]);
+      expect(await redis.arscan(arrayKey, 0, 5, "LIMIT", 1)).to.eql([
+        0,
+        "zero",
+      ]);
+    });
+
+    it("supports Buffer replies", async () => {
+      const arrayKey = key("arscan_buffer");
+
+      await redis.arset(arrayKey, 0, "zero");
+      await redis.arset(arrayKey, 3, Buffer.from("three"));
+
+      expect(await redis.arscanBuffer(arrayKey, 0, 5)).to.eql([
+        0,
+        Buffer.from("zero"),
+        3,
+        Buffer.from("three"),
+      ]);
+      expect(await redis.arscanBuffer(arrayKey, 0, 5, "LIMIT", 1)).to.eql([
+        0,
+        Buffer.from("zero"),
+      ]);
+    });
+  });
+
+  describe("arseek", () => {
+    it("sets the insert cursor for existing arrays", async () => {
+      const arrayKey = key("arseek");
+
+      await redis.arinsert(arrayKey, "zero", "one");
+
+      expect(await redis.arseek(arrayKey, "5")).to.eql(1);
+      expect(await redis.arnext(arrayKey)).to.eql(5);
+      expect(await redis.arinsert(arrayKey, "five")).to.eql(5);
+      expect(await redis.arget(arrayKey, 5)).to.eql("five");
+    });
+
+    it("returns 0 for missing keys", async () => {
+      expect(await redis.arseek(key("arseek_missing"), 1)).to.eql(0);
+    });
+  });
+
+  describe("arset", () => {
+    it("sets one value at a number or string index", async () => {
+      const arrayKey = key("arset_one");
+
+      expect(await redis.arset(arrayKey, 0, "zero")).to.eql(1);
+      expect(await redis.arset(arrayKey, "2", "two")).to.eql(1);
+      expect(await redis.argetrange(arrayKey, 0, 2)).to.eql([
+        "zero",
+        null,
+        "two",
+      ]);
+    });
+
+    it("sets multiple contiguous string, Buffer, and number values", async () => {
+      const arrayKey = key("arset_many");
+
+      expect(
+        await redis.arset(arrayKey, 1, "one", Buffer.from("two"), 3)
+      ).to.eql(3);
+      expect(await redis.argetrange(arrayKey, 0, 3)).to.eql([
+        null,
+        "one",
+        "two",
+        "3",
+      ]);
+    });
+
+    it("counts only newly populated slots", async () => {
+      const arrayKey = key("arset_existing");
+
+      await redis.arset(arrayKey, 0, "zero", "one");
+      expect(await redis.arset(arrayKey, 1, "ONE", "two")).to.eql(1);
+    });
+  });
+});

--- a/test/functional/commands/array.ts
+++ b/test/functional/commands/array.ts
@@ -6,7 +6,7 @@ describe("array commands", () => {
   let redis: Redis;
 
   before(async function () {
-    if (await isRedisVersionLowerThan("8.8")) {
+    if (await isRedisVersionLowerThan("8.7")) {
       this.skip();
     }
   });

--- a/test/functional/commands/array.ts
+++ b/test/functional/commands/array.ts
@@ -211,7 +211,10 @@ describe("array commands", () => {
           "WITHVALUES",
           "NOCASE"
         )
-      ).to.eql([0, "Alpha", 2, "alphabet"]);
+      ).to.eql([
+        [0, "Alpha"],
+        [2, "alphabet"],
+      ]);
       expect(
         await redis.argrep(
           arrayKey,
@@ -262,7 +265,7 @@ describe("array commands", () => {
       ]);
       expect(
         await redis.argrepBuffer(arrayKey, 0, 1, "EXACT", "beta", "WITHVALUES")
-      ).to.eql([1, Buffer.from("beta")]);
+      ).to.eql([[1, Buffer.from("beta")]]);
     });
   });
 
@@ -548,10 +551,8 @@ describe("array commands", () => {
       await redis.arset(arrayKey, 3, "three");
 
       expect(await redis.arscan(arrayKey, 0, 5)).to.eql([
-        0,
-        "zero",
-        3,
-        "three",
+        [0, "zero"],
+        [3, "three"],
       ]);
       expect(await redis.arscan(key("arscan_missing"), 0, 5)).to.eql([]);
     });
@@ -563,14 +564,11 @@ describe("array commands", () => {
       await redis.arset(arrayKey, 3, "three");
 
       expect(await redis.arscan(arrayKey, 5, 0)).to.eql([
-        3,
-        "three",
-        0,
-        "zero",
+        [3, "three"],
+        [0, "zero"],
       ]);
       expect(await redis.arscan(arrayKey, 0, 5, "LIMIT", 1)).to.eql([
-        0,
-        "zero",
+        [0, "zero"],
       ]);
     });
 
@@ -581,14 +579,11 @@ describe("array commands", () => {
       await redis.arset(arrayKey, 3, Buffer.from("three"));
 
       expect(await redis.arscanBuffer(arrayKey, 0, 5)).to.eql([
-        0,
-        Buffer.from("zero"),
-        3,
-        Buffer.from("three"),
+        [0, Buffer.from("zero")],
+        [3, Buffer.from("three")],
       ]);
       expect(await redis.arscanBuffer(arrayKey, 0, 5, "LIMIT", 1)).to.eql([
-        0,
-        Buffer.from("zero"),
+        [0, Buffer.from("zero")],
       ]);
     });
   });

--- a/test/typing/commands.test-d.ts
+++ b/test/typing/commands.test-d.ts
@@ -115,6 +115,43 @@ expectType<Promise<Buffer | null>>(redis.zscoreBuffer("key", "member"));
 // GETRANGE
 expectType<Promise<Buffer>>(redis.getrangeBuffer("foo", 0, 1));
 
+// Array commands
+expectType<Promise<number>>(redis.arcount("key"));
+expectType<Promise<number>>(redis.ardel("key", 0, 1));
+expectType<Promise<number>>(redis.ardelrange("key", 0, 2));
+expectType<Promise<string | null>>(redis.arget("key", 0));
+expectType<Promise<Buffer | null>>(redis.argetBuffer("key", 0));
+expectType<Promise<(string | null)[]>>(redis.argetrange("key", 0, 2));
+expectType<Promise<(Buffer | null)[]>>(redis.argetrangeBuffer("key", 0, 2));
+expectError(redis.argrep("key", 0, 4));
+expectType<Promise<number[]>>(redis.argrep("key", 0, 4, "MATCH", "alpha"));
+expectType<Promise<(number | string)[]>>(
+  redis.argrep("key", 0, 4, "MATCH", "alpha", "WITHVALUES", "NOCASE")
+);
+expectType<Promise<(number | Buffer)[]>>(
+  redis.argrepBuffer("key", 0, 4, "MATCH", "alpha", "WITHVALUES")
+);
+expectType<Promise<(string | number)[]>>(redis.arinfo("key"));
+expectType<Promise<(Buffer | number)[]>>(redis.arinfoBuffer("key", "FULL"));
+expectType<Promise<number>>(redis.arinsert("key", "a", "b"));
+expectType<Promise<(string | null)[]>>(redis.arlastitems("key", 2));
+expectType<Promise<(Buffer | null)[]>>(redis.arlastitemsBuffer("key", 2, "REV"));
+expectType<Promise<number>>(redis.arlen("key"));
+expectType<Promise<(string | null)[]>>(redis.armget("key", 0, 1));
+expectType<Promise<(Buffer | null)[]>>(redis.armgetBuffer("key", 0, 1));
+expectType<Promise<number>>(redis.armset("key", 0, "a", 1, "b"));
+expectType<Promise<number | null>>(redis.arnext("key"));
+expectType<Promise<string | null>>(redis.arop("key", 0, 2, "SUM"));
+expectType<Promise<Buffer | null>>(redis.aropBuffer("key", 0, 2, "SUM"));
+expectType<Promise<number | null>>(redis.arop("key", 0, 2, "AND"));
+expectType<Promise<number>>(redis.arop("key", 0, 2, "USED"));
+expectType<Promise<number>>(redis.arop("key", 0, 2, "MATCH", "a"));
+expectType<Promise<number>>(redis.arring("key", 3, "a", "b"));
+expectType<Promise<(number | string)[]>>(redis.arscan("key", 0, 2));
+expectType<Promise<(number | Buffer)[]>>(redis.arscanBuffer("key", 0, 2));
+expectType<Promise<number>>(redis.arseek("key", 0));
+expectType<Promise<number>>(redis.arset("key", 0, "a", "b"));
+
 // Callbacks
 redis.getBuffer("foo", (err, res) => {
   expectType<Error | null | undefined>(err);
@@ -139,6 +176,16 @@ redis.del("key1", "key2", (err, res) => {
 redis.del(["key1", "key2"], (err, res) => {
   expectType<Error | null | undefined>(err);
   expectType<number | undefined>(res);
+});
+
+redis.argrep("key", 0, 4, "MATCH", "alpha", (err, res) => {
+  expectType<Error | null | undefined>(err);
+  expectType<number[] | undefined>(res);
+});
+
+redis.arop("key", 0, 2, "SUM", (err, res) => {
+  expectType<Error | null | undefined>(err);
+  expectType<string | null | undefined>(res);
 });
 
 // XNACK

--- a/test/typing/commands.test-d.ts
+++ b/test/typing/commands.test-d.ts
@@ -125,10 +125,10 @@ expectType<Promise<(string | null)[]>>(redis.argetrange("key", 0, 2));
 expectType<Promise<(Buffer | null)[]>>(redis.argetrangeBuffer("key", 0, 2));
 expectError(redis.argrep("key", 0, 4));
 expectType<Promise<number[]>>(redis.argrep("key", 0, 4, "MATCH", "alpha"));
-expectType<Promise<(number | string)[]>>(
+expectType<Promise<Array<[index: number, value: string]>>>(
   redis.argrep("key", 0, 4, "MATCH", "alpha", "WITHVALUES", "NOCASE")
 );
-expectType<Promise<(number | Buffer)[]>>(
+expectType<Promise<Array<[index: number, value: Buffer]>>>(
   redis.argrepBuffer("key", 0, 4, "MATCH", "alpha", "WITHVALUES")
 );
 expectType<Promise<(string | number)[]>>(redis.arinfo("key"));
@@ -147,8 +147,12 @@ expectType<Promise<number | null>>(redis.arop("key", 0, 2, "AND"));
 expectType<Promise<number>>(redis.arop("key", 0, 2, "USED"));
 expectType<Promise<number>>(redis.arop("key", 0, 2, "MATCH", "a"));
 expectType<Promise<number>>(redis.arring("key", 3, "a", "b"));
-expectType<Promise<(number | string)[]>>(redis.arscan("key", 0, 2));
-expectType<Promise<(number | Buffer)[]>>(redis.arscanBuffer("key", 0, 2));
+expectType<Promise<Array<[index: number, value: string]>>>(
+  redis.arscan("key", 0, 2)
+);
+expectType<Promise<Array<[index: number, value: Buffer]>>>(
+  redis.arscanBuffer("key", 0, 2)
+);
 expectType<Promise<number>>(redis.arseek("key", 0));
 expectType<Promise<number>>(redis.arset("key", 0, "a", "b"));
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new surface area of Redis commands (and overloads/return-type inference) plus updates CI to run against a custom Redis image, which could introduce typing regressions or test/CI incompatibilities.
> 
> **Overview**
> Adds first-class support for Redis 8.8 *array commands* by extending the public TypeScript API (`RedisCommander`), return-type inference (`bin/returnTypes.js`), and command overrides (notably `argrep` overloads).
> 
> Introduces comprehensive functional coverage for the new array commands (including Buffer variants and option handling) and extends `tsd` typing tests to validate the new signatures, plus updates CI/docker test configuration to use a custom Redis image in the test matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e59986088f85f06799f4278b6e5611f39bb330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->