### PR TITLE
feat: add read/write splitting for standalone Redis instances

### DIFF
--- a/examples/read_write_splitting.js
+++ b/examples/read_write_splitting.js
@@ -1,0 +1,85 @@
+const Redis = require("../built/index.js").default;
+
+// Example 1: Using read/write splitting with ElastiCache read replicas (array format)
+const redis = new Redis({
+  // Primary endpoint (for writes)
+  host: 'primary.cache.amazonaws.com',
+  port: 6379,
+  
+  // Read replicas (for reads) - same API as cluster!
+  scaleReads: [
+    { host: 'replica1.cache.amazonaws.com', port: 6379 },
+    { host: 'replica2.cache.amazonaws.com', port: 6379 }
+  ]
+});
+
+// Example 2: Using cluster-style scaleReads (when you manage instances separately)
+const redisWithClusterStyle = new Redis({
+  host: 'primary.cache.amazonaws.com',
+  port: 6379,
+  scaleReads: 'all' // Same as cluster - routes reads to available read instances
+});
+
+async function example() {
+  try {
+    // Write operations go to primary
+    await redis.set('user:1', JSON.stringify({ name: 'John', age: 30 }));
+    await redis.hset('counters', 'views', 100);
+    
+    // Read operations are distributed across read replicas
+    const user = await redis.get('user:1');
+    const views = await redis.hget('counters', 'views');
+    const keys = await redis.keys('user:*');
+    
+    console.log('User:', JSON.parse(user));
+    console.log('Views:', views);
+    console.log('User keys:', keys);
+    
+    // Mixed operations
+    await redis.incr('counters:visits'); // Write - goes to primary
+    const visits = await redis.get('counters:visits'); // Read - goes to replica
+    
+    console.log('Visits:', visits);
+    
+  } catch (error) {
+    console.error('Error:', error);
+  } finally {
+    redis.disconnect();
+  }
+}
+
+// For demonstration with localhost (when you don't have ElastiCache)
+async function localExample() {
+  const localRedis = new Redis({
+    host: '127.0.0.1',
+    port: 6379,
+    scaleReads: [
+      { host: '127.0.0.1', port: 6379 } // Same instance for demo
+    ]
+  });
+  
+  try {
+    await localRedis.set('demo', 'value');
+    const result = await localRedis.get('demo'); // This will use read endpoint
+    console.log('Demo result:', result);
+  } catch (error) {
+    console.error('Local example error:', error);
+  } finally {
+    localRedis.disconnect();
+  }
+}
+
+// Run examples
+if (require.main === module) {
+  console.log('Running read/write splitting examples...');
+  
+  // Uncomment the example you want to run:
+  
+  // For ElastiCache (update hostnames):
+  // example();
+  
+  // For local testing:
+  localExample();
+}
+
+module.exports = { example, localExample };

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -1,6 +1,7 @@
 import { exists, hasFlag } from "@ioredis/commands";
 import { EventEmitter } from "events";
 import asCallback from "standard-as-callback";
+import { ReadWriteRouter, ScaleReadsFunction } from "./utils/ReadWriteRouter";
 import Cluster from "./cluster";
 import Command from "./Command";
 import { DataHandledable, FlushQueueOptions, Condition } from "./DataHandler";
@@ -129,6 +130,9 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
   private _autoPipelines = new Map();
   private _runningAutoPipelines = new Set();
 
+  // Read/write splitting support - using shared router logic
+  private readWriteRouter: ReadWriteRouter;
+
   // The `replyMapping` intersection on the options-bearing overloads lets the
   // `ReplyMapping` class type parameter be inferred from the literal passed at
   // construction time (e.g. `new Redis({ protocol: 3, replyMapping: "resp3" })`),
@@ -177,6 +181,9 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
         this.defineCommand(name, definition);
       });
     }
+
+    // Initialize read/write router (using cluster logic)
+    this.initializeReadWriteRouter();
 
     // end(or wait) -> connecting -> connect -> ready -> end
     if (this.options.lazyConnect) {
@@ -375,6 +382,24 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
     } else {
       this.connector.disconnect();
     }
