### PR TITLE
chore(release): update repository URL (#2154)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/luin/ioredis.git"
+    "url": "https://github.com/redis/ioredis.git"
   },
   "keywords": [
     "redis",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only change with no effect on library behavior, APIs, or runtime code.
> 
> **Overview**
> Updates the **`repository.url`** field in `package.json` from `git://github.com/luin/ioredis.git` to **`https://github.com/redis/ioredis.git`**, aligning npm metadata with the current GitHub organization and using HTTPS instead of the legacy `git://` scheme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807bb1c8660fd47d27a2f19a9a5c08aabec1ca43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->