### PR TITLE
fix(cluster): recreate stale connection on circular MOVED

### DIFF
--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -129,6 +129,10 @@ export default class ConnectionPool extends EventEmitter {
       this.nodes[readOnly ? "slave" : "master"][key] = redis;
 
       redis.once("end", () => {
+        if (this.nodes.all[key] && this.nodes.all[key] !== redis) {
+          // The node was recreated (see `recreate`); leave the new one alone.
+          return;
+        }
         this.removeNode(key);
         this.emit("-node", redis, key);
         if (!Object.keys(this.nodes.all).length) {
@@ -143,6 +147,30 @@ export default class ConnectionPool extends EventEmitter {
       });
     }
 
+    return redis;
+  }
+
+  /**
+   * Replace the connection to the node with a fresh one. Used when the
+   * existing connection is known to be stale, e.g. after a MOVED redirect
+   * that points back at the node it came from.
+   */
+  recreate(node: RedisOptions, readOnly = false): Redis {
+    const key = getNodeKey(node);
+    const existing = this.nodes.all[key];
+    if (existing) {
+      debug("Recreating connection to %s", key);
+      // Remove before disconnecting so the "end" event of the stale
+      // instance doesn't tear down the replacement.
+      this.removeNode(key);
+      existing.disconnect();
+    }
+    const redis = this.findOrCreate(node, readOnly);
+    if (existing) {
+      // Emit after the replacement is in place so listeners (e.g.
+      // ClusterSubscriber) never observe the pool without the node.
+      this.emit("-node", existing, key);
+    }
     return redis;
   }
 

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -27,6 +27,7 @@ import ConnectionPool from "./ConnectionPool";
 import DelayQueue from "./DelayQueue";
 import {
   getConnectionName,
+  getNodeKey,
   getUniqueHostnamesFromOptions,
   groupSrvRecords,
   NodeKey,
@@ -529,6 +530,9 @@ class Cluster extends Commander {
     let targetSlot = node ? node.slot : command.getSlot();
     const ttl = {};
     const _this = this;
+    // The connection the command was last sent on, used to detect
+    // MOVED redirects that point back at the same node.
+    let lastRedis: Redis | null = null;
     if (!node && !REJECT_OVERWRITTEN_COMMANDS.has(command)) {
       REJECT_OVERWRITTEN_COMMANDS.add(command);
 
@@ -546,7 +550,26 @@ class Cluster extends Commander {
             }
             _this._groupsBySlot[slot] =
               _this._groupsIds[_this.slots[slot].join(";")];
-            _this.connectionPool.findOrCreate(_this.natMapper(key));
+            const mapped = _this.natMapper(key);
+            const mappedKey = getNodeKey(mapped);
+            if (
+              lastRedis &&
+              getNodeKey(lastRedis.options as RedisOptions) === mappedKey &&
+              _this.connectionPool.getInstanceByKey(mappedKey) === lastRedis
+            ) {
+              // The redirect points back at the connection that returned
+              // the error, so it is stale (e.g. the endpoint is a proxy
+              // whose backing server changed) and retrying on it would
+              // loop forever. Replace it with a fresh one, unless another
+              // command already did — then reuse the replacement.
+              debug(
+                "MOVED redirect points back at %s; recreating its connection",
+                mappedKey
+              );
+              _this.connectionPool.recreate(mapped);
+            } else {
+              _this.connectionPool.findOrCreate(mapped);
+            }
             tryConnection();
             debug("refreshing slot caches... (triggered by MOVED error)");
             _this.refreshSlotsCache();
@@ -698,6 +721,7 @@ class Cluster extends Commander {
         return;
       }
 
+      lastRedis = redis;
       redis.sendCommand(command, stream);
     }
     return command.promise;

--- a/test/functional/cluster/moved.ts
+++ b/test/functional/cluster/moved.ts
@@ -119,6 +119,95 @@ describe("cluster:MOVED", () => {
     });
   });
 
+  it("refreshes the connection when MOVED points back at the same node", (done) => {
+    // Simulates a proxy endpoint whose backing server changed: old
+    // connections answer with MOVED pointing at the same address, new
+    // ones are routed correctly. https://github.com/redis/ioredis/issues/1865
+    const slotTable = [[0, 16383, ["127.0.0.1", 30001]]];
+    let swapped = false;
+    let movedCount = 0;
+    const freshSockets = new Set();
+    const server = new MockServer(30001, (argv, c) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        if (swapped && !freshSockets.has(c)) {
+          movedCount += 1;
+          return new Error(
+            "MOVED " + calculateSlot("foo") + " 127.0.0.1:30001"
+          );
+        }
+        return "bar";
+      }
+    });
+    server.on("connect", (c) => {
+      if (swapped) {
+        freshSockets.add(c);
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
+    // Establish the pooled connection before the swap so it goes stale.
+    cluster.get("foo", (err, res) => {
+      expect(err).to.eql(null);
+      expect(res).to.eql("bar");
+      swapped = true;
+      cluster.get("foo", (err2, res2) => {
+        expect(err2).to.eql(null);
+        expect(res2).to.eql("bar");
+        expect(movedCount).to.eql(1);
+        cluster.disconnect();
+        done();
+      });
+    });
+  });
+
+  it("recreates the connection only once for concurrent circular MOVED", (done) => {
+    // Two in-flight commands on the same stale connection both receive
+    // MOVED pointing back at the node. Only the first should replace the
+    // connection; the second must reuse the fresh one.
+    const slotTable = [[0, 16383, ["127.0.0.1", 30001]]];
+    let swapped = false;
+    const freshSockets = new Set();
+    const server = new MockServer(30001, (argv, c) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        if (swapped && !freshSockets.has(c)) {
+          return new Error(
+            "MOVED " + calculateSlot("foo") + " 127.0.0.1:30001"
+          );
+        }
+        return "bar";
+      }
+    });
+    server.on("connect", (c) => {
+      if (swapped) {
+        freshSockets.add(c);
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: 30001 }]);
+    cluster.get("foo", (err, res) => {
+      expect(err).to.eql(null);
+      expect(res).to.eql("bar");
+      swapped = true;
+      const recreateSpy = sinon.spy(cluster.connectionPool, "recreate");
+      Promise.all([cluster.get("foo"), cluster.get("foo")]).then(
+        ([res1, res2]) => {
+          expect(res1).to.eql("bar");
+          expect(res2).to.eql("bar");
+          expect(recreateSpy.callCount).to.eql(1);
+          cluster.disconnect();
+          done();
+        },
+        done
+      );
+    });
+  });
+
   it("should supports retryDelayOnMoved", (done) => {
     let cluster = undefined;
     const slotTable = [[0, 16383, ["127.0.0.1", 30001]]];

--- a/test/unit/clusters/ConnectionPool.ts
+++ b/test/unit/clusters/ConnectionPool.ts
@@ -39,6 +39,70 @@ describe("ConnectionPool", () => {
     });
   });
 
