### PR TITLE
fix(sentinel): preserve zero preferred slave priority

### DIFF
--- a/lib/connectors/SentinelConnector/index.ts
+++ b/lib/connectors/SentinelConnector/index.ts
@@ -405,24 +405,20 @@ function selectPreferredSentinel(
     selectedSlave = preferredSlaves(availableSlaves);
   } else if (preferredSlaves !== null && typeof preferredSlaves === "object") {
     const preferredSlavesArray = Array.isArray(preferredSlaves)
-      ? preferredSlaves
+      ? [...preferredSlaves]
       : [preferredSlaves];
 
     // sort by priority
     preferredSlavesArray.sort((a, b) => {
       // default the priority to 1
-      if (!a.prio) {
-        a.prio = 1;
-      }
-      if (!b.prio) {
-        b.prio = 1;
-      }
+      const aPrio = a.prio ?? 1;
+      const bPrio = b.prio ?? 1;
 
       // lowest priority first
-      if (a.prio < b.prio) {
+      if (aPrio < bPrio) {
         return -1;
       }
-      if (a.prio > b.prio) {
+      if (aPrio > bPrio) {
         return 1;
       }
       return 0;

--- a/test/functional/sentinel.ts
+++ b/test/functional/sentinel.ts
@@ -422,6 +422,55 @@ describe("sentinel", () => {
       });
     });
 
+    it("should preserve zero preferred slave priority without mutating options", async () => {
+      const preferredSlaves = [
+        { ip: "127.0.0.1", port: "17382" },
+        { ip: "127.0.0.1", port: "17383", prio: 0 },
+      ];
+      const originalPreferredSlaves = preferredSlaves.map((slave) => ({
+        ...slave,
+      }));
+
+      const sentinel = new MockServer(27379, (argv) => {
+        if (
+          argv[0] === "sentinel" &&
+          argv[1] === "slaves" &&
+          argv[2] === "master"
+        ) {
+          return [
+            ["ip", "127.0.0.1", "port", "17382", "flags", "slave"],
+            ["ip", "127.0.0.1", "port", "17383", "flags", "slave"],
+          ];
+        }
+      });
+      const defaultPrioritySlave = new MockServer(17382);
+      const zeroPrioritySlave = new MockServer(17383);
+
+      const redis = new Redis({
+        sentinels: [{ host: "127.0.0.1", port: 27379 }],
+        name: "master",
+        role: "slave",
+        preferredSlaves,
+      });
+
+      try {
+        const selectedPort = await Promise.race([
+          once(defaultPrioritySlave, "connect").then(() => "17382"),
+          once(zeroPrioritySlave, "connect").then(() => "17383"),
+        ]);
+
+        expect(selectedPort).to.eql("17383");
+        expect(preferredSlaves).to.deep.equal(originalPreferredSlaves);
+      } finally {
+        redis.disconnect();
+        await Promise.all([
+          sentinel.disconnectPromise(),
+          defaultPrioritySlave.disconnectPromise(),
+          zeroPrioritySlave.disconnectPromise(),
+        ]);
+      }
+    });
+
     it("should connect to the slave successfully based on preferred slave filter function", (done) => {
       new MockServer(27379, (argv) => {
         if (


### PR DESCRIPTION
Fixes #2128

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Sentinel slave selection with a targeted regression test; affects only `role: "slave"` preferred-slave ordering.
> 
> **Overview**
> Fixes **preferred slave selection** when `prio` is `0` and stops **mutating** the caller’s `preferredSlaves` option during sorting.
> 
> `selectPreferredSentinel` now copies the preferred-slaves array before sort, uses `a.prio ?? 1` / `b.prio ?? 1` for ordering (so `0` sorts ahead of default `1`), and no longer writes `prio` onto the original option objects. A functional test asserts a `prio: 0` entry is chosen over a default-priority peer and that `preferredSlaves` is unchanged after connect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c936776838aaf361e14e3c42533034f6359ebef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->