### PR TITLE
feat: add vector set command support

### DIFF
--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -306,6 +306,23 @@ module.exports = {
   type: "string",
   unlink: "number",
   unwatch: "'OK'",
+  vadd: "number",
+  vcard: "number",
+  vdim: "number",
+  vemb: "string[] | null",
+  vgetattr: "string | null",
+  vinfo: "(string | number)[] | null",
+  vismember: "number",
+  vlinks: "string[][] | null",
+  vrandmember: (types) => {
+    return types.some((type) => type.includes("number"))
+      ? "string[]"
+      : "string | null";
+  },
+  vrange: "string[]",
+  vrem: "number",
+  vsetattr: "number",
+  vsim: "(string | null)[]",
   wait: "number",
   watch: "'OK'",
   zadd: (types) => {

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -8876,6 +8876,128 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   unwatch(callback?: Callback<"OK">): Result<"OK", Context>;
 
   /**
+   * Add one or more elements to a vector set, or update its vector if it already exists
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vadd(...args: [key: RedisKey, ...args: (RedisValue)[], callback: Callback<number>]): Result<number, Context>;
+  vadd(...args: [key: RedisKey, ...args: (RedisValue)[]]): Result<number, Context>;
+
+  /**
+   * Return the number of elements in a vector set
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vcard(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Return the dimension of vectors in the vector set
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vdim(key: RedisKey, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Return the vector associated with an element
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vemb(key: RedisKey, element: string | Buffer | number, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  vembBuffer(key: RedisKey, element: string | Buffer | number, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  vemb(key: RedisKey, element: string | Buffer | number, raw: 'RAW', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  vembBuffer(key: RedisKey, element: string | Buffer | number, raw: 'RAW', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+
+  /**
+   * Retrieve the JSON attributes of elements
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vgetattr(key: RedisKey, element: string | Buffer | number, callback?: Callback<string | null>): Result<string | null, Context>;
+  vgetattrBuffer(key: RedisKey, element: string | Buffer | number, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+
+  /**
+   * Return information about a vector set
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vinfo(key: RedisKey, callback?: Callback<(string | number)[] | null>): Result<(string | number)[] | null, Context>;
+  vinfoBuffer(key: RedisKey, callback?: Callback<(Buffer | number)[] | null>): Result<(Buffer | number)[] | null, Context>;
+
+  /**
+   * Check if an element exists in a vector set
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vismember(key: RedisKey, element: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Return the neighbors of an element at each layer in the HNSW graph
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vlinks(key: RedisKey, element: string | Buffer | number, callback?: Callback<string[][] | null>): Result<string[][] | null, Context>;
+  vlinksBuffer(key: RedisKey, element: string | Buffer | number, callback?: Callback<Buffer[][] | null>): Result<Buffer[][] | null, Context>;
+  vlinks(key: RedisKey, element: string | Buffer | number, withscores: 'WITHSCORES', callback?: Callback<string[][] | null>): Result<string[][] | null, Context>;
+  vlinksBuffer(key: RedisKey, element: string | Buffer | number, withscores: 'WITHSCORES', callback?: Callback<Buffer[][] | null>): Result<Buffer[][] | null, Context>;
+
+  /**
+   * Return one or multiple random members from a vector set
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vrandmember(key: RedisKey, callback?: Callback<string | null>): Result<string | null, Context>;
+  vrandmemberBuffer(key: RedisKey, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  vrandmember(key: RedisKey, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  vrandmemberBuffer(key: RedisKey, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+
+  /**
+   * Return vector set elements in a lex range
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.4.0
+   */
+  vrange(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, callback?: Callback<string[]>): Result<string[], Context>;
+  vrangeBuffer(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+  vrange(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, count: number | string, callback?: Callback<string[]>): Result<string[], Context>;
+  vrangeBuffer(key: RedisKey, start: string | Buffer | number, end: string | Buffer | number, count: number | string, callback?: Callback<Buffer[]>): Result<Buffer[], Context>;
+
+  /**
+   * Remove an element from a vector set
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vrem(key: RedisKey, element: string | Buffer | number, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Associate or remove the JSON attributes of elements
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vsetattr(key: RedisKey, element: string | Buffer | number, json: string | Buffer, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Return elements by vector similarity
+   * - _group_: module
+   * - _complexity_: undefined
+   * - _since_: 8.0.0
+   */
+  vsim(...args: [key: RedisKey, ...args: (RedisValue)[], callback: Callback<(string | null)[]>]): Result<(string | null)[], Context>;
+  vsimBuffer(...args: [key: RedisKey, ...args: (RedisValue)[], callback: Callback<(Buffer | null)[]>]): Result<(Buffer | null)[], Context>;
+  vsim(...args: [key: RedisKey, ...args: (RedisValue)[]]): Result<(string | null)[], Context>;
+  vsimBuffer(...args: [key: RedisKey, ...args: (RedisValue)[]]): Result<(Buffer | null)[], Context>;
+
+  /**
    * Wait for the synchronous replication of all the write commands sent in the context of the current connection
    * - _group_: generic
    * - _complexity_: O(1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.10.1",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "1.9.0",
+        "@ioredis/commands": "1.10.0",
         "cluster-key-slot": "1.1.1",
         "debug": "4.4.3",
         "denque": "2.1.0",
@@ -541,9 +541,9 @@
       "dev": true
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.9.0.tgz",
-      "integrity": "sha512-duVEqZ/EAV7JKg3u3nS4gJOnX/FQd0vwNDnWjxnIwwNNofBKsCeffRPT1U/27dK3PtxpV7ukBoJntdEJKIqK/Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
       "license": "MIT"
     },
     "node_modules/@ioredis/interface-generator": {
@@ -9906,9 +9906,9 @@
       "dev": true
     },
     "@ioredis/commands": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.9.0.tgz",
-      "integrity": "sha512-duVEqZ/EAV7JKg3u3nS4gJOnX/FQd0vwNDnWjxnIwwNNofBKsCeffRPT1U/27dK3PtxpV7ukBoJntdEJKIqK/Q=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="
     },
     "@ioredis/interface-generator": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -43,11 +43,11 @@
     "url": "https://opencollective.com/ioredis"
   },
   "dependencies": {
-    "@ioredis/commands": "1.9.0",
+    "@ioredis/commands": "1.10.0",
     "cluster-key-slot": "1.1.1",
     "debug": "4.4.3",
     "denque": "2.1.0",
-    "lodash.defaults": "4.2.0",
+    "lodash.defaults": "4.2.0", 
     "lodash.isarguments": "3.1.0",
     "redis-errors": "1.2.0",
     "redis-parser": "3.0.0",

--- a/test/functional/commands/vector_set.ts
+++ b/test/functional/commands/vector_set.ts
@@ -1,0 +1,389 @@
+import Redis from "../../../lib/Redis";
+import { expect } from "chai";
+import { isRedisVersionLowerThan } from "../../helpers/util";
+
+describe("vector set commands", function () {
+  let redis: Redis;
+
+  before(async function () {
+    if (await isRedisVersionLowerThan("8.0")) {
+      this.skip();
+    }
+  });
+
+  beforeEach(() => {
+    redis = new Redis();
+  });
+
+  afterEach(() => {
+    redis.disconnect();
+  });
+
+  const key = (name: string) =>
+    `vector_set_${name}_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+
+  const toInfoRecord = (reply: (string | number | Buffer)[] | null) => {
+    const record: Record<string, string | number | Buffer | undefined> = {};
+
+    if (!reply) {
+      return record;
+    }
+
+    for (let index = 0; index < reply.length; index += 2) {
+      const rawField = reply[index];
+      const field = Buffer.isBuffer(rawField)
+        ? rawField.toString()
+        : String(rawField);
+      record[field] = reply[index + 1];
+    }
+
+    return record;
+  };
+
+  async function addVector(
+    vectorKey: string,
+    element: string,
+    values: number[] = [1, 2, 3],
+    attributes?: Record<string, unknown>
+  ) {
+    const args: (string | Buffer | number)[] = [
+      "VALUES",
+      values.length,
+      ...values,
+      element,
+    ];
+
+    if (attributes) {
+      args.push("SETATTR", JSON.stringify(attributes));
+    }
+
+    return redis.vadd(vectorKey, ...args);
+  }
+
+  const expectMembers = (members: string[], expected: string[]) => {
+    expect(members.slice().sort()).to.eql(expected.slice().sort());
+  };
+
+  describe("vadd", () => {
+    it("adds new elements and updates existing elements", async () => {
+      const vectorKey = key("vadd");
+
+      expect(await addVector(vectorKey, "one")).to.eql(1);
+      expect(await addVector(vectorKey, "one", [1, 2, 4])).to.eql(0);
+      expect(await addVector(vectorKey, "two", [4, 5, 6])).to.eql(1);
+    });
+  });
+
+  describe("vcard", () => {
+    it("returns the number of elements in a vector set", async () => {
+      const vectorKey = key("vcard");
+
+      await addVector(vectorKey, "one");
+      await addVector(vectorKey, "two", [4, 5, 6]);
+
+      expect(await redis.vcard(vectorKey)).to.eql(2);
+      expect(await redis.vcard(key("vcard_missing"))).to.eql(0);
+    });
+
+    it("supports callback replies", async () => {
+      const vectorKey = key("vcard_callback");
+
+      await addVector(vectorKey, "one");
+
+      const cardinality = await new Promise<number>((resolve, reject) => {
+        redis.vcard(vectorKey, (err, result) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          resolve(result as number);
+        });
+      });
+
+      expect(cardinality).to.eql(1);
+    });
+  });
+
+  describe("vdim", () => {
+    it("returns the dimension of vectors in a vector set", async () => {
+      const vectorKey = key("vdim");
+
+      await addVector(vectorKey, "one");
+
+      expect(await redis.vdim(vectorKey)).to.eql(3);
+    });
+  });
+
+  describe("vemb", () => {
+    it("returns vectors and null for missing elements", async () => {
+      const vectorKey = key("vemb");
+
+      await addVector(vectorKey, "one");
+
+      const vector = await redis.vemb(vectorKey, "one");
+      expect(vector).to.have.lengthOf(3);
+      expect(Number(vector?.[0])).to.be.closeTo(1, 0.2);
+      expect(Number(vector?.[1])).to.be.closeTo(2, 0.2);
+      expect(Number(vector?.[2])).to.be.closeTo(3, 0.2);
+      expect(await redis.vemb(vectorKey, "missing")).to.eql(null);
+    });
+
+    it("supports Buffer replies", async () => {
+      const vectorKey = key("vemb_buffer");
+
+      await addVector(vectorKey, "one");
+
+      const vector = await redis.vembBuffer(vectorKey, "one");
+      expect(vector).to.have.lengthOf(3);
+      expect(Buffer.isBuffer(vector?.[0])).to.eql(true);
+      expect(Number(vector?.[0]?.toString())).to.be.closeTo(1, 0.2);
+    });
+  });
+
+  describe("vgetattr and vsetattr", () => {
+    it("sets and gets JSON attributes", async () => {
+      const vectorKey = key("attributes");
+
+      await addVector(vectorKey, "one");
+      expect(await redis.vgetattr(vectorKey, "one")).to.eql(null);
+
+      expect(
+        await redis.vsetattr(vectorKey, "one", JSON.stringify({ tag: "blue" }))
+      ).to.eql(1);
+      expect(await redis.vgetattr(vectorKey, "one")).to.eql('{"tag":"blue"}');
+
+      expect(
+        await redis.vsetattr(vectorKey, "missing", JSON.stringify({ tag: "x" }))
+      ).to.eql(0);
+    });
+
+    it("supports Buffer replies", async () => {
+      const vectorKey = key("attributes_buffer");
+
+      await addVector(vectorKey, "one", [1, 2, 3], { tag: "blue" });
+
+      expect(await redis.vgetattrBuffer(vectorKey, "one")).to.eql(
+        Buffer.from('{"tag":"blue"}')
+      );
+    });
+  });
+
+  describe("vinfo", () => {
+    it("returns vector set metadata", async () => {
+      const vectorKey = key("vinfo");
+
+      await addVector(vectorKey, "one", [1, 2, 3], { tag: "blue" });
+      await addVector(vectorKey, "two", [4, 5, 6]);
+
+      const info = toInfoRecord(await redis.vinfo(vectorKey));
+      expect(info["vector-dim"]).to.eql(3);
+      expect(info.size).to.eql(2);
+      expect(info["attributes-count"]).to.eql(1);
+    });
+
+    it("supports Buffer replies", async () => {
+      const vectorKey = key("vinfo_buffer");
+
+      await addVector(vectorKey, "one");
+
+      const info = toInfoRecord(await redis.vinfoBuffer(vectorKey));
+      expect(info["vector-dim"]).to.eql(3);
+      expect(Buffer.isBuffer(info["quant-type"])).to.eql(true);
+    });
+  });
+
+  describe("vlinks", () => {
+    it("returns HNSW graph neighbors", async () => {
+      const vectorKey = key("vlinks");
+
+      await addVector(vectorKey, "one", [1, 2, 3]);
+      await addVector(vectorKey, "two", [1, 2.1, 3]);
+
+      const links = await redis.vlinks(vectorKey, "one");
+      expect(links).to.be.an("array");
+      expect(links?.some((layer) => layer.includes("two"))).to.eql(true);
+    });
+
+    it("supports Buffer replies", async () => {
+      const vectorKey = key("vlinks_buffer");
+
+      await addVector(vectorKey, "one", [1, 2, 3]);
+      await addVector(vectorKey, "two", [1, 2.1, 3]);
+
+      const links = await redis.vlinksBuffer(vectorKey, "one");
+      expect(links?.some((layer) => layer.some(Buffer.isBuffer))).to.eql(true);
+    });
+  });
+
+  describe("vrandmember", () => {
+    it("returns scalar, counted, and missing-key replies", async () => {
+      const vectorKey = key("vrandmember");
+
+      await addVector(vectorKey, "one", [1, 2, 3]);
+      await addVector(vectorKey, "two", [4, 5, 6]);
+      await addVector(vectorKey, "three", [7, 8, 9]);
+
+      expect(["one", "two", "three"]).to.include(
+        await redis.vrandmember(vectorKey)
+      );
+
+      const members = await redis.vrandmember(vectorKey, 2);
+      expect(members).to.have.lengthOf(2);
+      members.forEach((member) => {
+        expect(["one", "two", "three"]).to.include(member);
+      });
+
+      const repeated = await redis.vrandmember(vectorKey, -5);
+      expect(repeated).to.have.lengthOf(5);
+      repeated.forEach((member) => {
+        expect(["one", "two", "three"]).to.include(member);
+      });
+
+      expect(await redis.vrandmember(key("vrandmember_missing"))).to.eql(null);
+      expect(
+        await redis.vrandmember(key("vrandmember_missing_count"), 2)
+      ).to.eql([]);
+    });
+
+    it("supports Buffer replies", async () => {
+      const vectorKey = key("vrandmember_buffer");
+
+      await addVector(vectorKey, "one");
+      await addVector(vectorKey, "two", [4, 5, 6]);
+
+      const member = await redis.vrandmemberBuffer(vectorKey);
+      expect(Buffer.isBuffer(member)).to.eql(true);
+
+      const members = await redis.vrandmemberBuffer(vectorKey, 2);
+      expect(members).to.have.lengthOf(2);
+      expect(members.every(Buffer.isBuffer)).to.eql(true);
+    });
+  });
+
+  describe("vsim", () => {
+    it("searches by element or vector", async () => {
+      const vectorKey = key("vsim");
+
+      await addVector(vectorKey, "one", [1, 2, 3]);
+      await addVector(vectorKey, "two", [1, 2.1, 3]);
+      await addVector(vectorKey, "far", [7, 8, 9]);
+
+      const byElement = await redis.vsim(vectorKey, "ELE", "one", "COUNT", 2);
+      expect(byElement).to.include("one");
+      expect(byElement).to.have.lengthOf(2);
+
+      const byVector = await redis.vsim(
+        vectorKey,
+        "VALUES",
+        3,
+        7,
+        8,
+        9,
+        "COUNT",
+        1
+      );
+      expect(byVector).to.eql(["far"]);
+    });
+
+    it("supports WITHSCORES, WITHATTRIBS, and Buffer replies", async () => {
+      const vectorKey = key("vsim_options");
+
+      await addVector(vectorKey, "one", [1, 2, 3], { tag: "blue" });
+      await addVector(vectorKey, "two", [1, 2.1, 3]);
+
+      expect(
+        await redis.vsim(
+          vectorKey,
+          "ELE",
+          "one",
+          "WITHSCORES",
+          "WITHATTRIBS",
+          "COUNT",
+          1
+        )
+      ).to.eql(["one", "1", '{"tag":"blue"}']);
+
+      const result = await redis.vsimBuffer(
+        vectorKey,
+        "ELE",
+        "one",
+        "COUNT",
+        1
+      );
+      expect(result).to.eql([Buffer.from("one")]);
+    });
+  });
+
+  describe("vrem", () => {
+    it("removes elements and reports whether an element existed", async () => {
+      const vectorKey = key("vrem");
+
+      await addVector(vectorKey, "one");
+
+      expect(await redis.vrem(vectorKey, "one")).to.eql(1);
+      expect(await redis.vrem(vectorKey, "one")).to.eql(0);
+      expect(await redis.vcard(vectorKey)).to.eql(0);
+    });
+  });
+
+  describe("vismember", function () {
+    before(async function () {
+      if (await isRedisVersionLowerThan("8.2")) {
+        this.skip();
+      }
+    });
+
+    it("checks whether elements exist", async () => {
+      const vectorKey = key("vismember");
+
+      await addVector(vectorKey, "one");
+
+      expect(await redis.vismember(vectorKey, "one")).to.eql(1);
+      expect(await redis.vismember(vectorKey, "missing")).to.eql(0);
+      expect(await redis.vismember(key("vismember_missing"), "one")).to.eql(0);
+    });
+  });
+
+  describe("vrange", function () {
+    before(async function () {
+      if (await isRedisVersionLowerThan("8.4")) {
+        this.skip();
+      }
+    });
+
+    it("returns vector set elements in lexicographic order", async () => {
+      const vectorKey = key("vrange");
+
+      await addVector(vectorKey, "beta", [4, 5, 6]);
+      await addVector(vectorKey, "alpha", [1, 2, 3]);
+      await addVector(vectorKey, "gamma", [7, 8, 9]);
+
+      expect(await redis.vrange(vectorKey, "-", "+")).to.eql([
+        "alpha",
+        "beta",
+        "gamma",
+      ]);
+      expect(await redis.vrange(vectorKey, "-", "+", 2)).to.eql([
+        "alpha",
+        "beta",
+      ]);
+      expectMembers(await redis.vrange(vectorKey, "[beta", "+"), [
+        "beta",
+        "gamma",
+      ]);
+    });
+
+    it("supports Buffer replies", async () => {
+      const vectorKey = key("vrange_buffer");
+
+      await addVector(vectorKey, "alpha", [1, 2, 3]);
+      await addVector(vectorKey, "beta", [4, 5, 6]);
+
+      expect(await redis.vrangeBuffer(vectorKey, "-", "+")).to.eql([
+        Buffer.from("alpha"),
+        Buffer.from("beta"),
+      ]);
+    });
+  });
+});

--- a/test/typing/commands.test-d.ts
+++ b/test/typing/commands.test-d.ts
@@ -112,6 +112,19 @@ expectType<Promise<string[]>>(redis.zrandmember("key", 20));
 expectType<Promise<string | null>>(redis.zscore("key", "member"));
 expectType<Promise<Buffer | null>>(redis.zscoreBuffer("key", "member"));
 
+// Vector set commands
+expectType<Promise<number>>(redis.vcard("key"));
+expectType<Promise<string | null>>(redis.vgetattr("key", "element"));
+expectType<Promise<Buffer | null>>(redis.vgetattrBuffer("key", "element"));
+expectType<Promise<string | null>>(redis.vrandmember("key"));
+expectType<Promise<Buffer | null>>(redis.vrandmemberBuffer("key"));
+expectType<Promise<string[]>>(redis.vrandmember("key", 10));
+expectType<Promise<Buffer[]>>(redis.vrandmemberBuffer("key", 10));
+expectType<Promise<string[]>>(redis.vrange("key", "-", "+"));
+expectType<Promise<Buffer[]>>(redis.vrangeBuffer("key", "-", "+"));
+expectType<Promise<string[]>>(redis.vrange("key", "-", "+", 10));
+expectType<Promise<Buffer[]>>(redis.vrangeBuffer("key", "-", "+", 10));
+
 // GETRANGE
 expectType<Promise<Buffer>>(redis.getrangeBuffer("foo", 0, 1));
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new public command APIs/types for Redis 8+ vector set operations and bumps `@ioredis/commands`, which could affect command generation and downstream typing expectations.
> 
> **Overview**
> Adds Redis 8+ *vector set* command support by defining return types and TypeScript `RedisCommander` method overloads for `vadd`, `vcard`, `vdim`, `vemb`, `vgetattr`, `vinfo`, `vismember`, `vlinks`, `vrandmember`, `vrange`, `vrem`, `vsetattr`, and `vsim` (including `Buffer` variants where applicable).
> 
> Adds a new functional test suite covering these commands with Redis version gating (8.0/8.2/8.4) and extends the `test-d.ts` typing assertions for the new APIs. Updates `@ioredis/commands` from `1.9.0` to `1.10.0` in `package.json`/`package-lock.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71e96c87402aace8b59ff583926a4cfeeccb8829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->