### PR TITLE
feat: add LMOVEM and BLMOVEM command support

### DIFF
--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -132,6 +132,7 @@ module.exports = {
   brpop: "[string, string] | null",
   brpoplpush: "string | null",
   blmove: "string | null",
+  blmovem: "string[] | null",
   lmpop: "[key: string, members: string[]] | null",
   blmpop: "[key: string, members: string[]] | null",
   bzpopmin: {
@@ -301,6 +302,7 @@ module.exports = {
   },
   rpoplpush: "string",
   lmove: "string",
+  lmovem: "string[] | null",
   rpush: "number",
   rpushx: "number",
   sadd: "number",

--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -89,6 +89,7 @@ export interface CommandNameFlags {
     "brpop",
     "brpoplpush",
     "blmove",
+    "blmovem",
     "bzpopmin",
     "bzpopmax",
     "bzmpop",
@@ -163,6 +164,7 @@ export default class Command implements Respondable {
       "brpop",
       "brpoplpush",
       "blmove",
+      "blmovem",
       "bzpopmin",
       "bzpopmax",
       "bzmpop",
@@ -481,6 +483,11 @@ export default class Command implements Respondable {
     }
 
     const name = this.name.toLowerCase();
+
+    // BLMOVEM may have trailing options, but its timeout is always the fifth argument.
+    if (name === "blmovem") {
+      return parseSecondsArgument(args[4]);
+    }
 
     if (Command.checkFlag("LAST_ARG_TIMEOUT_COMMANDS", name)) {
       return parseSecondsArgument(args[args.length - 1]);

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -576,6 +576,52 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   blmoveBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
   blmove(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, callback?: Callback<string | null>): Result<string | null, Context>;
   blmoveBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, callback?: Callback<Buffer | null>): Result<Buffer | null, Context>;
+  /**
+   * Moves up to (or exactly) a number of elements from one list to another and returns them. Blocks until the elements are available otherwise. Deletes the source list if it becomes empty.
+   * - _group_: list
+   * - _complexity_: O(N) where N is the number of elements moved.
+   * - _since_: 8.10.0
+   */
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', timeout: number | string, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', timeout: number | string, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', timeout: number | string, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  blmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  blmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', timeout: number | string, callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
 
   /**
    * Pops the first element from one of multiple lists. Blocks until an element is available otherwise. Deletes the list if the last element was popped.
@@ -2398,6 +2444,52 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   lmoveBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', callback?: Callback<Buffer>): Result<Buffer, Context>;
   lmove(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', callback?: Callback<string>): Result<string, Context>;
   lmoveBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', callback?: Callback<Buffer>): Result<Buffer, Context>;
+  /**
+   * Moves up to (or exactly) a number of elements from one list to another and returns them. Deletes the source list if it becomes empty.
+   * - _group_: list
+   * - _complexity_: O(N) where N is the number of elements moved.
+   * - _since_: 8.10.0
+   */
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', countToken: 'COUNT', count: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', countToken: 'COUNT', count: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', exactlyToken: 'EXACTLY', exactly: number | string, obo: 'OBO', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', exactlyToken: 'EXACTLY', exactly: number | string, bulk: 'BULK', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', left1: 'LEFT', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, left: 'LEFT', right: 'RIGHT', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', left: 'LEFT', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
+  lmovem(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', callback?: Callback<string[] | null>): Result<string[] | null, Context>;
+  lmovemBuffer(source: RedisKey, destination: RedisKey, right: 'RIGHT', right1: 'RIGHT', callback?: Callback<Buffer[] | null>): Result<Buffer[] | null, Context>;
 
   /**
    * Returns multiple elements from a list after removing them. Deletes the list if the last element was popped.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.11.1",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "1.11.0",
+        "@ioredis/commands": "2.0.0",
         "cluster-key-slot": "1.1.1",
         "debug": "4.4.3",
         "denque": "2.1.0",
@@ -537,9 +537,9 @@
       "dev": true
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.11.0.tgz",
-      "integrity": "sha512-tuMmOu6dtyGFv/fzCjtapCJj/zgoHaFsqs3wKsroJSRXtlLmyL/t+B7uaQiavGk1F3WWFQcUqZwk92bpp9jKcA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-2.0.0.tgz",
+      "integrity": "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==",
       "license": "MIT"
     },
     "node_modules/@ioredis/interface-generator": {
@@ -11276,9 +11276,9 @@
       "dev": true
     },
     "@ioredis/commands": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.11.0.tgz",
-      "integrity": "sha512-tuMmOu6dtyGFv/fzCjtapCJj/zgoHaFsqs3wKsroJSRXtlLmyL/t+B7uaQiavGk1F3WWFQcUqZwk92bpp9jKcA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-2.0.0.tgz",
+      "integrity": "sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg=="
     },
     "@ioredis/interface-generator": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "https://opencollective.com/ioredis"
   },
   "dependencies": {
-    "@ioredis/commands": "1.11.0",
+    "@ioredis/commands": "2.0.0",
     "cluster-key-slot": "1.1.1",
     "debug": "4.4.3",
     "denque": "2.1.0",

--- a/test/functional/blocking_timeout.ts
+++ b/test/functional/blocking_timeout.ts
@@ -92,6 +92,43 @@ describe("blocking command recovery", function () {
     }
   });
 
+  it("resolves stalled BLMOVEM with trailing options after its timeout", async () => {
+    const server = new MockServer(30001, (argv, _socket, flags) => {
+      if (argv[0] === "blmovem") {
+        flags.hang = true;
+      }
+    });
+
+    const redis = new Redis({
+      port: 30001,
+      blockingTimeout: 1000,
+      lazyConnect: true,
+      enableReadyCheck: false,
+    });
+    redis.on("error", () => {});
+
+    try {
+      await redis.connect();
+      const start = Date.now();
+      const result = await redis.blmovem(
+        "source",
+        "destination",
+        "LEFT",
+        "RIGHT",
+        0.01,
+        "EXACTLY",
+        2,
+        "BULK"
+      );
+
+      expect(result).to.be.null;
+      expect(Date.now() - start).to.be.lessThan(500);
+    } finally {
+      redis.disconnect();
+      await server.disconnectPromise();
+    }
+  });
+
   it("arms blocking timer for finite-timeout commands in offline queue when blockingTimeout is set", async () => {
     // When blockingTimeout is set (feature opt-in), we arm the timer
     // for blocking commands with finite timeout in offline queue

--- a/test/functional/commands/blmovem.ts
+++ b/test/functional/commands/blmovem.ts
@@ -1,0 +1,64 @@
+import Redis from "../../../lib/Redis";
+import { expect } from "chai";
+import { RESP_CONFIGS } from "../../helpers/respConfigs";
+import { isRedisVersionLowerThan } from "../../helpers/util";
+
+for (const { name, opts } of RESP_CONFIGS) {
+  describe(`blmovem (${name})`, function () {
+    let redis: Redis;
+
+    before(async function () {
+      if (await isRedisVersionLowerThan("8.9")) {
+        this.skip();
+      }
+    });
+
+    beforeEach(async () => {
+      redis = new Redis(opts);
+      await redis.flushdb();
+    });
+
+    afterEach(() => {
+      redis.disconnect();
+    });
+
+    it("returns null when the timeout elapses", async () => {
+      const source = `blmovem:timeout:${Date.now()}:src`;
+      const destination = `blmovem:timeout:${Date.now()}:dst`;
+
+      expect(
+        await redis.blmovem(
+          source,
+          destination,
+          "LEFT",
+          "RIGHT",
+          0.001,
+          "EXACTLY",
+          2,
+          "BULK"
+        )
+      ).to.equal(null);
+    });
+
+    it("moves available elements and returns them", async () => {
+      const source = `blmovem:count:${Date.now()}:src`;
+      const destination = `blmovem:count:${Date.now()}:dst`;
+      await redis.rpush(source, "a", "b", "c");
+
+      expect(
+        await redis.blmovem(
+          source,
+          destination,
+          "LEFT",
+          "RIGHT",
+          0,
+          "COUNT",
+          2,
+          "BULK"
+        )
+      ).to.eql(["a", "b"]);
+      expect(await redis.lrange(source, 0, -1)).to.eql(["c"]);
+      expect(await redis.lrange(destination, 0, -1)).to.eql(["a", "b"]);
+    });
+  });
+}

--- a/test/functional/commands/lmovem.ts
+++ b/test/functional/commands/lmovem.ts
@@ -1,0 +1,118 @@
+import Redis from "../../../lib/Redis";
+import { expect } from "chai";
+import { RESP_CONFIGS } from "../../helpers/respConfigs";
+import { isRedisVersionLowerThan } from "../../helpers/util";
+
+for (const { name, opts } of RESP_CONFIGS) {
+  describe(`lmovem (${name})`, function () {
+    let redis: Redis;
+
+    before(async function () {
+      if (await isRedisVersionLowerThan("8.9")) {
+        this.skip();
+      }
+    });
+
+    beforeEach(async () => {
+      redis = new Redis(opts);
+      await redis.flushdb();
+    });
+
+    afterEach(() => {
+      redis.disconnect();
+    });
+
+    it("returns null when the source is missing", async () => {
+      const source = `lmovem:missing:${Date.now()}:src`;
+      const destination = `lmovem:missing:${Date.now()}:dst`;
+
+      expect(await redis.lmovem(source, destination, "LEFT", "RIGHT")).to.equal(
+        null
+      );
+    });
+
+    it("moves one element when no count is provided", async () => {
+      const source = `lmovem:single:${Date.now()}:src`;
+      const destination = `lmovem:single:${Date.now()}:dst`;
+      await redis.rpush(source, "a", "b", "c");
+
+      expect(
+        await redis.lmovem(source, destination, "LEFT", "RIGHT")
+      ).to.eql(["a"]);
+      expect(await redis.lrange(source, 0, -1)).to.eql(["b", "c"]);
+      expect(await redis.lrange(destination, 0, -1)).to.eql(["a"]);
+    });
+
+    it("supports COUNT with OBO and BULK ordering", async () => {
+      const oboSource = `lmovem:obo:${Date.now()}:src`;
+      const oboDestination = `lmovem:obo:${Date.now()}:dst`;
+      await redis.rpush(oboSource, "1", "2", "3", "4");
+
+      expect(
+        await redis.lmovem(
+          oboSource,
+          oboDestination,
+          "LEFT",
+          "LEFT",
+          "COUNT",
+          3,
+          "OBO"
+        )
+      ).to.eql(["3", "2", "1"]);
+
+      const bulkSource = `lmovem:bulk:${Date.now()}:src`;
+      const bulkDestination = `lmovem:bulk:${Date.now()}:dst`;
+      await redis.rpush(bulkSource, "1", "2", "3", "4");
+
+      expect(
+        await redis.lmovem(
+          bulkSource,
+          bulkDestination,
+          "LEFT",
+          "LEFT",
+          "COUNT",
+          3,
+          "BULK"
+        )
+      ).to.eql(["1", "2", "3"]);
+    });
+
+    it("returns null without moving when EXACTLY cannot be satisfied", async () => {
+      const source = `lmovem:exactly:${Date.now()}:src`;
+      const destination = `lmovem:exactly:${Date.now()}:dst`;
+      await redis.rpush(source, "a", "b");
+
+      expect(
+        await redis.lmovem(
+          source,
+          destination,
+          "LEFT",
+          "RIGHT",
+          "EXACTLY",
+          3,
+          "BULK"
+        )
+      ).to.equal(null);
+      expect(await redis.lrange(source, 0, -1)).to.eql(["a", "b"]);
+      expect(await redis.exists(destination)).to.equal(0);
+    });
+
+    it("returns buffers from the buffer variant", async () => {
+      const source = `lmovem:buffer:${Date.now()}:src`;
+      const destination = `lmovem:buffer:${Date.now()}:dst`;
+      await redis.rpush(source, Buffer.from([0xff]), Buffer.from("value"));
+
+      expect(
+        await redis.lmovemBuffer(
+          source,
+          destination,
+          "LEFT",
+          "RIGHT",
+          "COUNT",
+          2,
+          "BULK"
+        )
+      ).to.eql([Buffer.from([0xff]), Buffer.from("value")]);
+    });
+  });
+}

--- a/test/typing/commands.test-d.ts
+++ b/test/typing/commands.test-d.ts
@@ -100,6 +100,48 @@ expectType<Promise<Buffer | null>>(redis.lpopBuffer("key"));
 expectType<Promise<string[] | null>>(redis.lpop("key", 17));
 expectType<Promise<Buffer[] | null>>(redis.lpopBuffer("key", 17));
 
+// LMOVEM / BLMOVEM
+expectType<Promise<string[] | null>>(
+  redis.lmovem("source", "destination", "LEFT", "RIGHT")
+);
+expectType<Promise<string[] | null>>(
+  redis.lmovem(
+    "source",
+    "destination",
+    "LEFT",
+    "RIGHT",
+    "COUNT",
+    2,
+    "BULK"
+  )
+);
+expectType<Promise<Buffer[] | null>>(
+  redis.lmovemBuffer(
+    "source",
+    "destination",
+    "RIGHT",
+    "LEFT",
+    "EXACTLY",
+    "2",
+    "OBO"
+  )
+);
+expectType<Promise<string[] | null>>(
+  redis.blmovem(
+    "source",
+    "destination",
+    "LEFT",
+    "RIGHT",
+    0,
+    "COUNT",
+    2,
+    "BULK"
+  )
+);
+expectType<Promise<Buffer[] | null>>(
+  redis.blmovemBuffer("source", "destination", "RIGHT", "LEFT", "0")
+);
+
 // LPOS
 expectType<Promise<number | null>>(redis.lpos("key", "element"));
 expectType<Promise<number[]>>(
@@ -231,6 +273,21 @@ redis.hgetexBuffer("key", "EX", 60, "FIELDS", 1, "field", (err, res) => {
   expectType<Error | null | undefined>(err);
   expectType<(Buffer | null)[] | undefined>(res);
 });
+
+redis.blmovem(
+  "source",
+  "destination",
+  "LEFT",
+  "RIGHT",
+  0,
+  "EXACTLY",
+  2,
+  "OBO",
+  (err, res) => {
+    expectType<Error | null | undefined>(err);
+    expectType<string[] | null | undefined>(res);
+  }
+);
 
 redis.set("foo", "bar", (err, res) => {
   expectType<Error | null | undefined>(err);

--- a/test/unit/command.ts
+++ b/test/unit/command.ts
@@ -173,6 +173,7 @@ describe("Command", () => {
         false
       );
       expect(Command.checkFlag("WILL_DISCONNECT", "quit")).to.eql(true);
+      expect(Command.checkFlag("BLOCKING_COMMANDS", "blmovem")).to.eql(true);
     });
 
     it("should be case insensitive for command name", () => {
@@ -349,6 +350,47 @@ describe("Command", () => {
       it("handles fractional seconds", () => {
         const command = new Command("blpop", ["key", "1.5"]);
         expect(command.extractBlockingTimeout()).to.equal(1500);
+      });
+    });
+
+    describe("BLMOVEM", () => {
+      it("extracts timeout without trailing options", () => {
+        const command = new Command("blmovem", [
+          "source",
+          "destination",
+          "LEFT",
+          "RIGHT",
+          "5",
+        ]);
+        expect(command.extractBlockingTimeout()).to.equal(5000);
+      });
+
+      it("extracts timeout with trailing COUNT options", () => {
+        const command = new Command("blmovem", [
+          "source",
+          "destination",
+          "LEFT",
+          "RIGHT",
+          "1.5",
+          "COUNT",
+          "2",
+          "BULK",
+        ]);
+        expect(command.extractBlockingTimeout()).to.equal(1500);
+      });
+
+      it("extracts timeout with trailing EXACTLY options", () => {
+        const command = new Command("BLMOVEM", [
+          "source",
+          "destination",
+          "RIGHT",
+          "LEFT",
+          Buffer.from("10"),
+          "EXACTLY",
+          "3",
+          "OBO",
+        ]);
+        expect(command.extractBlockingTimeout()).to.equal(10000);
       });
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive Redis command support with targeted blocking-timeout logic and tests; no changes to auth, security, or existing command behavior beyond the new APIs.
> 
> **Overview**
> Adds client support for Redis **LMOVEM** and **BLMOVEM** (multi-element list moves), including typed `lmovem` / `blmovem` (and buffer variants) and return types of `string[] | null`.
> 
> **BLMOVEM** is registered as a blocking command. Timeout parsing uses the **fifth argument** (not the last), so `COUNT` / `EXACTLY` / `OBO` / `BULK` trailing options do not break `blockingTimeout` or stall recovery.
> 
> Bumps **`@ioredis/commands`** to `2.0.0` for command metadata. Coverage includes functional tests (Redis 8.9+), unit tests for timeout extraction, typing tests, and a blocking-timeout scenario with trailing options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf16f0bdd3c790d55762dc2b62a4741f15c69d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->