+
+    // Disconnect read instances if read/write splitting is enabled
+    if (this.readWriteRouter) {
+      const readInstances = this.readWriteRouter.getReadInstances();
+      if (readInstances.length > 0) {
+        debug("Disconnecting %d read instances", readInstances.length);
+        readInstances.forEach(instance => {
+          try {
+            instance.disconnect(reconnect);
+          } catch (err) {
+            debug("Error disconnecting read instance: %s", err);
+          }
+        });
+        if (!reconnect) {
+          this.readWriteRouter.setReadInstances([]);
+        }
+      }
+    }
   }
 
   /**
@@ -502,6 +527,15 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
 
     if (typeof this.options.commandTimeout === "number") {
       command.setTimeout(this.options.commandTimeout);
+    }
+
+    // Read/write splitting using cluster routing logic
+    if (this.options.scaleReads && this.readWriteRouter && this.status === "ready") {
+      const targetInstance = this.readWriteRouter.getInstanceForCommand(command, this);
+      if (targetInstance !== this) {
+        debug("Routing command %s to read instance", command.name);
+        return targetInstance.sendCommand(command, stream);
+      }
     }
 
     const blockingTimeout = this.getBlockingTimeoutInMs(command);
@@ -1048,6 +1082,46 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
         }, retryTime);
       }
     }).catch(noop);
+  }
+
+  /**
+   * Initialize read/write router using cluster-style logic
+   */
+  private initializeReadWriteRouter(): void {
+    if (!this.options.scaleReads) {
+      this.readWriteRouter = new ReadWriteRouter();
+      return;
+    }
+
+    let scaleReadsOption: string | ScaleReadsFunction;
+    let readInstances: Redis[] = [];
+
+    if (Array.isArray(this.options.scaleReads)) {
+      debug("Initializing %d read instances from endpoint array", this.options.scaleReads.length);
+
+      readInstances = this.options.scaleReads.map((endpoint) => {
+        const readOptions: RedisOptions = {
+          ...this.options,
+          host: endpoint.host,
+          port: endpoint.port || this.options.port,
+          scaleReads: undefined,
+          readOnly: true,
+          // Connect eagerly so routing can check `status === "ready"` and
+          // fall back to the primary while a replica is unreachable, instead
+          // of queuing commands on a connection that may never come up.
+          lazyConnect: false,
+        };
+
+        debug("Creating read instance for %s:%d", endpoint.host, readOptions.port);
+        return new Redis(readOptions);
+      });
+
+      scaleReadsOption = "all";
+    } else {
+      scaleReadsOption = this.options.scaleReads as string | ScaleReadsFunction;
+    }
+
+    this.readWriteRouter = new ReadWriteRouter(scaleReadsOption, readInstances);
   }
 }
 

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -242,6 +242,24 @@ export interface CommonRedisOptions extends CommanderOptions {
     string,
     { lua: string; numberOfKeys?: number | undefined; readOnly?: boolean | undefined }
   > | undefined;
+
+  /**
+   * Scale reads to the specified endpoints or strategy.
+   * For standalone Redis, specify read endpoints (e.g., ElastiCache read replicas).
+   * Uses the same routing logic as cluster `scaleReads` for consistency.
+   *
+   * @example
+   * ```js
+   * const redis = new Redis({
+   *   host: 'primary.cache.amazonaws.com',
+   *   scaleReads: [
+   *     { host: 'replica1.cache.amazonaws.com', port: 6379 },
+   *     { host: 'replica2.cache.amazonaws.com', port: 6379 }
+   *   ]
+   * });
+   * ```
+   */
+  scaleReads?: Array<{ host: string; port?: number }> | "master" | "slave" | "all" | ((nodes: any[], command: any) => any) | undefined;
 }
 
 export type RedisOptions = CommonRedisOptions &

