### PR TITLE
feat: support Uint8Array in command arguments

### DIFF
--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -7,6 +7,9 @@ import {
   toArg,
   convertMapToArray,
   convertObjectToArray,
+  checkAndConvertUint8Array,
+  isUint8Array,
+  toBuffer,
 } from "./utils";
 import { Callback, Respondable, CommandParameter } from "./types";
 import {
@@ -17,8 +20,9 @@ import {
 export type ArgumentType =
   | string
   | Buffer
+  | Uint8Array
   | number
-  | (string | Buffer | number | any[])[];
+  | (string | Buffer | Uint8Array | number | any[])[];
 
 interface CommandOptions {
   /**
@@ -241,12 +245,16 @@ export default class Command implements Respondable {
     this.replyEncoding = options.replyEncoding;
     this.errorStack = options.errorStack;
 
-    this.args = args.flat();
+    this.args = args.flat().map(checkAndConvertUint8Array);
     this.callback = callback;
 
     this.initPromise();
 
     if (options.keyPrefix) {
+      if (isUint8Array(options.keyPrefix)) {
+        // @ts-expect-error
+        options.keyPrefix = toBuffer(options.keyPrefix);
+      }
       // @ts-expect-error
       const isBufferKeyPrefix = options.keyPrefix instanceof Buffer;
       // @ts-expect-error
@@ -343,6 +351,9 @@ export default class Command implements Respondable {
       if (typeof arg === "string") {
         // buffers and strings don't need any transformation
       } else if (arg instanceof Buffer) {
+        this.bufferMode = true;
+      } else if (isUint8Array(arg)) {
+        this.args[i] = toBuffer(arg);
         this.bufferMode = true;
       } else {
         this.args[i] = toArg(arg);

--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -10,6 +10,7 @@ import {
   checkAndConvertUint8Array,
   isUint8Array,
   toBuffer,
+  toBufferIfUint8Array,
 } from "./utils";
 import { Callback, Respondable, CommandParameter } from "./types";
 import {
@@ -251,10 +252,7 @@ export default class Command implements Respondable {
     this.initPromise();
 
     if (options.keyPrefix) {
-      if (isUint8Array(options.keyPrefix)) {
-        // @ts-expect-error
-        options.keyPrefix = toBuffer(options.keyPrefix);
-      }
+      options.keyPrefix = toBufferIfUint8Array(options.keyPrefix);
       // @ts-expect-error
       const isBufferKeyPrefix = options.keyPrefix instanceof Buffer;
       // @ts-expect-error

--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -3,7 +3,7 @@ import * as calculateSlot from "cluster-key-slot";
 import asCallback from "standard-as-callback";
 import { exists, getKeyIndexes, hasFlag } from "@ioredis/commands";
 import { ArgumentType } from "./Command";
-import { isUint8Array, toBuffer } from "./utils";
+import { toBufferIfUint8Array } from "./utils";
 
 export const kExec = Symbol("exec");
 export const kCallbacks = Symbol("callbacks");
@@ -104,19 +104,11 @@ export function getFirstValueInFlattenedArray(
       if (arg.length === 0) {
         continue;
       }
-      const val = arg[0];
-      if (isUint8Array(val)) {
-        return toBuffer(val);
-      }
-      return val;
+      return toBufferIfUint8Array(arg[0]);
     }
     const flattened = [arg].flat();
     if (flattened.length > 0) {
-      const val = flattened[0];
-      if (isUint8Array(val)) {
-        return toBuffer(val);
-      }
-      return val;
+      return toBufferIfUint8Array(flattened[0]);
     }
   }
   return undefined;
@@ -133,11 +125,7 @@ export function getFirstKeyForCommand(
     });
 
     if (keyIndexes.length) {
-      const key = flattenedArgs[keyIndexes[0]];
-      if (isUint8Array(key)) {
-        return toBuffer(key);
-      }
-      return key;
+      return toBufferIfUint8Array(flattenedArgs[keyIndexes[0]]);
     }
   }
 

--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -3,6 +3,7 @@ import * as calculateSlot from "cluster-key-slot";
 import asCallback from "standard-as-callback";
 import { exists, getKeyIndexes, hasFlag } from "@ioredis/commands";
 import { ArgumentType } from "./Command";
+import { isUint8Array, toBuffer } from "./utils";
 
 export const kExec = Symbol("exec");
 export const kCallbacks = Symbol("callbacks");
@@ -94,7 +95,7 @@ export function shouldUseAutoPipelining(
 
 export function getFirstValueInFlattenedArray(
   args: ArgumentType[]
-): string | Buffer | Uint8Array | number | null | undefined {
+): string | Buffer | number | null | undefined {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (typeof arg === "string") {
@@ -103,20 +104,28 @@ export function getFirstValueInFlattenedArray(
       if (arg.length === 0) {
         continue;
       }
-      return arg[0];
+      const val = arg[0];
+      if (isUint8Array(val)) {
+        return toBuffer(val);
+      }
+      return val;
     }
     const flattened = [arg].flat();
     if (flattened.length > 0) {
-      return flattened[0];
+      const val = flattened[0];
+      if (isUint8Array(val)) {
+        return toBuffer(val);
+      }
+      return val;
     }
   }
   return undefined;
 }
 
-function getFirstKeyForCommand(
+export function getFirstKeyForCommand(
   commandName: string,
   args: ArgumentType[]
-): string | Buffer | Uint8Array | number | null | undefined {
+): string | Buffer | number | null | undefined {
   if (exists(commandName, { caseInsensitive: true })) {
     const flattenedArgs = args.flat() as (string | Buffer | Uint8Array | number)[];
     const keyIndexes = getKeyIndexes(commandName, flattenedArgs as any, {
@@ -124,7 +133,11 @@ function getFirstKeyForCommand(
     });
 
     if (keyIndexes.length) {
-      return flattenedArgs[keyIndexes[0]];
+      const key = flattenedArgs[keyIndexes[0]];
+      if (isUint8Array(key)) {
+        return toBuffer(key);
+      }
+      return key;
     }
   }
 

--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -94,7 +94,7 @@ export function shouldUseAutoPipelining(
 
 export function getFirstValueInFlattenedArray(
   args: ArgumentType[]
-): string | Buffer | number | null | undefined {
+): string | Buffer | Uint8Array | number | null | undefined {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (typeof arg === "string") {
@@ -116,10 +116,10 @@ export function getFirstValueInFlattenedArray(
 function getFirstKeyForCommand(
   commandName: string,
   args: ArgumentType[]
-): string | Buffer | number | null | undefined {
+): string | Buffer | Uint8Array | number | null | undefined {
   if (exists(commandName, { caseInsensitive: true })) {
-    const flattenedArgs = args.flat() as (string | Buffer | number)[];
-    const keyIndexes = getKeyIndexes(commandName, flattenedArgs, {
+    const flattenedArgs = args.flat() as (string | Buffer | Uint8Array | number)[];
+    const keyIndexes = getKeyIndexes(commandName, flattenedArgs as any, {
       nameCaseInsensitive: true,
     });
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,7 +4,7 @@ import { TLSSocket } from "tls";
 export type Callback<T = any> = (err?: Error | null, result?: T) => void;
 export type NetStream = Socket | TLSSocket;
 
-export type CommandParameter = string | Buffer | number | any[];
+export type CommandParameter = string | Buffer | Uint8Array | number | any[];
 export interface Respondable {
   name: string;
   args: CommandParameter[];

--- a/lib/utils/buffer.ts
+++ b/lib/utils/buffer.ts
@@ -15,6 +15,13 @@ export function toBuffer(val: Uint8Array): Buffer {
 }
 
 /**
+ * Convert a value to Buffer if it is a Uint8Array, otherwise return it as-is.
+ */
+export function toBufferIfUint8Array(val: any): any {
+  return isUint8Array(val) ? toBuffer(val) : val;
+}
+
+/**
  * Recursively convert any Uint8Array instances in the argument to Buffer.
  * Supports arrays, Map instances, and plain object literals.
  */

--- a/lib/utils/buffer.ts
+++ b/lib/utils/buffer.ts
@@ -1,0 +1,51 @@
+import { Buffer } from "buffer";
+
+/**
+ * Check if the value is a Uint8Array but not a Buffer.
+ */
+export function isUint8Array(val: unknown): val is Uint8Array {
+  return val instanceof Uint8Array && !Buffer.isBuffer(val);
+}
+
+/**
+ * Convert a Uint8Array to a Buffer.
+ */
+export function toBuffer(val: Uint8Array): Buffer {
+  return Buffer.from(val.buffer, val.byteOffset, val.byteLength);
+}
+
+/**
+ * Recursively convert any Uint8Array instances in the argument to Buffer.
+ * Supports arrays, Map instances, and plain object literals.
+ */
+export function checkAndConvertUint8Array(arg: any): any {
+  if (isUint8Array(arg)) {
+    return toBuffer(arg);
+  }
+  if (Array.isArray(arg)) {
+    return arg.map(checkAndConvertUint8Array);
+  }
+  if (arg instanceof Map) {
+    const newMap = new Map();
+    for (const [key, val] of arg.entries()) {
+      newMap.set(
+        checkAndConvertUint8Array(key),
+        checkAndConvertUint8Array(val)
+      );
+    }
+    return newMap;
+  }
+  if (
+    typeof arg === "object" &&
+    arg !== null &&
+    (Object.getPrototypeOf(arg) === Object.prototype ||
+      Object.getPrototypeOf(arg) === null)
+  ) {
+    const newObj = {};
+    for (const key of Object.keys(arg)) {
+      newObj[key] = checkAndConvertUint8Array(arg[key]);
+    }
+    return newObj;
+  }
+  return arg;
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -400,3 +400,4 @@ export async function getPackageMeta() {
 }
 
 export { Debug, defaults, isArguments, noop };
+export * from "./buffer";

--- a/test/unit/autoPipelining.ts
+++ b/test/unit/autoPipelining.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { getFirstValueInFlattenedArray } from "../../lib/autoPipelining";
+import { getFirstValueInFlattenedArray, getFirstKeyForCommand } from "../../lib/autoPipelining";
 
 describe("autoPipelining", function () {
   const expectGetFirstValueIs = (values, expected) => {
@@ -25,5 +25,24 @@ describe("autoPipelining", function () {
     expectGetFirstValueIs([createArguments(), createArguments("key")], "key");
     // @ts-expect-error
     expectGetFirstValueIs([createArguments("")], "");
+  });
+
+  it("should convert Uint8Array to Buffer in getFirstValueInFlattenedArray", function () {
+    const u8 = new Uint8Array([102, 111, 111]); // 'foo'
+    const result = getFirstValueInFlattenedArray([u8]);
+    expect(result).to.be.instanceof(Buffer);
+    expect((result as Buffer).toString()).to.eql("foo");
+
+    const nestedResult = getFirstValueInFlattenedArray([[u8]]);
+    expect(nestedResult).to.be.instanceof(Buffer);
+    expect((nestedResult as Buffer).toString()).to.eql("foo");
+  });
+
+  it("should convert Uint8Array to Buffer in getFirstKeyForCommand", function () {
+    const u8 = new Uint8Array([102, 111, 111]); // 'foo'
+    // MGET key1 key2
+    const result = getFirstKeyForCommand("mget", [[u8, "bar"]]);
+    expect(result).to.be.instanceof(Buffer);
+    expect((result as Buffer).toString()).to.eql("foo");
   });
 });

--- a/test/unit/command.ts
+++ b/test/unit/command.ts
@@ -8,6 +8,34 @@ describe("Command", () => {
       const command = new Command("get", ["foo", ["bar", ["zoo", "zoo"]]]);
       expect(command.args).to.eql(["foo", "bar", "zoo,zoo"]);
     });
+
+    it("should convert Uint8Array arguments to Buffer", () => {
+      const u8 = new Uint8Array([102, 111, 111]); // 'foo'
+      const command = new Command("set", ["key", u8]);
+      expect(command.args[1]).to.be.instanceof(Buffer);
+      expect((command.args[1] as Buffer).toString()).to.eql("foo");
+    });
+
+    it("should convert Uint8Array inside object arguments to Buffer", () => {
+      const u8 = new Uint8Array([98, 97, 114]); // 'bar'
+      const command = new Command("mset", [{ key1: u8 }]);
+      expect(command.args[1]).to.be.instanceof(Buffer);
+      expect((command.args[1] as Buffer).toString()).to.eql("bar");
+    });
+
+    it("should convert Uint8Array inside Map arguments to Buffer", () => {
+      const u8 = new Uint8Array([98, 97, 114]); // 'bar'
+      const command = new Command("mset", [new Map([["key1", u8]])]);
+      expect(command.args[1]).to.be.instanceof(Buffer);
+      expect((command.args[1] as Buffer).toString()).to.eql("bar");
+    });
+
+    it("should convert keyPrefix if it is a Uint8Array", () => {
+      const prefix = new Uint8Array([112, 114, 101, 102, 105, 120, 58]); // 'prefix:'
+      const command = new Command("get", ["key"], { keyPrefix: prefix as any });
+      expect(command.args[0]).to.be.instanceof(Buffer);
+      expect((command.args[0] as Buffer).toString()).to.eql("prefix:key");
+    });
   });
 
   describe("#toWritable()", () => {
@@ -20,6 +48,16 @@ describe("Command", () => {
 
     it("should return buffer when there's at least one arg is a buffer", () => {
       const command = new Command("get", ["foo", Buffer.from("bar"), "zooo"]);
+      const result = command.toWritable();
+      expect(result).to.be.instanceof(Buffer);
+      expect(result.toString()).to.eql(
+        "*4\r\n$3\r\nget\r\n$3\r\nfoo\r\n$3\r\nbar\r\n$4\r\nzooo\r\n"
+      );
+    });
+
+    it("should return buffer when there's at least one arg is a Uint8Array", () => {
+      const u8 = new Uint8Array([98, 97, 114]); // 'bar'
+      const command = new Command("get", ["foo", u8, "zooo"]);
       const result = command.toWritable();
       expect(result).to.be.instanceof(Buffer);
       expect(result.toString()).to.eql(


### PR DESCRIPTION
### Description
This pull request adds support for raw `Uint8Array` instances as command arguments and key prefixes.

Since Node's `Buffer` inherits from `Uint8Array`, we detect instances of `Uint8Array` that are not `Buffer`s and convert them to `Buffer` views. This conversion uses a zero-copy operation:
```js
Buffer.from(val.buffer, val.byteOffset, val.byteLength)
```
This ensures high performance and zero memory copying overhead.

### Usage Example
```ts
import Redis from "ioredis";

const redis = new Redis();

// 1. Set using a raw Uint8Array (which is not a Buffer)
const u8 = new Uint8Array([102, 111, 111]); // Represents 'foo'
await redis.set("binary-key", u8);

// 2. Read it back (returns a Buffer)
const result = await redis.getBuffer("binary-key");
console.log(result instanceof Buffer); // true
console.log(result.toString()); // 'foo'
```

### Changes
- Added helper file `lib/utils/buffer.ts` to recursively convert `Uint8Array` inside standard arrays, `Map`s, and plain object literals.
- Updated `CommandParameter` and `ArgumentType` to support `Uint8Array` types.
- Updated `Command` constructor to map command arguments and convert `options.keyPrefix`.
- Updated `stringifyArguments` to convert any remaining `Uint8Array` arguments to `Buffer`.
- Added unit tests in `test/unit/command.ts` to cover `Uint8Array` args, objects, maps, and key prefix inputs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized argument normalization and type extensions; existing Buffer paths unchanged, with unit tests covering encoding and cluster key extraction.
> 
> **Overview**
> Adds first-class support for **non-Buffer `Uint8Array`** values in Redis command arguments and `keyPrefix`, converting them to `Buffer` via zero-copy `Buffer.from(buffer, byteOffset, byteLength)` so binary payloads work without callers manually wrapping buffers.
> 
> New helpers in `lib/utils/buffer.ts` recursively normalize `Uint8Array` in arrays, plain objects, and `Map`s. `Command` applies this on flatten, in `stringifyArguments` (including buffer-mode wire encoding), and for `keyPrefix`. Auto-pipelining key/slot routing now normalizes `Uint8Array` keys the same way, with `getFirstKeyForCommand` exported for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4391f5ded8a386904afd5dae166d59a62ec9fb25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->