### PR TITLE
Prevent timed-out offline commands from replaying

### DIFF
--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -487,7 +487,11 @@ export default class Command implements Respondable {
 
       this.resolve = this._convertValue(resolve);
       this.reject = (err: Error) => {
+        if (this.isResolved) {
+          return;
+        }
         this._clearTimers();
+        this.isResolved = true;
         if (this.errorStack) {
           reject(optimizeErrorStack(err, this.errorStack.stack, __dirname));
         } else {

--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -212,6 +212,7 @@ export default class Command implements Respondable {
   resolve: (result: any) => void;
   promise: Promise<any>;
 
+  isSettled = false;
   private replyEncoding: BufferEncoding | null;
   private errorStack: Error;
   private bufferMode: boolean;
@@ -375,7 +376,7 @@ export default class Command implements Respondable {
   setTimeout(ms: number) {
     if (!this._commandTimeoutTimer) {
       this._commandTimeoutTimer = setTimeout(() => {
-        if (!this.isResolved) {
+        if (!this.isSettled) {
           this.reject(new Error("Command timed out"));
         }
       }, ms);
@@ -415,7 +416,7 @@ export default class Command implements Respondable {
     }
 
     this._blockingTimeoutTimer = setTimeout(() => {
-      if (this.isResolved) {
+      if (this.isSettled) {
         this._blockingTimeoutTimer = undefined;
         return;
       }
@@ -475,6 +476,8 @@ export default class Command implements Respondable {
   }
 
   private initPromise() {
+    this.isResolved = false;
+    this.isSettled = false;
     const promise = new Promise((resolve, reject) => {
       if (!this.transformed) {
         this.transformed = true;
@@ -487,11 +490,11 @@ export default class Command implements Respondable {
 
       this.resolve = this._convertValue(resolve);
       this.reject = (err: Error) => {
-        if (this.isResolved) {
+        if (this.isSettled) {
           return;
         }
         this._clearTimers();
-        this.isResolved = true;
+        this.isSettled = true;
         if (this.errorStack) {
           reject(optimizeErrorStack(err, this.errorStack.stack, __dirname));
         } else {
@@ -530,10 +533,14 @@ export default class Command implements Respondable {
    */
   private _convertValue(resolve: Function): (result: any) => void {
     return (value) => {
+      if (this.isSettled) {
+        return this.promise;
+      }
       try {
         this._clearTimers();
         resolve(this.transformReply(value));
         this.isResolved = true;
+        this.isSettled = true;
       } catch (err) {
         this.reject(err);
       }

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -443,7 +443,7 @@ class Redis extends Commander implements DataHandledable {
    * @ignore
    */
   sendCommand(command: Command, stream?: WriteableStream): unknown {
-    if (command.isResolved) {
+    if (command.isSettled) {
       return command.promise;
     }
     if (this.status === "wait") {

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -443,6 +443,9 @@ class Redis extends Commander implements DataHandledable {
    * @ignore
    */
   sendCommand(command: Command, stream?: WriteableStream): unknown {
+    if (command.isResolved) {
+      return command.promise;
+    }
     if (this.status === "wait") {
       this.connect().catch(noop);
     }

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -509,7 +509,7 @@ class Cluster extends Commander {
    * @ignore
    */
   sendCommand(command: Command, stream?: WriteableStream, node?: any): unknown {
-    if (command.isResolved) {
+    if (command.isSettled) {
       return command.promise;
     }
     if (this.status === "wait") {

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -509,6 +509,9 @@ class Cluster extends Commander {
    * @ignore
    */
   sendCommand(command: Command, stream?: WriteableStream, node?: any): unknown {
+    if (command.isResolved) {
+      return command.promise;
+    }
     if (this.status === "wait") {
       this.connect().catch(noop);
     }

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -14,8 +14,11 @@ export interface CommonRedisOptions extends CommanderOptions {
   retryStrategy?: RetryStrategy;
 
   /**
-   * If a command does not return a reply within a set number of milliseconds,
+   * If a command is not completed within a set number of milliseconds,
    * a "Command timed out" error will be thrown.
+   *
+   * This timer starts when the command is issued, so it includes time spent
+   * waiting in the offline queue for reconnect/ready state.
    */
   commandTimeout?: number | undefined;
 

--- a/test/functional/commandTimeout.ts
+++ b/test/functional/commandTimeout.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import * as net from "net";
 import * as sinon from "sinon";
 import Redis from "../../lib/Redis";
 import MockServer from "../helpers/mock_server";
@@ -33,5 +34,70 @@ describe("commandTimeout", () => {
     clock.restore();
     redis.disconnect();
     await server.disconnectPromise();
+  });
+
+  it("does not replay a timed-out command from the offline queue", async () => {
+    const writes: string[] = [];
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.on("close", () => sockets.delete(socket));
+      socket.on("data", (data) => {
+        writes.push(data.toString());
+        socket.write("+OK\r\n");
+      });
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve)
+    );
+    const { port } = server.address() as net.AddressInfo;
+
+    class DelayedConnector {
+      private stream?: net.Socket;
+
+      check() {
+        return true;
+      }
+
+      disconnect() {
+        this.stream?.destroy();
+      }
+
+      connect() {
+        return new Promise<net.Socket>((resolve) => {
+          setTimeout(() => {
+            const stream = net.createConnection({ port, host: "127.0.0.1" });
+            this.stream = stream;
+            stream.once("connect", () => resolve(stream));
+          }, 50);
+        });
+      }
+    }
+
+    const redis = new Redis({
+      Connector: DelayedConnector,
+      lazyConnect: true,
+      commandTimeout: 20,
+      enableReadyCheck: false,
+      disableClientInfo: true,
+      retryStrategy: null,
+    });
+
+    try {
+      let error: Error | undefined;
+      await redis.set("side-effect-key", "value").catch((err) => {
+        error = err;
+      });
+      expect(error?.message).to.eql("Command timed out");
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(writes).to.eql([]);
+    } finally {
+      redis.disconnect();
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 });


### PR DESCRIPTION
## Summary

This preserves the existing `commandTimeout` semantics as a total command lifetime timeout, including time spent waiting in the offline queue, but prevents a command that has already timed out from being replayed later when the connection becomes ready.

Fixes #2130.

## Details

- Mark rejected commands as settled so timeout rejection is a terminal command state.
- Return early from standalone and cluster `sendCommand()` when the command is already settled, before queueing or writing it again.
- Clarify the `commandTimeout` option docs to state that the timer starts when the command is issued and includes offline queue / reconnect wait.
- Add a regression test with a delayed connector: the command times out while queued offline, then the connection becomes ready, and the server must not receive the already-timed-out command.

## Tests

```bash
npm run build
TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test npx mocha --no-experimental-strip-types "test/functional/commandTimeout.ts"
TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test npx mocha --no-experimental-strip-types "test/unit/command.ts" "test/unit/redis.ts"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core command lifecycle and send paths for standalone and cluster clients; behavior change is narrow (already-rejected commands) but affects reconnect/offline-queue replay semantics.
> 
> **Overview**
> Fixes a case where a command that hit **`commandTimeout` while sitting in the offline queue** could still be sent to Redis after the connection became ready, even though the caller had already received **"Command timed out"**.
> 
> **`Command`** now tracks **`isSettled`** as a terminal state on reject/resolve (including timeout rejection), with guards so settled commands are not resolved/rejected again. Command and blocking timeout handlers use **`isSettled`** instead of **`isResolved`**.
> 
> **`Redis.sendCommand`** and **`Cluster.sendCommand`** return the existing promise immediately when **`command.isSettled`**, so flushed/replayed offline commands are not queued or written again.
> 
> **`commandTimeout`** docs now state the timer starts when the command is issued and counts offline-queue wait. A functional test uses a delayed connector to assert the server receives no bytes after a timed-out offline **`set`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 034ebcc045931a321357c78575b40aece50ee874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->