### PR TITLE
ci: update Redis test image to 8.10 RC2

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x, 26.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8.0", "custom-28772936538-debian"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8.0", "8.10-rc2"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v6

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-custom-28772936538-debian}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-8.10-rc2}
 
 services:
   single:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test infrastructure only; no application or production runtime behavior changes.
> 
> **Overview**
> **CI matrix and Docker defaults** now use the `redislabs/client-libs-test` tag **`8.10-rc2`** in place of **`custom-28772936538-debian`**.
> 
> The coverage workflow’s Redis matrix entry and `test/docker-compose.yml`’s `REDIS_VERSION` default were updated together so GitHub Actions and local `docker:setup` runs exercise the same image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d48207ea7564adcf9c15ce486e5d550245d530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->