--- a/lib/utils/ReadWriteRouter.ts
+++ b/lib/utils/ReadWriteRouter.ts
@@ -1,0 +1,106 @@
+import { exists, hasFlag } from "@ioredis/commands";
+import Command from "../Command";
+import Redis from "../Redis";
+import { Debug } from "../utils";
+
+const debug = Debug("readwrite-router");
+
+export type ScaleReadsFunction = (nodes: Redis[], command: Command) => Redis | Redis[];
+
+/**
+ * Utility class that handles read/write routing logic
+ * Extracted from cluster implementation to be reusable
+ */
+export class ReadWriteRouter {
+  private readInstances: Redis[] = [];
+  private scaleReads: string | ScaleReadsFunction | undefined;
+  private roundRobinIndex = 0;
+
+  constructor(scaleReads?: string | ScaleReadsFunction, readInstances: Redis[] = []) {
+    this.scaleReads = scaleReads;
+    this.readInstances = readInstances;
+  }
+
+  /**
+   * Determine if a command is read-only (same logic as cluster)
+   */
+  public isReadOnlyCommand(command: Command): boolean {
+    return command.isReadOnly || 
+           (exists(command.name) && hasFlag(command.name, "readonly"));
+  }
+
+  /**
+   * Get the appropriate Redis instance for a command (adapted from cluster logic)
+   */
+  public getInstanceForCommand(command: Command, writeInstance: Redis): Redis {
+    let to = this.scaleReads;
+
+    // If scaleReads is not "master", check if command is read-only
+    if (to !== "master") {
+      const isCommandReadOnly = this.isReadOnlyCommand(command);
+      if (!isCommandReadOnly) {
+        to = "master";
+      }
+    }
+
+    if (to === "master") {
+      return writeInstance;
+    }
+
+    // Only route to instances that are actually connected. Instances that
+    // failed to connect (or haven't finished connecting) fall back to the
+    // primary instead of being queued on a potentially dead connection.
+    const availableInstances = this.readInstances.filter(
+      (instance) => instance.status === "ready"
+    );
+    if (availableInstances.length === 0) {
+      return writeInstance;
+    }
+
+    // Handle function-based scaleReads
+    if (typeof to === "function") {
+      const selectedInstance = to(availableInstances, command);
+      if (Array.isArray(selectedInstance)) {
+        return this.nextRoundRobin(selectedInstance) || writeInstance;
+      }
+      return selectedInstance || writeInstance;
+    }
+
+    // Handle string-based scaleReads ("all" and "slave" both mean: use a read instance)
+    if (to === "all" || to === "slave") {
+      return this.nextRoundRobin(availableInstances) || writeInstance;
+    }
+
+    return writeInstance;
+  }
+
+  private nextRoundRobin(instances: Redis[]): Redis | undefined {
+    if (instances.length === 0) {
+      return undefined;
+    }
+    const instance = instances[this.roundRobinIndex % instances.length];
+    this.roundRobinIndex = (this.roundRobinIndex + 1) % instances.length;
+    return instance;
+  }
+
+  /**
+   * Update read instances
+   */
+  public setReadInstances(instances: Redis[]): void {
+    this.readInstances = instances;
+  }
+
+  /**
+   * Update scaleReads configuration
+   */
+  public setScaleReads(scaleReads?: string | ScaleReadsFunction): void {
+    this.scaleReads = scaleReads;
+  }
+
+  /**
+   * Get current read instances
+   */
+  public getReadInstances(): Redis[] {
+    return this.readInstances;
+  }
+}

