### PR TITLE
fix(cluster): validate MOVED slot to prevent Array.prototype pollution

### DIFF
--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -163,17 +163,17 @@ class Pipeline extends Commander<{ type: "pipeline" }> {
         };
         const cluster = this.redis as Cluster;
         cluster.handleError(commonError, this.leftRedirections, {
-          moved: function (_slot: string, key: string) {
+          moved: function (slot: number, key: string) {
             _this.preferKey = key;
-            if (cluster.slots[errv[1]]) {
-                if (cluster.slots[errv[1]][0] !== key) {
-                  cluster.slots[errv[1]] = [key];
-                }
+            if (cluster.slots[slot]) {
+              if (cluster.slots[slot][0] !== key) {
+                cluster.slots[slot] = [key];
+              }
             } else {
-              cluster.slots[errv[1]] = [key];
+              cluster.slots[slot] = [key];
             }
-            cluster._groupsBySlot[errv[1]] =
-              cluster._groupsIds[cluster.slots[errv[1]].join(";")];
+            cluster._groupsBySlot[slot] =
+              cluster._groupsIds[cluster.slots[slot].join(";")];
             cluster.refreshSlotsCache();
             _this.exec();
           },

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -578,13 +578,25 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
           moved: function (slot, key) {
             debug("command %s is moved to %s", command.name, key);
             targetSlot = Number(slot);
-            if (_this.slots[slot]) {
-              _this.slots[slot][0] = key;
-            } else {
-              _this.slots[slot] = [key];
+            // Reject redirects whose slot is not a valid integer in the
+            // cluster range. A malformed slot such as "__proto__" would
+            // otherwise index Array.prototype and pollute it globally.
+            if (
+              !Number.isInteger(targetSlot) ||
+              targetSlot < 0 ||
+              targetSlot >= 16384
+            ) {
+              debug("ignoring MOVED with invalid slot %s", slot);
+              reject.call(command, err);
+              return;
             }
-            _this._groupsBySlot[slot] =
-              _this._groupsIds[_this.slots[slot].join(";")];
+            if (_this.slots[targetSlot]) {
+              _this.slots[targetSlot][0] = key;
+            } else {
+              _this.slots[targetSlot] = [key];
+            }
+            _this._groupsBySlot[targetSlot] =
+              _this._groupsIds[_this.slots[targetSlot].join(";")];
             const mapped = _this.natMapper(key);
             const mappedKey = getNodeKey(mapped);
             if (

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -578,25 +578,13 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
           moved: function (slot, key) {
             debug("command %s is moved to %s", command.name, key);
             targetSlot = Number(slot);
-            // Reject redirects whose slot is not a valid integer in the
-            // cluster range. A malformed slot such as "__proto__" would
-            // otherwise index Array.prototype and pollute it globally.
-            if (
-              !Number.isInteger(targetSlot) ||
-              targetSlot < 0 ||
-              targetSlot >= 16384
-            ) {
-              debug("ignoring MOVED with invalid slot %s", slot);
-              reject.call(command, err);
-              return;
-            }
-            if (_this.slots[targetSlot]) {
-              _this.slots[targetSlot][0] = key;
+            if (_this.slots[slot]) {
+              _this.slots[slot][0] = key;
             } else {
-              _this.slots[targetSlot] = [key];
+              _this.slots[slot] = [key];
             }
-            _this._groupsBySlot[targetSlot] =
-              _this._groupsIds[_this.slots[targetSlot].join(";")];
+            _this._groupsBySlot[slot] =
+              _this._groupsIds[_this.slots[slot].join(";")];
             const mapped = _this.natMapper(key);
             const mappedKey = getNodeKey(mapped);
             if (
@@ -815,15 +803,25 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
     }
     const errv = error.message.split(" ");
     if (errv[0] === "MOVED") {
+      const slot = Number(errv[1]);
+      // Reject redirects whose slot is not a valid integer in the cluster
+      // range. The moved handlers use the slot to index the `slots` array;
+      // a crafted token such as "__proto__" would otherwise resolve to
+      // Array.prototype and pollute it globally. See
+      // https://hackerone.com/reports/3761875
+      if (!Number.isInteger(slot) || slot < 0 || slot >= 16384) {
+        handlers.defaults();
+        return;
+      }
       const timeout = this.options.retryDelayOnMoved;
       if (timeout && typeof timeout === "number") {
         this.delayQueue.push(
           "moved",
-          handlers.moved.bind(null, errv[1], errv[2]),
+          handlers.moved.bind(null, slot, errv[2]),
           { timeout }
         );
       } else {
-        handlers.moved(errv[1], errv[2]);
+        handlers.moved(slot, errv[2]);
       }
     } else if (errv[0] === "ASK") {
       handlers.ask(errv[1], errv[2]);

--- a/test/functional/cluster/moved.ts
+++ b/test/functional/cluster/moved.ts
@@ -238,6 +238,39 @@ describe("cluster:MOVED", () => {
     });
   });
 
+  it("rejects a MOVED redirect with a non-numeric slot inside a pipeline without polluting Array.prototype", (done) => {
+    // The pipeline retry path has its own MOVED handler; it must also
+    // reject a crafted slot such as "__proto__" (or a token like "length"
+    // that would throw RangeError). https://hackerone.com/reports/3761875
+    let cluster = undefined;
+    const slotTable = [[0, 16383, ["127.0.0.1", 30001]]];
+    new MockServer(30001, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        return new Error("MOVED __proto__ 127.0.0.1:30002");
+      }
+    });
+
+    cluster = new Cluster([{ host: "127.0.0.1", port: "30001" }], {
+      maxRedirections: 2,
+    });
+    cluster
+      .pipeline()
+      .get("foo")
+      .exec((err, results) => {
+        expect(err).to.eql(null);
+        expect(results[0][0]).to.be.instanceOf(Error);
+        expect(results[0][0].message).to.include("MOVED __proto__");
+        // eslint-disable-next-line no-prototype-builtins
+        expect(Array.prototype.hasOwnProperty(0)).to.eql(false);
+        expect([].length).to.eql(0);
+        cluster.disconnect();
+        done();
+      });
+  });
+
   it("should supports retryDelayOnMoved", (done) => {
     let cluster = undefined;
     const slotTable = [[0, 16383, ["127.0.0.1", 30001]]];

--- a/test/functional/cluster/moved.ts
+++ b/test/functional/cluster/moved.ts
@@ -208,6 +208,36 @@ describe("cluster:MOVED", () => {
     });
   });
 
+  it("rejects a MOVED redirect with a non-numeric slot without polluting Array.prototype", (done) => {
+    // A malicious/compromised node replying with a crafted slot such as
+    // "__proto__" must not be used to index the internal slots array,
+    // which would write to Array.prototype[0].
+    // https://hackerone.com/reports/3761875
+    let cluster = undefined;
+    const slotTable = [[0, 16383, ["127.0.0.1", 30001]]];
+    new MockServer(30001, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        return new Error("MOVED __proto__ 127.0.0.1:30002");
+      }
+    });
+
+    cluster = new Cluster([{ host: "127.0.0.1", port: "30001" }], {
+      maxRedirections: 2,
+    });
+    cluster.get("foo", (err) => {
+      expect(err).to.be.instanceOf(Error);
+      expect(err.message).to.include("MOVED __proto__");
+      // eslint-disable-next-line no-prototype-builtins
+      expect(Array.prototype.hasOwnProperty(0)).to.eql(false);
+      expect([].length).to.eql(0);
+      cluster.disconnect();
+      done();
+    });
+  });
+
   it("should supports retryDelayOnMoved", (done) => {
     let cluster = undefined;
     const slotTable = [[0, 16383, ["127.0.0.1", 30001]]];


### PR DESCRIPTION
## Description

This pull request fixes a prototype pollution vulnerability in the Cluster MOVED redirect handler.

**The bug:** `Cluster#handleError` splits the RESP error string and passes the slot token straight into the `moved` handler, which used it as an index into the internal `slots` array without validation:

```js
if (_this.slots[slot]) {
  _this.slots[slot][0] = key;
} else {
  _this.slots[slot] = [key];
}
```

`slots` is initialized as `[]`. A malicious or compromised cluster node — or an attacker in a MITM / DNS-poisoning position — replying with `-MOVED __proto__ host:port` makes `_this.slots["__proto__"]` resolve to `Array.prototype` (truthy), so `_this.slots[slot][0] = key` writes to `Array.prototype[0]`, polluting every array in the process.

This is a variant of the previously fixed `hgetall` prototype pollution (#1267) that was never applied to the MOVED code path.

**The fix:** validate the slot is an integer in the cluster range `[0, 16383]` before using it as an index. Malformed redirects are rejected with the original error instead of being applied, so no attacker-controlled value can reach `slots[...]`.

**Behavior change:** a MOVED reply with a non-numeric or out-of-range slot is now rejected rather than acted on. Well-behaved Redis Cluster servers always send an integer slot, so legitimate traffic is unaffected.

Ref: https://hackerone.com/reports/3761875

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix in cluster redirect handling that prevents global prototype pollution from untrusted MOVED replies; behavior change only for malformed/out-of-range slots.
> 
> **Overview**
> Fixes a **prototype pollution** vulnerability when handling Redis Cluster `MOVED` redirects. A malicious node (or MITM) could reply with `MOVED __proto__ host:port`; the client used the slot token as an array index on the internal `slots` table (`[]`), which made `slots["__proto__"]` resolve to `Array.prototype` and allowed writes like `Array.prototype[0]`.
> 
> **`Cluster#handleError`** now parses the slot with `Number()`, requires an integer in **`[0, 16383]`**, and calls **`handlers.defaults()`** (surface the original error) when validation fails. Valid slots are passed as a **`number`** into `moved` handlers instead of the raw string token.
> 
> **`Pipeline`**’s inline `moved` callback is updated to use that numeric `slot` when updating `cluster.slots` and `_groupsBySlot` (replacing incorrect `errv[1]` references).
> 
> Functional tests cover crafted `MOVED __proto__` for single commands and pipelines, asserting `Array.prototype` is not polluted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a01d99762c811b8fd3476344913cae9fc5b022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->