### PR TITLE
fix(redis): keep reconnecting when connection closes during client setup (#2099)

### DIFF
--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -112,6 +112,21 @@ export function connectHandler(self) {
     Promise.all(clientCommandPromises)
       .catch(noop)
       .finally(() => {
+        // The connection may have been closed (and possibly already
+        // reconnected) while the client setup commands above were still
+        // in flight. In that case this callback is stale and the
+        // connection is no longer the one we are setting up, so calling
+        // readyHandler() would mark a dead connection as "ready" and
+        // permanently stop reconnection. The enableReadyCheck branch
+        // below is already guarded by the same connectionEpoch check.
+        // See https://github.com/redis/ioredis/issues/2099
+        if (
+          connectionEpoch !== self.connectionEpoch ||
+          self.status !== "connect"
+        ) {
+          return;
+        }
+
         if (!self.options.enableReadyCheck) {
           exports.readyHandler(self)();
         }

--- a/test/functional/connection.ts
+++ b/test/functional/connection.ts
@@ -479,6 +479,57 @@ describe("connection", function () {
       });
     });
   });
+
+  describe("enableReadyCheck: false", function () {
+    it("keeps reconnecting after the connection is closed during client setup (#2099)", function (done) {
+      let clientSetupCommands = 0;
+      let connectionsAccepted = 0;
+
+      const server = new MockServer(30010, function (argv, socket, flags) {
+        if (String(argv[0]).toLowerCase() !== "client") {
+          return;
+        }
+        clientSetupCommands += 1;
+        if (clientSetupCommands === 1) {
+          // Drop the first connection while the CLIENT SETNAME handshake
+          // command is still in flight, before replying to it.
+          flags.hang = true;
+          socket.destroy();
+        }
+        // Later connections: reply "+OK" so the client can become ready.
+      });
+      server.on("connect", function () {
+        connectionsAccepted += 1;
+      });
+
+      const redis = new Redis(30010, {
+        enableReadyCheck: false,
+        disableClientInfo: true,
+        connectionName: "test-2099",
+        // Forces closeHandler() to flush the in-flight setup command on
+        // every close, which is what makes the connect-time readiness
+        // callback run after the connection has already gone away.
+        maxRetriesPerRequest: 0,
+        retryStrategy: () => 50,
+      });
+      redis.on("error", function () {});
+
+      redis.on("ready", function () {
+        // A genuine "ready" only happens if the client actually reconnected,
+        // i.e. the mock server accepted a second connection. With the bug the
+        // client wedges in the "ready" state on the dead first connection and
+        // never reconnects, so only one connection is ever accepted.
+        const err =
+          connectionsAccepted < 2
+            ? new Error(
+                "redis did not reconnect after the connection was closed during client setup"
+              )
+            : undefined;
+        redis.disconnect();
+        done(err);
+      });
+    });
+  });
 });
 
 describe("disconnection", function () {

--- a/test/functional/connection.ts
+++ b/test/functional/connection.ts
@@ -481,11 +481,11 @@ describe("connection", function () {
   });
 
   describe("enableReadyCheck: false", function () {
-    it("keeps reconnecting after the connection is closed during client setup (#2099)", function (done) {
+    it("keeps reconnecting after the connection is closed during client setup (#2099)", (done) => {
       let clientSetupCommands = 0;
       let connectionsAccepted = 0;
 
-      const server = new MockServer(30010, function (argv, socket, flags) {
+      const node = new MockServer(30010, function (argv, socket, flags) {
         if (String(argv[0]).toLowerCase() !== "client") {
           return;
         }
@@ -498,7 +498,7 @@ describe("connection", function () {
         }
         // Later connections: reply "+OK" so the client can become ready.
       });
-      server.on("connect", function () {
+      node.on("connect", function () {
         connectionsAccepted += 1;
       });
 


### PR DESCRIPTION
## Summary

Fixes #2099 — when `enableReadyCheck: false`, the client can permanently stop reconnecting after the socket closes during the `CLIENT SETNAME` / `CLIENT SETINFO` handshake.

`connectHandler()` (`lib/redis/event_handler.ts`) calls `readyHandler()` from `Promise.all(clientCommandPromises).finally()` without validating that the connection is still live. If the socket closes during that window and `closeHandler()` reaches the `maxRetriesPerRequest` threshold (default 20), it flushes the in-flight handshake commands. The individual handshake promises swallow rejection via `.catch(noop)`, so the flush settles `Promise.all` and runs the now-stale `.finally()`. By then `closeHandler()` has already moved status to `"reconnecting"` and scheduled a reconnect; the stale callback overwrites it with `"ready"` and resets `retryAttempts`. The pending `connect()` then rejects with "Redis is already connecting/connected" — swallowed by `.catch(noop)` — and no further reconnect is ever scheduled.

This regressed in #2033, which moved the handshake commands out of `readyHandler()` and made the `enableReadyCheck: false` readiness emission asynchronous. Detailed root-cause analysis is in [the issue comment](https://github.com/redis/ioredis/issues/2099#issuecomment-4262731864).

## Fix

Guard the `.finally()` callback the same way the `enableReadyCheck: true` ready-check callback (line 136) already is, plus a status check:

```js
if (
  connectionEpoch !== self.connectionEpoch ||
  self.status !== "connect"
) {
  return;
}
```

A stale callback becomes a no-op.

## Alignment with existing handshake / reconnect behavior

The fix deliberately reuses patterns already established in this file rather than introducing new mechanisms:

- **`connectionEpoch` guard** mirrors the existing guards in the AUTH callback (`event_handler.ts:29`) and the `_readyCheck` callback (`event_handler.ts:136`). Both are captured the same way (`const { connectionEpoch } = self;` at line 26) and compared identically.
- **`status !== "connect"` guard** is needed in addition to the epoch check because `connectionEpoch` is only incremented inside `_connect()` (`Redis.ts:210`). Between `closeHandler()` setting status to `"reconnecting"` and the reconnect timer firing `_connect()`, the epoch still matches the captured one — only the status reflects that the connection is no longer the one we're setting up. The status check covers exactly that window.
- **No behavior change on the live path:** when the connection is still healthy, both `connectionEpoch === self.connectionEpoch` and `self.status === "connect"` hold, so `readyHandler()` is called exactly as before.
- **No change to `closeHandler()`, `_connect()`, `flushQueue()`, or `readyHandler()`:** the bug is purely that a stale callback runs; the surrounding state machine already does the right thing on its own.
- **Symmetry with the `enableReadyCheck: true` branch:** that branch is naturally protected because `_readyCheck()` sends `INFO` and a dead socket cannot answer, and additionally re-checks `connectionEpoch` at line 136. The fix gives the `enableReadyCheck: false` branch equivalent protection (epoch + status) without introducing a synthetic round-trip.
- **#2040 is not affected:** it touched the same handshake-command flow but for a different `(p)subscribe`-during-`connect` race (#2037) and did not add a guard for the connection closing mid-handshake.

## Regression test

`test/functional/connection.ts` — `enableReadyCheck: false → keeps reconnecting after the connection is closed during client setup (#2099)`.

The test uses `MockServer` to deterministically reproduce the race:

- First connection: server destroys the socket while `CLIENT SETNAME` is in flight (`flags.hang = true; socket.destroy()`).
- Client config: `enableReadyCheck: false`, `disableClientInfo: true`, `connectionName: "test-2099"`, `maxRetriesPerRequest: 0`, `retryStrategy: () => 50`.
- `maxRetriesPerRequest: 0` is what makes the failure 100% deterministic — it forces `closeHandler()` to call `flushQueue()` on every close (`retryAttempts % (0 + 1) === 0` is always true), which is what surfaces the stale `.finally()` against the dead connection. With the default of 20, the same scenario only triggers every 21st failed attempt, which is why the issue reporter saw it intermittently when starting/stopping Redis.
- Assertion: a `"ready"` event is only emitted on a real reconnection (second `connect` accepted by the mock server). Without the fix, the client wedges in `"ready"` on the dead first connection and the test times out.

## Test plan

- [x] New regression test passes with the fix; fails without it (verified locally).
- [x] Full functional suite passes: `npm run test:js` — 713 passing.
- [x] Cluster suite passes: `npm run test:cluster` — 17 passing.
- [x] No changes outside `lib/redis/event_handler.ts` and `test/functional/connection.ts`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connect/ready/reconnect timing in event_handler.ts; behavior change is narrowly scoped to stale callbacks, with a targeted regression test.
> 
> **Overview**
> Fixes a reconnect wedge when **`enableReadyCheck: false`** and the socket dies during the post-connect **`CLIENT`** handshake (`SETNAME` / `SETINFO`).
> 
> In `connectHandler`, the `Promise.all(clientCommandPromises).finally()` path could still call **`readyHandler()`** after `closeHandler` had already moved the client to **`reconnecting`** and scheduled a retry—especially when in-flight setup commands are flushed (e.g. **`maxRetriesPerRequest`**). That stale callback marked a dead connection **`ready`** and reset retry state, so the client stopped reconnecting (#2099).
> 
> The change **bails out** of that `.finally()` unless **`connectionEpoch`** still matches and **`status === "connect"`**, mirroring guards already used for AUTH and the **`enableReadyCheck`** ready-check callback. A new functional test drops the first mock connection mid-**`CLIENT SETNAME`** and asserts a second connection reaches **`ready`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac232d3b2ae85a13981a9e1e099b20dfe9c90bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->