### PR TITLE
ci: update Redis test image

### DIFF
--- a/.github/workflows/test_with_cov.yml
+++ b/.github/workflows/test_with_cov.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         node: [20.x, 22.x, 24.x, 26.x]
-        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8.0", "8.10-rc2"]
+        redis: ["rs-7.4.0-v1", "8.2", "8.4.0", "8.8.0", "custom-30445126297-debian"]
     steps:
       - name: Git checkout
         uses: actions/checkout@v6

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/luin/ioredis.git"
+    "url": "https://github.com/redis/ioredis.git"
   },
   "keywords": [
     "redis",

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,5 +1,5 @@
 x-redis-common: &redis-common
-  image: redislabs/client-libs-test:${REDIS_VERSION:-8.10-rc2}
+  image: redislabs/client-libs-test:${REDIS_VERSION:-custom-30445126297-debian}
 
 services:
   single:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test infrastructure and metadata only; no runtime library or application logic changes.
> 
> **Overview**
> CI and local Docker tests now use the **`custom-30445126297-debian`** tag of `redislabs/client-libs-test` instead of **`8.10-rc2`**, in both the coverage workflow matrix and the default `REDIS_VERSION` in `test/docker-compose.yml`.
> 
> **`package.json`** updates the repository URL from `git://github.com/luin/ioredis.git` to **`https://github.com/redis/ioredis.git`** to match the current org/home.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aac171b02ee0fd0b959087e379eda97024b41ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->