### PR TITLE
ci: add custom Redis image to test matrix

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x, 26.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8.0"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8.0", "custom-28772936538-debian"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v6

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-8.8.0}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-custom-28772936538-debian}
 
 services:
   single:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only CI matrix and local Docker default image tags change; no application or library runtime behavior is modified.
> 
> **Overview**
> CI now runs the full test matrix against an additional **`custom-28772936538-debian`** Redis image tag, alongside the existing `rs-7.4.0-v1`, `8.2`, `8.4.0`, and `8.8.0` variants.
> 
> Local Docker test defaults change too: when **`REDIS_VERSION`** is unset, **`test/docker-compose.yml`** pulls **`redislabs/client-libs-test:custom-28772936538-debian`** instead of **`8.8.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66e14fe0202094537c8228c2365ff6ea4443bb5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->