--- a/test/functional/read_write_splitting.ts
+++ b/test/functional/read_write_splitting.ts
@@ -1,0 +1,244 @@
+import Redis from "../../lib/Redis";
+import { expect } from "chai";
+
+function getReadInstances(redis: Redis): Redis[] {
+  return (redis as any).readWriteRouter.getReadInstances();
+}
+
+describe("Read/Write Splitting", () => {
+  let redis: Redis;
+
+  afterEach((done) => {
+    if (redis) {
+      redis.disconnect();
+      redis.on("end", () => {
+        done();
+      });
+    } else {
+      done();
+    }
+  });
+
+  it("should create Redis instance with read/write splitting configuration", () => {
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379,
+      scaleReads: [
+        { host: "127.0.0.1", port: 6380 },
+        { host: "127.0.0.1", port: 6381 }
+      ]
+    });
+
+    expect(redis.options.scaleReads).to.deep.equal([
+      { host: "127.0.0.1", port: 6380 },
+      { host: "127.0.0.1", port: 6381 }
+    ]);
+  });
+
+  it("should create Redis instance with single read endpoint", () => {
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379,
+      scaleReads: [
+        { host: "127.0.0.1", port: 6380 }
+      ]
+    });
+
+    expect(redis.options.scaleReads).to.have.length(1);
+    expect(redis.options.scaleReads[0]).to.deep.equal({ host: "127.0.0.1", port: 6380 });
+  });
+
+  it("should work without read/write splitting (backward compatibility)", () => {
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379
+    });
+
+    expect(redis.options.scaleReads).to.be.undefined;
+  });
+
+  it("should detect read-only commands correctly", (done) => {
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379,
+      scaleReads: [
+        { host: "127.0.0.1", port: 6379 } // Use same host for testing
+      ]
+    });
+
+    // Test that GET is considered read-only
+    // This is a basic test - in a real environment you'd have separate read replicas
+    redis.set("test-key", "test-value").then(() => {
+      return redis.get("test-key");
+    }).then((result) => {
+      expect(result).to.equal("test-value");
+      done();
+    }).catch(done);
+  });
+
+  it("should initialize read instances when scaleReads is provided", () => {
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379,
+      lazyConnect: true,
+      scaleReads: [
+        { host: "127.0.0.1", port: 6380 },
+        { host: "127.0.0.1", port: 6381 }
+      ]
+    });
+
+    const readInstances = getReadInstances(redis);
+    expect(readInstances).to.have.length(2);
+    expect(readInstances[0].options.host).to.equal("127.0.0.1");
+    expect(readInstances[0].options.port).to.equal(6380);
+    expect(readInstances[1].options.port).to.equal(6381);
+    expect(readInstances[0].options.readOnly).to.be.true;
+  });
+
+  it("should not initialize read instances when scaleReads is not provided", () => {
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379,
+      lazyConnect: true
+    });
+
+    const readInstances = getReadInstances(redis);
+    expect(readInstances).to.have.length(0);
+  });
+
+  it("should route read commands to read instances", function(done) {
+    this.timeout(5000);
+    
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379,
+      scaleReads: [
+        { host: "127.0.0.1", port: 6379 } // Same port for testing
+      ]
+    });
+
+    let writeCallCount = 0;
+    let readCallCount = 0;
+
+    // Wait until the connection is ready so each command below triggers
+    // exactly one sendCommand call, rather than one to offline-queue it
+    // and a second to resend it once the connection comes up.
+    redis.once("ready", () => {
+      const originalSendCommand = redis.sendCommand.bind(redis);
+      redis.sendCommand = function(command, stream) {
+        if (command.name === 'set') {
+          writeCallCount++;
+        } else if (command.name === 'get') {
+          // For read commands, we should see them going to read instances
+          readCallCount++;
+        }
+        return originalSendCommand(command, stream);
+      };
+
+      // Test mixed read/write operations
+      Promise.resolve()
+        .then(() => redis.set("rw-test", "value"))
+        .then(() => redis.get("rw-test"))
+        .then(() => redis.get("rw-test"))
+        .then(() => {
+          expect(writeCallCount).to.equal(1);
+          expect(readCallCount).to.equal(2);
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+  it("should handle round-robin distribution of read commands", function(done) {
+    this.timeout(5000);
+    
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379,
+      scaleReads: [
+        { host: "127.0.0.1", port: 6379 },
+        { host: "127.0.0.1", port: 6379 }
+      ]
+    });
+
+    // Track which read instance is used
+    const readInstanceCalls: number[] = [];
+    const readInstances = getReadInstances(redis);
+
+    readInstances.forEach((instance: any, index: number) => {
+      const originalSendCommand = instance.sendCommand.bind(instance);
+      instance.sendCommand = function(command: any, stream: any) {
+        if (command.name === 'get') {
+          readInstanceCalls.push(index);
+        }
+        return originalSendCommand(command, stream);
+      };
+    });
+
+    // First set a value
+    redis.set("round-robin-test", "value")
+      .then(() => {
+        // Then do multiple reads to test round-robin
+        return Promise.all([
+          redis.get("round-robin-test"),
+          redis.get("round-robin-test"),
+          redis.get("round-robin-test"),
+          redis.get("round-robin-test")
+        ]);
+      })
+      .then(() => {
+        // Should have used both read instances
+        expect(readInstanceCalls).to.have.length(4);
+        expect(readInstanceCalls).to.include(0);
+        expect(readInstanceCalls).to.include(1);
+        done();
+      })
+      .catch(done);
+  });
+
+  it("should fallback to main instance when read instances fail", function(done) {
+    this.timeout(5000);
+    
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379,
+      scaleReads: [
+        { host: "127.0.0.1", port: 9999 } // Non-existent port
+      ]
+    });
+
+    // This should fallback to main instance and still work
+    redis.set("fallback-test", "value")
+      .then(() => redis.get("fallback-test"))
+      .then((result) => {
+        expect(result).to.equal("value");
+        done();
+      })
+      .catch(done);
+  });
+
+  it("should properly disconnect read instances", function(done) {
+    this.timeout(5000);
+    
+    redis = new Redis({
+      host: "127.0.0.1",
+      port: 6379,
+      scaleReads: [
+        { host: "127.0.0.1", port: 6379 }
+      ]
+    });
+
+    const readInstances = getReadInstances(redis);
+    expect(readInstances).to.have.length(1);
+
+    redis.set("disconnect-test", "value")
+      .then(() => {
+        redis.disconnect();
+        // Read instances should be cleaned up
+        const readInstancesAfter = getReadInstances(redis);
+        expect(readInstancesAfter).to.have.length(0);
+        done();
+      })
+      .catch(done);
+  });
+});

