### PR TITLE
ci: update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v6
         with:
           node-version: "lts/*"
       - run: npm ci

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       # First step: Handle regular issues (excluding needs-information)
       - name: Mark regular issues as stale
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -64,7 +64,7 @@ jobs:
 
       # Second step: Handle needs-information issues with accelerated timeline
       - name: Mark needs-information issues as stale
-        uses: actions/stale@v9
+        uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
         node: [12.x, 14.x, 16.x, 18.x, 20.x]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.event.pull_request.head.ref || github.ref_name }} 
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -11,10 +11,10 @@ jobs:
         redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8.0"]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
 
@@ -31,7 +31,7 @@ jobs:
       - name: Coveralls
         if: matrix.node == '24.x'
         continue-on-error: true
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: node-${{matrix.node}}
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Coveralls
         continue-on-error: true
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only dependency version bumps with no application or secrets logic changes; main risk is transient CI breakage from action major-version behavior.
> 
> **Overview**
> Bumps third-party GitHub Actions across CI workflows so jobs run on current action releases aligned with newer GitHub-hosted Node runtimes (e.g. Node 24).
> 
> **Release** (`release.yml`): `actions/checkout` v2 → v6, `actions/setup-node` v2 → v6.
> 
> **Test** (`test.yml`, `test_with_cov.yml`): same checkout/setup-node upgrades (setup-node was v1 in test workflows).
> 
> **Coverage** (`test_with_cov.yml`): `coverallsapp/github-action` from `@master` to `@v2` in both the test matrix Coveralls step and the `code-coverage` finish job.
> 
> **Stale issues** (`stale-issues.yml`): `actions/stale` v9 → v10 in both stale-management steps; behavior and env timings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac4fbad02060b69b8b7cdf6a974d136c71b9afad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->