### PR TITLE
fix: parse protocol-relative Redis URLs as TCP connections

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -215,10 +215,14 @@ export function parseURL(url: string): Record<string, unknown> {
 
   // Determine if the URL has a known protocol (redis:// or rediss://)
   const hasProtocol = /^rediss?:\/\//i.test(rawUrl);
+  const isProtocolRelative = rawUrl.startsWith("//");
+  // TODO(next major): Consider rejecting protocol-relative Redis URLs early and
+  // requiring explicit redis:// or rediss:// schemes instead. Keep them working
+  // in 5.x for backward compatibility.
 
   // Unix socket paths (starting with "/") are not valid URLs — handle separately.
   // Preserve query params (e.g., /tmp/redis.sock?db=2)
-  if (rawUrl[0] === "/") {
+  if (rawUrl[0] === "/" && !isProtocolRelative) {
     const qIdx = rawUrl.indexOf("?");
     const result: Record<string, unknown> = {
       path: qIdx === -1 ? rawUrl : rawUrl.slice(0, qIdx),
@@ -237,6 +241,8 @@ export function parseURL(url: string): Record<string, unknown> {
   let parsed: URL;
   if (hasProtocol) {
     parsed = new URL(rawUrl);
+  } else if (isProtocolRelative) {
+    parsed = new URL("redis:" + rawUrl);
   } else {
     // Prepend a dummy protocol so new URL() can parse "host:port?query" correctly
     parsed = new URL("redis://" + rawUrl);
@@ -258,8 +264,9 @@ export function parseURL(url: string): Record<string, unknown> {
   }
 
   if (parsed.pathname && parsed.pathname !== "/") {
-    if (hasProtocol) {
-      // For redis:// and rediss://, the path after / is the db number
+    if (hasProtocol || isProtocolRelative) {
+      // For redis://, rediss://, and protocol-relative URLs, the path after /
+      // is the db number
       if (parsed.pathname.length > 1) {
         result.db = parsed.pathname.slice(1);
       }

--- a/test/unit/utils.ts
+++ b/test/unit/utils.ts
@@ -284,6 +284,24 @@ describe("utils", () => {
         host: "127.0.0.1",
         port: "6379",
       });
+      // TODO(next major): Consider rejecting protocol-relative Redis URLs early
+      // and requiring redis:// or rediss:// instead. Keep this behavior in 5.x
+      // for backward compatibility.
+      expect(utils.parseURL("//service-redis:6379")).to.eql({
+        host: "service-redis",
+        port: "6379",
+      });
+      expect(utils.parseURL("//pi.local:6379?family=4")).to.eql({
+        host: "pi.local",
+        port: "6379",
+        family: 4,
+      });
+      expect(utils.parseURL("//127.0.0.1:6379/4?key=value")).to.eql({
+        host: "127.0.0.1",
+        port: "6379",
+        db: "4",
+        key: "value",
+      });
       expect(utils.parseURL("127.0.0.1:6379?db=2&key=value")).to.eql({
         host: "127.0.0.1",
         port: "6379",


### PR DESCRIPTION
Fixes #2124

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized URL parsing fix with tests; no auth or connection logic changes beyond correct options for // URLs.
> 
> **Overview**
> **`parseURL`** now treats strings starting with **`//`** as protocol-relative Redis TCP URLs instead of Unix socket paths (which also start with `/`).
> 
> Those URLs are parsed with an implicit **`redis:`** scheme, so host, port, query options, and path-as-**`db`** behave like **`redis://`** / **`rediss://`**. Unix socket handling is unchanged for paths that are a single leading slash (e.g. **`/tmp.sock`**). Comments note a possible future major-version break: require explicit **`redis://`** / **`rediss://`** instead of **`//`**.
> 
> Unit tests cover **`//host:port`**, query params, and **`db`** in the path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032a8a14faabe4c390aa858719b40891ccac7c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->