+  describe("#recreate", () => {
+    it("replaces the existing connection with a new instance", () => {
+      const pool = new ConnectionPool({});
+      const oldRedis = pool.findOrCreate({ host: "127.0.0.1", port: 30001 });
+      const disconnectStub = sinon.stub(oldRedis, "disconnect");
+
+      const newRedis = pool.recreate({ host: "127.0.0.1", port: 30001 });
+
+      expect(disconnectStub.calledOnce).to.eql(true);
+      expect(newRedis).to.not.equal(oldRedis);
+      expect(pool.getInstanceByKey("127.0.0.1:30001")).to.equal(newRedis);
+      expect(pool.getNodes().length).to.eql(1);
+    });
+
+    it("emits -node for the old instance and +node for the new one", () => {
+      const pool = new ConnectionPool({});
+      const oldRedis = pool.findOrCreate({ host: "127.0.0.1", port: 30001 });
+      sinon.stub(oldRedis, "disconnect");
+
+      const removed = [];
+      const added = [];
+      pool.on("-node", (redis, key) => removed.push([redis, key]));
+      pool.on("+node", (redis, key) => added.push([redis, key]));
+
+      const newRedis = pool.recreate({ host: "127.0.0.1", port: 30001 });
+      oldRedis.emit("end");
+
+      expect(removed).to.eql([[oldRedis, "127.0.0.1:30001"]]);
+      expect(added).to.eql([[newRedis, "127.0.0.1:30001"]]);
+    });
+
+    it("does not remove the new node when the stale connection ends", () => {
+      const pool = new ConnectionPool({});
+      const oldRedis = pool.findOrCreate({ host: "127.0.0.1", port: 30001 });
+      sinon.stub(oldRedis, "disconnect");
+
+      const newRedis = pool.recreate({ host: "127.0.0.1", port: 30001 });
+      oldRedis.emit("end");
+
+      expect(pool.getInstanceByKey("127.0.0.1:30001")).to.equal(newRedis);
+      expect(pool.getNodes().length).to.eql(1);
+    });
+
+    it("creates the connection when the node is not in the pool", () => {
+      const pool = new ConnectionPool({});
+      const redis = pool.recreate({ host: "127.0.0.1", port: 30001 });
+      expect(pool.getInstanceByKey("127.0.0.1:30001")).to.equal(redis);
+    });
+
+    it("still removes the node when the current connection ends", () => {
+      const pool = new ConnectionPool({});
+      const newRedis = pool.recreate({ host: "127.0.0.1", port: 30001 });
+
+      let drained = false;
+      pool.on("drain", () => {
+        drained = true;
+      });
+      newRedis.emit("end");
+
+      expect(pool.getNodes().length).to.eql(0);
+      expect(drained).to.eql(true);
+    });
+  });
+
   describe("#reset", () => {
     it("prefers to master if there are two same node for a slot", () => {
       const pool = new ConnectionPool({});


### PR DESCRIPTION
When a MOVED redirect points back to the same pooled node, replace the existing connection before retrying so proxy-backed endpoints can recover after their backing server changes.

Fixes #1865

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core cluster redirect and connection-pool lifecycle; behavior change is narrow (self-referential MOVED only) but mistakes could affect node events or pool consistency.
> 
> **Overview**
> Fixes infinite retry loops when a **MOVED** redirect targets the same address as the connection that returned the error (e.g. a proxy whose backend changed while the pooled TCP connection stayed open).
> 
> **ConnectionPool** gains **`recreate()`**, which drops the stale client from the pool, disconnects it, and opens a new one. The stale connection’s **`end`** handler no longer removes the replacement, and **`-node`** is emitted only after the new connection is registered.
> 
> **Cluster** command routing records **`lastRedis`** per attempt; on **MOVED**, if the mapped target is the same node key and still the pooled instance that failed, it calls **`recreate()`** instead of **`findOrCreate()`** so concurrent circular **MOVED**s share a single refresh. Normal **MOVED** to another host is unchanged.
> 
> Functional and unit tests cover the proxy-style scenario and single **`recreate`** under concurrency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5153baa088f5390efac9d74b6d04e7e6299870fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->