### PR TITLE
ci: update Redis test image

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x, 26.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8.0", "8.10-rc2"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8.0", "custom-30445126297-debian"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v6

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-8.10-rc2}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-custom-30445126297-debian}
 
 services:
   single:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test infrastructure only; no application or library runtime behavior changes.
> 
> **Overview**
> Swaps the **Redis test container** used in CI and local Docker from **`8.10-rc2`** to **`custom-30445126297-debian`** on the `redislabs/client-libs-test` image.
> 
> The **GitHub Actions** coverage workflow matrix (`test_with_cov.yml`) and the **default** `REDIS_VERSION` in `test/docker-compose.yml` are updated so tests run against the new tag when `REDIS_VERSION` is not set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0369c82e3d58b7c0fd064f48cca624e4a24c10e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->