### PR TITLE
fix: clear stale socket timeout on reconnect

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -685,8 +685,9 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
   }
 
   private setSocketTimeout() {
+    const stream = this.stream;
     this.socketTimeoutTimer = setTimeout(() => {
-      this.stream.destroy(
+      stream.destroy(
         new Error(
           `Socket timeout. Expecting data, but didn't receive any in ${this.options.socketTimeout}ms.`
         )
@@ -696,7 +697,7 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
 
     // this handler must run after the "data" handler in "DataHandler"
     // so that `this.commandQueue.length` will be updated
-    this.stream.once("data", () => {
+    stream.once("data", () => {
       clearTimeout(this.socketTimeoutTimer);
       this.socketTimeoutTimer = undefined;
       if (this.commandQueue.length === 0) return;

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -343,6 +343,12 @@ export function closeHandler(self) {
     const prevStatus = self.status;
     self.setStatus("close");
 
+    // The timeout belongs to the stream that just closed and must not survive reconnect.
+    if (self.socketTimeoutTimer !== undefined) {
+      clearTimeout(self.socketTimeoutTimer);
+      self.socketTimeoutTimer = undefined;
+    }
+
     if (self.commandQueue.length) {
       abortIncompletePipelines(self.commandQueue);
     }

--- a/test/functional/socketTimeout.ts
+++ b/test/functional/socketTimeout.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { Done } from 'mocha';
+import { Socket } from 'net';
 import Redis from '../../lib/Redis';
+import MockServer from '../helpers/mock_server';
 
 describe('Redis Connection Socket Timeout', () => {
   const SOCKET_TIMEOUT_MS = 500;
@@ -28,6 +30,54 @@ describe('Redis Connection Socket Timeout', () => {
       redis.ping();
     });
   });
+
+  it('does not apply a closed connection timeout to its replacement', async () => {
+    let connectionCount = 0;
+    let closeCount = 0;
+    let firstSocket: Socket | undefined;
+    const errors: string[] = [];
+
+    const server = new MockServer(30001, (argv, socket, flags) => {
+      if (argv[0] !== 'ping') {
+        return;
+      }
+      if (socket === firstSocket) {
+        flags.hang = true;
+        setTimeout(() => socket.destroy(), 20);
+        return;
+      }
+      return 'PONG';
+    });
+    server.on('connect', (socket) => {
+      connectionCount += 1;
+      firstSocket ??= socket;
+    });
+
+    const redis = createRedis({
+      port: 30001,
+      protocol: 2,
+      disableClientInfo: true,
+      enableReadyCheck: false,
+      socketTimeout: 250
+    });
+    redis.on('error', (error) => errors.push(error.message));
+    redis.on('close', () => closeCount++);
+
+    try {
+      await redis.connect();
+      expect(await redis.ping()).to.equal('PONG');
+
+      await new Promise((resolve) => setTimeout(resolve, 350));
+
+      expect(errors).to.deep.equal([]);
+      expect(closeCount).to.equal(1);
+      expect(connectionCount).to.equal(2);
+      expect(redis.status).to.equal('ready');
+    } finally {
+      redis.disconnect();
+      await server.disconnectPromise();
+    }
+  }).timeout(5000);
 
   function createRedis(options = {}) {
     return new Redis({


### PR DESCRIPTION
This pull request resolves #2147.

The socket timeout timer was stored on the Redis instance and survived after its original stream closed. Because its callback accessed `this.stream` when it fired, it could destroy a replacement connection that had already returned data successfully.

The fix clears the timer when the connection closes and captures the owning stream when the timer is created.

A regression test covers the close → reconnect → successful reply → old deadline interleaving.

## Validation

- `test/functional/socketTimeout.ts`: 4 passing
- `npm run build`
- `npm run lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection lifecycle and stream teardown in a hot path used whenever socketTimeout is set; behavior change is narrowly scoped but affects all reconnect scenarios with that option.
> 
> **Overview**
> Fixes a reconnect bug when **`socketTimeout`** is enabled: the client-wide timer could outlive the socket that created it and later tear down a **new** stream after a successful reply.
> 
> **`setSocketTimeout`** now binds the timeout and its one-shot `data` listener to the **stream instance** that was active when the timer was armed, instead of reading **`this.stream`** when the timer fires. **`closeHandler`** clears **`socketTimeoutTimer`** as soon as the connection closes so deadlines from the old socket are not carried into the next connect.
> 
> A functional test simulates first-socket hang/destroy, reconnect, and waits past the old timeout to assert the replacement stays **`ready`** with no spurious socket-timeout errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d8e7c96df58eb8b311570684009c4364b8a908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->