### PR TITLE
fix(tracing): redact values for GETSET and PSETEX

### DIFF
--- a/lib/tracing.ts
+++ b/lib/tracing.ts
@@ -10,7 +10,8 @@ import type { CommandParameter } from "./types";
 const SERIALIZATION_SUBSETS: Array<{ regex: RegExp; args: number }> = [
   { regex: /^ECHO/i, args: 0 },
   {
-    regex: /^(LPUSH|MSET|PFA|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i,
+    regex:
+      /^(GETSET|LPUSH|MSET|PFA|PSETEX|PUBLISH|RPUSH|SADD|SET|SPUBLISH|XADD|ZADD)/i,
     args: 1,
   },
   { regex: /^(HSET|HMSET|LSET|LINSERT)/i, args: 2 },

--- a/test/functional/tracing.ts
+++ b/test/functional/tracing.ts
@@ -393,6 +393,25 @@ describeOrSkip("tracing", function () {
       ]);
     });
 
+    it("should keep key but redact value for GETSET", function () {
+      expect(sanitizeArgs("getset", ["mykey", "secret"])).to.eql([
+        "mykey",
+        "?",
+      ]);
+      expect(sanitizeArgs("GETSET", ["mykey", "secret"])).to.eql([
+        "mykey",
+        "?",
+      ]);
+    });
+
+    it("should keep key but redact value for PSETEX", function () {
+      expect(sanitizeArgs("psetex", ["mykey", "300000", "secret"])).to.eql([
+        "mykey",
+        "?",
+        "?",
+      ]);
+    });
+
     it("should keep key but redact values for LPUSH with multiple elements", function () {
       expect(sanitizeArgs("lpush", ["mylist", "a", "b", "c"])).to.eql([
         "mylist",


### PR DESCRIPTION
The command tracing added in #2089 sanitizes argument values before emitting them on the `ioredis:command` diagnostics channel, so secrets are not leaked to APM/observability subscribers. The README states values in commands like `SET` are replaced with `?`. Two write commands slip through and emit their value in plaintext:

```
GETSET mykey <SECRET>          -> traced as ["mykey", "<SECRET>"]      (expected ["mykey", "?"])
PSETEX mykey 300000 <SECRET>   -> traced as ["mykey", "300000", "<SECRET>"] (expected ["mykey", "?", "?"])
```

`GETSET` and `PSETEX` are just `SET`-with-return and `SET`-with-expiry, so their value is as sensitive as `SET`'s.

## Cause

In `lib/tracing.ts`, `SERIALIZATION_SUBSETS` is matched first-hit-wins. `GETSET` and `PSETEX` are absent from the `args: 1` (redact values, keep key) group, so they fall through to the broad `args: -1` (retain all) rule via its `GET` and `P[EFISTU]` prefixes. This also diverges from the upstream `@opentelemetry/redis-common` serialization subsets the file states it adapts, which place both `GETSET` and `PSETEX` in the redact-values group.

## Fix

Add `GETSET` and `PSETEX` to the `args: 1` regex, matching upstream. `SET`/`SETEX`/`SETNX` were already covered; this only closes the two-command gap.

## Testing

Added cases to the existing `sanitizeArgs` describe block in `test/functional/tracing.ts` asserting the key is kept and the value is redacted for `GETSET` and `PSETEX`. They fail on the current code (value emitted verbatim) and pass with the fix; the full `sanitizeArgs` block stays green, and `GETDEL`/`GETRANGE`/`PTTL`/`PERSIST` still return all args (no shadowing).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow observability sanitization fix with tests; no runtime command behavior or auth/data-path changes.
> 
> **Overview**
> **GETSET** and **PSETEX** were leaking value arguments on the `ioredis:command` tracing channel because they were not in the `args: 1` sanitization group and instead matched the broad read-only rule (`GET` / `P*` prefixes), which keeps all arguments visible.
> 
> This PR adds both commands to the same `args: 1` regex as **SET** and related write commands in `lib/tracing.ts`, so only the key is emitted and TTL/value args become `?`. Functional tests in `test/functional/tracing.ts` lock in the expected `sanitizeArgs` output for lowercase and uppercase command names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4391821fa196bc56cb47b4a829cfad51b94b8d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->