### PR TITLE
fix(cluster): handle zero-argument sunsubscribe in sharded pubsub

### DIFF
--- a/lib/cluster/ClusterSubscriberGroup.ts
+++ b/lib/cluster/ClusterSubscriberGroup.ts
@@ -39,7 +39,7 @@ export default class ClusterSubscriberGroup {
    */
   constructor(
     private readonly subscriberGroupEmitter: EventEmitter,
-    private readonly options: ClusterOptions,
+    private readonly options: ClusterOptions
   ) {}
 
   /**
@@ -90,7 +90,7 @@ export default class ClusterSubscriberGroup {
 
     return Array.from(this.channels.values()).reduce(
       (sum, array) => sum + array.length,
-      0,
+      0
     );
   }
 
@@ -117,8 +117,29 @@ export default class ClusterSubscriberGroup {
 
     return Array.from(this.channels.values()).reduce(
       (sum, array) => sum + array.length,
-      0,
+      0
     );
+  }
+
+  /**
+   * Removes all tracked channels and returns the subscriber instances that had
+   * active subscriptions so that a zero-argument sunsubscribe can be sent to each.
+   */
+  removeAllChannels(): ShardedSubscriber[] {
+    const affectedSubscribers: ShardedSubscriber[] = [];
+
+    for (const slot of this.channels.keys()) {
+      const nodeKey = this.clusterSlots[slot]?.[0];
+      if (nodeKey) {
+        const sub = this.shardedSubscribers.get(nodeKey);
+        if (sub && sub.isHealthy()) {
+          affectedSubscribers.push(sub);
+        }
+      }
+    }
+
+    this.channels.clear();
+    return affectedSubscribers;
   }
 
   /**
@@ -151,7 +172,7 @@ export default class ClusterSubscriberGroup {
             })
             .catch((err) => {
               this.handleSubscriberConnectFailed(err, s.getNodeKey());
-            }),
+            })
         );
 
         this.subscriberGroupEmitter.emit("+subscriber");
@@ -177,7 +198,7 @@ export default class ClusterSubscriberGroup {
 
       if (!hasTopologyChanged && !hasFailedSubscribers) {
         debug(
-          "No topology change detected or failed subscribers. Skipping reset.",
+          "No topology change detected or failed subscribers. Skipping reset."
         );
         return;
       }
@@ -223,7 +244,7 @@ export default class ClusterSubscriberGroup {
                 })
                 .catch((error) => {
                   this.handleSubscriberConnectFailed(error, nodeKey);
-                }),
+                })
             );
           }
 
@@ -252,7 +273,7 @@ export default class ClusterSubscriberGroup {
         const sub = new ShardedSubscriber(
           this.subscriberGroupEmitter,
           redis.options,
-          this.options.redisOptions,
+          this.options.redisOptions
         );
 
         this.shardedSubscribers.set(nodeKey, sub);
@@ -266,7 +287,7 @@ export default class ClusterSubscriberGroup {
               })
               .catch((error) => {
                 this.handleSubscriberConnectFailed(error, nodeKey);
-              }),
+              })
           );
         }
 
@@ -300,9 +321,12 @@ export default class ClusterSubscriberGroup {
   private _refreshSlots(targetSlots: string[][]): boolean {
     //If there was an actual change, then reassign the slot ranges
     // Also rebuild if subscriberToSlotsIndex is empty (e.g., after stop() was called)
-    if (this._slotsAreEqual(targetSlots) && this.subscriberToSlotsIndex.size > 0) {
+    if (
+      this._slotsAreEqual(targetSlots) &&
+      this.subscriberToSlotsIndex.size > 0
+    ) {
       debug(
-        "Nothing to refresh because the new cluster map is equal to the previous one.",
+        "Nothing to refresh because the new cluster map is equal to the previous one."
       );
 
       return false;
@@ -362,7 +386,7 @@ export default class ClusterSubscriberGroup {
                       debug(
                         "Failed to ssubscribe on node %s: %s",
                         nodeKey,
-                        err,
+                        err
                       );
                     });
                   });
@@ -370,7 +394,7 @@ export default class ClusterSubscriberGroup {
               }
             });
           }
-        },
+        }
       );
     }
   }
@@ -400,11 +424,11 @@ export default class ClusterSubscriberGroup {
    */
   private hasUnhealthySubscribers(): boolean {
     const hasFailedSubscribers = Array.from(
-      this.shardedSubscribers.values(),
+      this.shardedSubscribers.values()
     ).some((sub) => !sub.isHealthy());
 
     const hasMissingSubscribers = Array.from(
-      this.subscriberToSlotsIndex.keys(),
+      this.subscriberToSlotsIndex.keys()
     ).some((nodeKey) => !this.shardedSubscribers.has(nodeKey));
 
     return hasFailedSubscribers || hasMissingSubscribers;
@@ -424,11 +448,11 @@ export default class ClusterSubscriberGroup {
 
     const attempts = Math.min(
       failedAttempts,
-      ClusterSubscriberGroup.MAX_RETRY_ATTEMPTS,
+      ClusterSubscriberGroup.MAX_RETRY_ATTEMPTS
     );
     const backoff = Math.min(
       ClusterSubscriberGroup.BASE_BACKOFF_MS * 2 ** attempts,
-      ClusterSubscriberGroup.MAX_BACKOFF_MS,
+      ClusterSubscriberGroup.MAX_BACKOFF_MS
     );
     const jitter = Math.floor((Math.random() - 0.5) * (backoff * 0.5));
     const delay = Math.max(0, backoff + jitter);
@@ -436,7 +460,7 @@ export default class ClusterSubscriberGroup {
     debug(
       "Failed to connect subscriber for %s. Refreshing slots in %dms",
       nodeKey,
-      delay,
+      delay
     );
 
     this.subscriberGroupEmitter.emit("subscriberConnectFailed", {

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -81,7 +81,9 @@ type ClusterStatus =
 /**
  * Client for the official Redis Cluster
  */
-class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commander<{
+class Cluster<
+  ReplyMapping extends ReplyMappingMode = "legacy"
+> extends Commander<{
   type: "default";
   mapping: ReplyMapping extends "resp3" ? "resp3" : "resp2";
 }> {
@@ -377,7 +379,6 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
       this.shardedSubscribers.stop();
     }
 
-
     if (status === "wait") {
       const ret = asCallback(Promise.resolve<"OK">("OK"), callback);
 
@@ -492,7 +493,7 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
     if (this.isRefreshing) {
       return;
     }
-    
+
     this.isRefreshing = true;
 
     const _this = this;
@@ -646,6 +647,23 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
             _this.options.shardedSubscribers &&
             (command.name == "ssubscribe" || command.name == "sunsubscribe")
           ) {
+            const keys = command.getKeys();
+
+            // Zero-argument sunsubscribe: unsubscribe from all sharded channels
+            if (command.name == "sunsubscribe" && keys.length === 0) {
+              const subscribers = _this.shardedSubscribers.removeAllChannels();
+
+              for (const sub of subscribers) {
+                const subInstance = sub.getInstance();
+                if (subInstance) {
+                  subInstance.sendCommand(new Command("sunsubscribe"));
+                }
+              }
+
+              command.resolve(undefined);
+              return;
+            }
+
             const sub =
               _this.shardedSubscribers.getResponsibleSubscriber(targetSlot);
 
@@ -659,13 +677,11 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
             let status = -1;
 
             if (command.name == "ssubscribe") {
-              status = _this.shardedSubscribers.addChannels(command.getKeys());
+              status = _this.shardedSubscribers.addChannels(keys);
             }
 
             if (command.name == "sunsubscribe") {
-              status = _this.shardedSubscribers.removeChannels(
-                command.getKeys()
-              );
+              status = _this.shardedSubscribers.removeChannels(keys);
             }
 
             if (status !== -1) {
@@ -943,9 +959,7 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
 
   private natMapper(nodeKey: NodeKey | RedisOptions): RedisOptions {
     const key =
-      typeof nodeKey === "string"
-        ? nodeKey
-        : `${nodeKey.host}:${nodeKey.port}`;
+      typeof nodeKey === "string" ? nodeKey : `${nodeKey.host}:${nodeKey.port}`;
 
     let mapped = null;
     if (this.options.natMap && typeof this.options.natMap === "function") {


### PR DESCRIPTION
## Problem

Fixes #2133

When `sunsubscribe()` is called without arguments in cluster mode with `shardedSubscribers: true`, the command crashes with:

```
TypeError: Cannot read properties of undefined (reading '0')
    at ClusterSubscriberGroup.getResponsibleSubscriber (lib/cluster/ClusterSubscriberGroup.ts:51)
```

**Root cause:** The command has no keys, so `command.getSlot()` returns `null`. The routing code passes this `null` to `getResponsibleSubscriber()`, which tries `this.clusterSlots[null][0]` and crashes.

Redis's `SUNSUBSCRIBE` without arguments is valid — it means "unsubscribe from all previously subscribed shard channels." The zero-argument form has no channel keys from which to compute a hash slot, so slot-based routing cannot apply.

## Solution

1. **`ClusterSubscriberGroup.removeAllChannels()`** — new method that clears all tracked channels and returns the subscriber instances that had active subscriptions.

2. **Zero-argument detection in `cluster/index.ts`** — when `sunsubscribe` is called with empty keys, the new code calls `removeAllChannels()`, sends the `SUNSUBSCRIBE` command to each affected subscriber, and resolves the original command.

This mirrors how regular (non-sharded) `unsubscribe` works — the single `ClusterSubscriber` handles the bare command without slot-based routing.

## Changes

- `lib/cluster/ClusterSubscriberGroup.ts`: Add `removeAllChannels()` method
- `lib/cluster/index.ts`: Handle zero-argument `sunsubscribe` before slot-based routing

## Testing

- TypeScript build passes
- Lint passes (0 errors, pre-existing warnings only)
- Unit tests: 359 passing, 1 failing (pre-existing `StandaloneConnector` sinon issue — same on `upstream/main`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster sharded pub/sub command routing and local channel bookkeeping; scope is narrow but incorrect handling could leave stale subscriptions or miss nodes.
> 
> **Overview**
> Fixes a crash when **`sunsubscribe()`** is called with no channel names on a cluster client with **`shardedSubscribers: true`**. With no keys, slot routing used **`null`** and **`getResponsibleSubscriber`** threw before the command could run.
> 
> **`ClusterSubscriberGroup.removeAllChannels()`** clears all tracked shard channels and returns healthy **`ShardedSubscriber`** instances that had active subscriptions. In **`sendCommand`**, a zero-argument **`sunsubscribe`** is handled before slot-based routing: that method runs, each affected connection gets a bare **`SUNSUBSCRIBE`**, and the user command resolves—matching Redis semantics and the non-sharded **`unsubscribe`** pattern.
> 
> Remaining edits are mostly formatting (trailing commas, whitespace).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6be8d8fdd6e15ac28272d591a266d23314c6b552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->