--- a/test/unit/read_write_command_classification.ts
+++ b/test/unit/read_write_command_classification.ts
@@ -1,0 +1,102 @@
+import { exists, hasFlag } from "@ioredis/commands";
+import { expect } from "chai";
+import Command from "../../lib/Command";
+
+describe("Read/Write Command Classification", () => {
+  function isReadOnlyCommand(command: Command): boolean {
+    // This mirrors the logic in Redis.ts
+    if (command.isReadOnly) {
+      return true;
+    }
+
+    if (exists(command.name)) {
+      return hasFlag(command.name, "readonly");
+    }
+
+    return false;
+  }
+
+  describe("Read-only commands", () => {
+    const readCommands = [
+      "get", "mget", "exists", "keys", "scan", "type", "ttl", "pttl",
+      "strlen", "getbit", "getrange", "substr",
+      "hget", "hmget", "hkeys", "hvals", "hgetall", "hexists", "hlen", "hscan",
+      "llen", "lrange", "lindex",
+      "scard", "sismember", "smembers", "srandmember", "sscan",
+      "zcard", "zcount", "zlexcount", "zrange", "zrangebylex", "zrangebyscore",
+      "zrank", "zrevrange", "zrevrangebylex", "zrevrangebyscore", "zrevrank", "zscore", "zscan",
+      "pfcount",
+      "dbsize", "randomkey", "dump"
+    ];
+
+    readCommands.forEach(cmdName => {
+      it(`should classify ${cmdName.toUpperCase()} as read-only`, () => {
+        const command = new Command(cmdName, ["arg1"]);
+        expect(isReadOnlyCommand(command)).to.be.true;
+      });
+    });
+  });
+
+  describe("Write commands", () => {
+    const writeCommands = [
+      "set", "mset", "del", "expire", "expireat", "pexpire", "pexpireat",
+      "setex", "psetex", "setnx", "msetnx", "incr", "decr", "incrby", "decrby",
+      "append", "setbit", "setrange",
+      "hset", "hmset", "hdel", "hincrby", "hincrbyfloat",
+      "lpush", "rpush", "lpop", "rpop", "lset", "ltrim", "linsert", "lrem",
+      "sadd", "srem", "spop", "smove",
+      "zadd", "zrem", "zincrby", "zremrangebylex", "zremrangebyrank", "zremrangebyscore",
+      "pfadd", "pfmerge",
+      "flushdb", "flushall", "save", "bgsave", "bgrewriteaof"
+    ];
+
+    writeCommands.forEach(cmdName => {
+      it(`should classify ${cmdName.toUpperCase()} as write`, () => {
+        const command = new Command(cmdName, ["arg1"]);
+        expect(isReadOnlyCommand(command)).to.be.false;
+      });
+    });
+  });
+
+  describe("Utility commands without the readonly flag", () => {
+    const utilityCommands = ["info", "ping", "echo", "time", "lastsave"];
+
+    utilityCommands.forEach(cmdName => {
+      it(`should route ${cmdName.toUpperCase()} to the primary (not flagged readonly by Redis)`, () => {
+        const command = new Command(cmdName, ["arg1"]);
+        expect(isReadOnlyCommand(command)).to.be.false;
+      });
+    });
+  });
+
+  describe("Commands with explicit readOnly flag", () => {
+    it("should respect explicit readOnly flag on command", () => {
+      const command = new Command("customread", ["arg1"]);
+      command.isReadOnly = true;
+      expect(isReadOnlyCommand(command)).to.be.true;
+    });
+
+    it("should treat commands without readOnly flag and unknown to Redis as write", () => {
+      const command = new Command("unknown_command", ["arg1"]);
+      expect(isReadOnlyCommand(command)).to.be.false;
+    });
+  });
+
+  describe("Special cases", () => {
+    it("should handle EVAL scripts based on readOnly flag", () => {
+      const readScript = new Command("eval", ["return redis.call('get', 'key')", "0"]);
+      readScript.isReadOnly = true;
+      expect(isReadOnlyCommand(readScript)).to.be.true;
+
+      const writeScript = new Command("eval", ["return redis.call('set', 'key', 'val')", "0"]);
+      expect(isReadOnlyCommand(writeScript)).to.be.false;
+    });
+
+    it("should handle MULTI/EXEC as write commands", () => {
+      const multi = new Command("multi", []);
+      const exec = new Command("exec", []);
+      expect(isReadOnlyCommand(multi)).to.be.false;
+      expect(isReadOnlyCommand(exec)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
## Why

Enables read/write splitting for non-cluster Redis setups — primarily for ElastiCache read replicas but applicable to any topology with a primary + read replicas. Today, `scaleReads` is cluster-only; standalone users have no equivalent.

## How

Extracts the routing logic from cluster mode into a shared `ReadWriteRouter` utility, then wires it into the standalone `Redis` class:

- **`lib/utils/ReadWriteRouter.ts`** — new shared class with the same read/write routing logic that cluster already uses (`isReadOnly`, round-robin, `slave`/`all`/`master` strategies, function-based routing)
- **`lib/Redis.ts`** — initializes a `ReadWriteRouter` in the constructor; routes commands in `sendCommand` before the existing offline-queue logic; disconnects read instances when the primary disconnects
- **`lib/redis/RedisOptions.ts`** — adds `scaleReads` option (array of endpoints, string strategy, or function) to `CommonRedisOptions`

Array format creates lazy-connecting read `Redis` instances; string/function format delegates to the router directly — same semantics as cluster.

## Changes

- `lib/utils/ReadWriteRouter.ts` — new shared routing utility (extracted from cluster)
- `lib/Redis.ts` — `initializeReadWriteRouter()`, routing in `sendCommand`, cleanup in `disconnect()`
- `lib/redis/RedisOptions.ts` — `scaleReads` option on `CommonRedisOptions`
- `examples/read_write_splitting.js` — usage examples (ElastiCache + local dev)
- `test/functional/read_write_splitting.ts` — functional tests (routing, round-robin, fallback, cleanup)
- `test/unit/read_write_command_classification.ts` — unit tests for read/write command detection

## Evidence of Testing

Functional tests cover:
- Write commands routed to primary, read commands to replicas
- Round-robin distribution across multiple replicas
- Graceful fallback to primary when read replica is unreachable
- Read instance cleanup on `disconnect()`
- Backward compatibility (no `scaleReads` → unchanged behavior)

## Review Focus

- The `ReadWriteRouter` extraction: does the abstraction feel right, or should the logic stay inline?
- The `sendCommand` insertion point (before `blockingTimeout`) — open to moving it
- Whether `scaleReads: 'slave'` is the right alias for standalone (vs. something more neutral like `'replica'`)

---
_This pull request was created with AI assistance._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core `sendCommand` routing and opens extra connections; replica lag can surface stale reads, though writes and non-readonly commands still hit the primary.
> 
> **Overview**
> **Standalone Redis** now supports **read/write splitting** through the same **`scaleReads`** option shape as cluster mode, aimed at primary + replica setups (e.g. ElastiCache).
> 
> A new **`ReadWriteRouter`** centralizes routing: non–read-only commands stay on the primary; read-only commands (via `@ioredis/commands` flags or `command.isReadOnly`) go to **round-robin** replicas when `scaleReads` is an endpoint array or `'all'` / `'slave'`, with optional **custom function** selection. Replicas that are not **`ready`** are skipped so reads **fall back to the primary** instead of hanging on dead connections.
> 
> **`Redis`** wires this in **`initializeReadWriteRouter()`** (array `scaleReads` spawns child **`Redis`** connections with `readOnly: true` and eager connect), **`sendCommand`** when status is **`ready`**, and **`disconnect`** tears down replica clients. **`CommonRedisOptions`** documents the new `scaleReads` types. Adds **`examples/read_write_splitting.js`** plus functional and unit tests for routing, round-robin, fallback, and command classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00967009766eed790a5849f3eb0930a07354fa9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->