### PR TITLE
chore: update Redis 8.8 test image to custom

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8-rc1"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "custom-26235535976-debian"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v2

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-8.8-rc1}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-custom-26235535976-debian}
 
 services:
   single:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: CI-only change that swaps the Redis container image/tag used in tests; main impact is potential test failures if the custom image differs from the previous 8.8-rc1 build.
> 
> **Overview**
> Updates CI and docker test configuration to **stop testing against `8.8-rc1`** and instead use a **custom Redis test image tag** (`custom-26235535976-debian`).
> 
> This changes both the GitHub Actions matrix (`test_with_cov.yml`) and the default `REDIS_VERSION` used by `test/docker-compose.yml`, keeping other tested Redis versions unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404dff378cae8bf35c82c98d78bc2f887fd87960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->