### PR TITLE
feat: add increx command

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8-rc1"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "custom-26235535976-debian"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -190,6 +190,8 @@ module.exports = {
   incr: "number",
   incrby: "number",
   incrbyfloat: "string",
+  increx:
+    "[value: number, increment: number] | [value: string, increment: string]",
   info: "string",
   lolwut: "string",
   keys: "string[]",

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -4409,6 +4409,17 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   ): Result<string, Context>;
 
   /**
+   * Increments the numeric value of a key by a number and sets its expiration time. Uses 0 as initial value if the key doesn't exist.
+   * - _group_: string
+   * - _complexity_: O(1)
+   * - _since_: 8.8.0
+   */
+  increx(...args: [key: RedisKey, ...args: (RedisValue)[], callback: Callback<[value: number, increment: number] | [value: string, increment: string]>]): Result<[value: number, increment: number] | [value: string, increment: string], Context>;
+  increxBuffer(...args: [key: RedisKey, ...args: (RedisValue)[], callback: Callback<[value: number, increment: number] | [value: Buffer, increment: Buffer]>]): Result<[value: number, increment: number] | [value: Buffer, increment: Buffer], Context>;
+  increx(...args: [key: RedisKey, ...args: (RedisValue)[]]): Result<[value: number, increment: number] | [value: string, increment: string], Context>;
+  increxBuffer(...args: [key: RedisKey, ...args: (RedisValue)[]]): Result<[value: number, increment: number] | [value: Buffer, increment: Buffer], Context>;
+
+  /**
    * Get information and statistics about the server
    * - _group_: server
    * - _complexity_: O(1)

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-8.8-rc1}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-custom-26235535976-debian}
 
 services:
   single:

--- a/test/functional/commands/increx.ts
+++ b/test/functional/commands/increx.ts
@@ -27,7 +27,7 @@ describe("increx", function () {
     expect(result).to.deep.equal([1, 1]);
   });
 
-  it("supports BYINT with bounds, overflow policy, and expiration options", async () => {
+  it("supports BYINT with bounds, SATURATE, and expiration options", async () => {
     const key = `increx_byint_${Date.now()}`;
 
     await redis.set(key, 5);
@@ -39,14 +39,57 @@ describe("increx", function () {
       0,
       "UBOUND",
       10,
-      "OVERFLOW",
-      "SAT",
+      "SATURATE",
       "EX",
-      60
+      60,
     );
 
     expect(result).to.deep.equal([10, 5]);
     expect(await redis.ttl(key)).to.be.greaterThan(0);
+  });
+
+  it("saturates BYINT to an explicit LBOUND", async () => {
+    const key = `increx_byint_lbound_${Date.now()}`;
+
+    await redis.set(key, 5);
+    const result = await redis.increx(
+      key,
+      "BYINT",
+      -20,
+      "LBOUND",
+      0,
+      "SATURATE",
+    );
+
+    expect(result).to.deep.equal([0, -5]);
+    expect(await redis.get(key)).to.equal("0");
+  });
+
+  it("surfaces out-of-bounds BYINT rejection with expiration options", async () => {
+    const timestamp = Date.now();
+    const cases: Array<{
+      key: string;
+      options: Array<string | number>;
+    }> = [
+      { key: `increx_byint_reject_ex_${timestamp}`, options: ["EX", 60] },
+      { key: `increx_byint_reject_px_${timestamp}`, options: ["PX", 30_000] },
+      { key: `increx_byint_reject_persist_${timestamp}`, options: ["PERSIST"] },
+    ];
+
+    for (const { key, options } of cases) {
+      await redis.set(key, 10);
+      const result = await redis.increx(
+        key,
+        "BYINT",
+        100,
+        "UBOUND",
+        15,
+        ...options
+      );
+
+      expect(result).to.deep.equal([10, 0]);
+      expect(result[1]).to.equal(0);
+    }
   });
 
   it("supports expiration-only integer options", async () => {
@@ -76,9 +119,10 @@ describe("increx", function () {
     expect(result).to.deep.equal(["0.5", "0.5"]);
   });
 
-  it("supports BYFLOAT with bounds, overflow policy, and expiration options", async () => {
+  it("supports BYFLOAT with bounds, SATURATE, and expiration options", async () => {
     const key = `increx_byfloat_options_${Date.now()}`;
 
+    await redis.set(key, "9.75");
     const result = await redis.increx(
       key,
       "BYFLOAT",
@@ -87,30 +131,37 @@ describe("increx", function () {
       "0",
       "UBOUND",
       "10",
-      "OVERFLOW",
-      "SAT",
+      "SATURATE",
       "PX",
       60_000,
-      "ENX"
+      "ENX",
     );
 
-    expect(result).to.deep.equal(["0.5", "0.5"]);
+    expect(result).to.deep.equal(["10", "0.25"]);
     expect(await redis.pttl(key)).to.be.greaterThan(0);
   });
 
-  it("returns string values when BYFLOAT follows another option", async () => {
-    const key = `increx_byfloat_order_${Date.now()}`;
+  it("surfaces out-of-bounds BYFLOAT rejection without SATURATE", async () => {
+    const key = `increx_byfloat_reject_${Date.now()}`;
 
-    const result = await redis.increx(key, "EX", 60, "BYFLOAT", "0.5");
+    await redis.set(key, "9.75");
+    const result = await redis.increx(
+      key,
+      "BYFLOAT",
+      "0.5",
+      "UBOUND",
+      "10",
+    );
 
-    expect(result).to.deep.equal(["0.5", "0.5"]);
+    expect(result).to.deep.equal(["9.75", "0"]);
+    expect(result[1]).to.equal("0");
   });
 
-  it("supports PERSIST before BYFLOAT", async () => {
+  it("supports PERSIST after BYFLOAT", async () => {
     const key = `increx_persist_byfloat_${Date.now()}`;
 
     await redis.set(key, "1.25", "EX", 60);
-    const result = await redis.increx(key, "PERSIST", "BYFLOAT", "0.25");
+    const result = await redis.increx(key, "BYFLOAT", "0.25", "PERSIST");
 
     expect(result).to.deep.equal(["1.5", "0.25"]);
     expect(await redis.ttl(key)).to.equal(-1);

--- a/test/functional/commands/increx.ts
+++ b/test/functional/commands/increx.ts
@@ -6,7 +6,7 @@ describe("increx", function () {
   let redis: Redis;
 
   before(async function () {
-    if (await isRedisVersionLowerThan("8.8")) {
+    if (await isRedisVersionLowerThan("8.7")) {
       this.skip();
     }
   });

--- a/test/functional/commands/increx.ts
+++ b/test/functional/commands/increx.ts
@@ -1,0 +1,157 @@
+import Redis from "../../../lib/Redis";
+import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
+
+describe("increx", function () {
+  let redis: Redis;
+
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.8")) {
+      this.skip();
+    }
+  });
+
+  beforeEach(() => {
+    redis = new Redis();
+  });
+
+  afterEach(() => {
+    redis.disconnect();
+  });
+
+  it("increments by one by default", async () => {
+    const key = `increx_default_${Date.now()}`;
+
+    const result = await redis.increx(key);
+
+    expect(result).to.deep.equal([1, 1]);
+  });
+
+  it("supports BYINT with bounds, overflow policy, and expiration options", async () => {
+    const key = `increx_byint_${Date.now()}`;
+
+    await redis.set(key, 5);
+    const result = await redis.increx(
+      key,
+      "BYINT",
+      20,
+      "LBOUND",
+      0,
+      "UBOUND",
+      10,
+      "OVERFLOW",
+      "SAT",
+      "EX",
+      60
+    );
+
+    expect(result).to.deep.equal([10, 5]);
+    expect(await redis.ttl(key)).to.be.greaterThan(0);
+  });
+
+  it("supports expiration-only integer options", async () => {
+    const key = `increx_expiration_${Date.now()}`;
+
+    const result = await redis.increx(key, "EX", 60, "ENX");
+
+    expect(result).to.deep.equal([1, 1]);
+    expect(await redis.ttl(key)).to.be.greaterThan(0);
+  });
+
+  it("supports PERSIST without an explicit increment mode", async () => {
+    const key = `increx_persist_${Date.now()}`;
+
+    await redis.set(key, 10, "EX", 60);
+    const result = await redis.increx(key, "PERSIST");
+
+    expect(result).to.deep.equal([11, 1]);
+    expect(await redis.ttl(key)).to.equal(-1);
+  });
+
+  it("returns string values for BYFLOAT", async () => {
+    const key = `increx_byfloat_${Date.now()}`;
+
+    const result = await redis.increx(key, "BYFLOAT", "0.5", "EX", 60, "ENX");
+
+    expect(result).to.deep.equal(["0.5", "0.5"]);
+  });
+
+  it("supports BYFLOAT with bounds, overflow policy, and expiration options", async () => {
+    const key = `increx_byfloat_options_${Date.now()}`;
+
+    const result = await redis.increx(
+      key,
+      "BYFLOAT",
+      "0.5",
+      "LBOUND",
+      "0",
+      "UBOUND",
+      "10",
+      "OVERFLOW",
+      "SAT",
+      "PX",
+      60_000,
+      "ENX"
+    );
+
+    expect(result).to.deep.equal(["0.5", "0.5"]);
+    expect(await redis.pttl(key)).to.be.greaterThan(0);
+  });
+
+  it("returns string values when BYFLOAT follows another option", async () => {
+    const key = `increx_byfloat_order_${Date.now()}`;
+
+    const result = await redis.increx(key, "EX", 60, "BYFLOAT", "0.5");
+
+    expect(result).to.deep.equal(["0.5", "0.5"]);
+  });
+
+  it("supports PERSIST before BYFLOAT", async () => {
+    const key = `increx_persist_byfloat_${Date.now()}`;
+
+    await redis.set(key, "1.25", "EX", 60);
+    const result = await redis.increx(key, "PERSIST", "BYFLOAT", "0.25");
+
+    expect(result).to.deep.equal(["1.5", "0.25"]);
+    expect(await redis.ttl(key)).to.equal(-1);
+  });
+
+  it("returns buffers for BYFLOAT buffer variant", async () => {
+    const key = `increx_byfloat_buffer_${Date.now()}`;
+
+    const result = await redis.increxBuffer(key, "BYFLOAT", "0.5");
+
+    expect(result).to.have.lengthOf(2);
+    expect(result[0]).to.be.instanceOf(Buffer);
+    expect(result[1]).to.be.instanceOf(Buffer);
+    expect(result.map((item) => item.toString())).to.deep.equal(["0.5", "0.5"]);
+  });
+
+  it("keeps integer replies as numbers for buffer variant", async () => {
+    const key = `increx_integer_buffer_${Date.now()}`;
+
+    const result = await redis.increxBuffer(key, "EX", 60);
+
+    expect(result).to.deep.equal([1, 1]);
+  });
+
+  it("supports callback form", async () => {
+    const key = `increx_callback_${Date.now()}`;
+
+    await new Promise<void>((resolve, reject) => {
+      redis.increx(key, "BYINT", 2, (error, result) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        try {
+          expect(result).to.deep.equal([2, 2]);
+          resolve();
+        } catch (assertionError) {
+          reject(assertionError);
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new Redis command surface (`increx`) with multiple overloads and buffer behavior, plus a large new functional test suite; correctness depends on Redis 8.8+ semantics. CI/test infrastructure is also shifted to a custom Redis Docker image, which could affect stability and reproducibility.
> 
> **Overview**
> Adds support for the Redis `INCREX` command, including new return-type mapping and `RedisCommander` TypeScript overloads for both string/number and buffer variants.
> 
> Introduces a comprehensive functional test suite covering default behavior, `BYINT`/`BYFLOAT` modes, bounds + `SATURATE`, expiration options (`EX`/`PX`/`PERSIST`/`ENX`), and callback usage (skipping on Redis < 8.7).
> 
> Updates CI and test Docker configuration to run against a custom Redis image/tag (`custom-26235535976-debian`) instead of the previous `8.8-rc1`/`8.8-rc1` matrix entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e305ac3d7f011a568d1370cc5224e2457cd050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->