### PR TITLE
docs: clarify Redis URL constructor usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ new Redis({
 });
 ```
 
-You can also specify connection options as a [`redis://` URL](http://www.iana.org/assignments/uri-schemes/prov/redis) or [`rediss://` URL](https://www.iana.org/assignments/uri-schemes/prov/rediss) when using [TLS encryption](#tls-options):
+You can also pass a connection string as the first constructor argument.
+Use a [`redis://` URL](http://www.iana.org/assignments/uri-schemes/prov/redis) or [`rediss://` URL](https://www.iana.org/assignments/uri-schemes/prov/rediss) when using [TLS encryption](#tls-options):
 
 ```javascript
 // Connect to 127.0.0.1:6380, db 4, using password "authpassword":
@@ -922,7 +923,8 @@ const redis = new Redis({
 });
 ```
 
-Alternatively, specify the connection through a [`rediss://` URL](https://www.iana.org/assignments/uri-schemes/prov/rediss).
+Alternatively, pass a [`rediss://` URL](https://www.iana.org/assignments/uri-schemes/prov/rediss) directly to the constructor.
+The `host` field in `RedisOptions` should contain only the hostname; a `rediss://` URL in `host` is not parsed as a TLS URL.
 
 ```javascript
 const redis = new Redis("rediss://redis.my-service.com");


### PR DESCRIPTION
Closes #1945 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or API behavior changes.
> 
> **Overview**
> **README-only** updates that steer users toward passing **`redis://` / `rediss://` strings as the first `Redis` constructor argument**, instead of wording that sounded like URLs were just another “connection option” shape.
> 
> In the **TLS** section, the docs now say to pass **`rediss://` directly to the constructor** and add an explicit caveat: **`host` in `RedisOptions` must be a plain hostname**—putting a `rediss://` URL in `host` is **not** treated as a TLS connection URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f667553e1313a35c708d5be9b5216aedfcc247ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->