### PR TITLE
docs: add security policy

### DIFF
--- a/.agents/skills/code-change-verification/SKILL.md
+++ b/.agents/skills/code-change-verification/SKILL.md
@@ -23,7 +23,8 @@ Use this skill to choose the smallest credible validation set for an ioredis cha
    - Build/tooling changes: run `npm run build` and the affected script directly.
 
 3. Prefer focused validation before broad validation.
-   - Unit-only change: `TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test npx mocha --no-experimental-strip-types "test/helpers/*.ts" "test/unit/<file>.ts"`.
+   - For self-contained pure unit files, run the test file alone first: `TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test npx mocha --no-experimental-strip-types "test/unit/<file>.ts"`.
+   - Include `test/helpers/*.ts` only when the unit file relies on global hooks or helper setup.
    - Functional command change: include `test/helpers/*.ts` and the specific `test/functional/...` file.
    - Typing change: `npm run build` then `npx tsd --files test/typing/<file>.test-d.ts` when a focused file exists.
    - Public API or cross-cutting behavior: escalate to `npm test` after focused tests pass.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability, to ensure proper review 
+and assessment, we kindly ask vulnerability reports be submitted through
+our [Redis Vulnerability Disclosure Program.](https://redis.io/redis-responsible-vulnerability-disclosure/)
+
+We have found this path to be beneficial for both researchers and us for 
+a number of reasons. Including, offering fast response times to researchers and 
+opportunities for us to invite those with exceptional reports into closed paid 
+engagements.  
+
+For those averse to using our chosen platform, we will also accept reports directly
+via GitHub's "Report a Vulnerability".  
+
+To contact the security team directly with questions use: [security@redis.com](mailto:security@redis.com)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,4 @@ a number of reasons. Including, offering fast response times to researchers and
 opportunities for us to invite those with exceptional reports into closed paid 
 engagements.  
 
-For those averse to using our chosen platform, we will also accept reports directly
-via GitHub's "Report a Vulnerability".  
-
 To contact the security team directly with questions use: [security@redis.com](mailto:security@redis.com)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and contributor/agent guidance only; no runtime, auth, or data-handling code changes.
> 
> **Overview**
> Adds a **SECURITY.md** that directs vulnerability reports to the [Redis Vulnerability Disclosure Program](https://redis.io/redis-responsible-vulnerability-disclosure/) and lists **security@redis.com** for general security questions.
> 
> Updates the **code-change-verification** agent skill so focused unit runs start with the single `test/unit/<file>.ts` when it is self-contained, and only pull in `test/helpers/*.ts` when global hooks or helpers are required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7e15dcb5d608ca106146e44e7d7f99c46a95f70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->