### PR TITLE
fix(command): serialize large integer arguments in decimal notation

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -169,6 +169,13 @@ export function toArg(arg: any): string {
   if (arg === null || typeof arg === "undefined") {
     return "";
   }
+  if (
+    typeof arg === "number" &&
+    Number.isInteger(arg) &&
+    !Number.isSafeInteger(arg)
+  ) {
+    return BigInt(arg).toString();
+  }
   return String(arg);
 }
 

--- a/test/unit/command.ts
+++ b/test/unit/command.ts
@@ -26,6 +26,14 @@ describe("Command", () => {
         "*4\r\n$3\r\nget\r\n$3\r\nfoo\r\n$3\r\nbar\r\n$4\r\nzooo\r\n"
       );
     });
+
+    it("should serialize large integer arguments in decimal notation", () => {
+      const command = new Command("set", ["key", 10 ** 21]);
+      expect(command.args).to.eql(["key", "1000000000000000000000"]);
+      expect(command.toWritable()).to.eql(
+        "*3\r\n$3\r\nset\r\n$3\r\nkey\r\n$22\r\n1000000000000000000000\r\n"
+      );
+    });
   });
 
   describe("#resolve()", () => {


### PR DESCRIPTION
Numeric command arguments are stringified with `String()`. For integers `>= 1e21`, `String()` produces exponential notation, which is written verbatim to the wire:

```js
new Command("set", ["key", 10 ** 21]).args; // ["key", "1e+21"]
```

Redis stores the literal `1e+21` and rejects it for integer commands (`PEXPIRE`, `PSETEX`, `INCR`, `SET … PX`, …) with `ERR value is not an integer or out of range`. Even exactly-representable integers are affected: `2 ** 70` serializes to `"1.1805916207174113e+21"` instead of `"1180591620717411303424"`.

In `toArg`, integer-valued numbers outside the safe-integer range are converted with `BigInt`, yielding the full decimal string. Safe integers, floats, strings and buffers are untouched. Adds a unit test asserting the serialized argument bytes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to argument stringification for unsafe integers only, with a targeted unit test and no auth or data-path redesign.
> 
> **Overview**
> **Fixes Redis wire serialization for numeric command arguments that exceed JavaScript’s safe integer range.**
> 
> `toArg` now detects integer `number` values where `!Number.isSafeInteger(arg)` and stringifies them via `BigInt(arg).toString()` instead of `String(arg)`. That avoids exponential forms like `1e+21` on the RESP payload, which Redis treats as invalid for integer-oriented commands (`PEXPIRE`, `INCR`, `SET` with `PX`, etc.). Safe integers, floats, strings, and buffers still follow the existing `String()` path.
> 
> A unit test on `Command` asserts both normalized `args` and `toWritable()` output for `10 ** 21`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598f72fa02a53179374b837ca4aa8917d8e7f710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->