### PR TITLE
fix(types): export ScanStreamOptions, RedisStatus and ClusterStatus

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -46,7 +46,7 @@ import { defaults, noop } from "./utils/lodash";
 import Deque = require("denque");
 const debug = Debug("redis");
 
-type RedisStatus =
+export type RedisStatus =
   | "wait"
   | "reconnecting"
   | "connecting"

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -68,7 +68,7 @@ export type ClusterNode =
       port?: number | undefined;
     };
 
-type ClusterStatus =
+export type ClusterStatus =
   | "end"
   | "close"
   | "wait"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -66,6 +66,9 @@ export type {
   RedisValue,
   ChainableCommander,
 } from "./utils/RedisCommander";
+export type { ScanStreamOptions } from "./types";
+export type { RedisStatus } from "./Redis";
+export type { ClusterStatus } from "./cluster";
 
 // Tracing types for diagnostics_channel consumers
 export type {

--- a/test/typing/exports.test-d.ts
+++ b/test/typing/exports.test-d.ts
@@ -1,0 +1,35 @@
+import { expectAssignable, expectType } from "tsd";
+import {
+  Redis,
+  Cluster,
+  ScanStreamOptions,
+  RedisStatus,
+  ClusterStatus,
+} from "../../built";
+
+// The types used by the public API are exported, so consumers can name them
+// instead of re-deriving them with Parameters<...>/ReturnType<...>.
+
+// ScanStreamOptions is the parameter type of the *scanStream() methods on both
+// Redis and Cluster.
+const scanOptions: ScanStreamOptions = {
+  match: "user:*",
+  type: "string",
+  count: 100,
+  noValues: false,
+};
+expectAssignable<Parameters<Redis["scanStream"]>[0]>(scanOptions);
+expectAssignable<Parameters<Redis["hscanStream"]>[1]>(scanOptions);
+expectAssignable<Parameters<Cluster["sscanStream"]>[1]>(scanOptions);
+
+// RedisStatus is the type of the public `status` property and of the event
+// names accepted by on()/once().
+declare const redis: Redis;
+expectType<RedisStatus>(redis.status);
+expectAssignable<RedisStatus>("ready");
+expectAssignable<RedisStatus>("connecting");
+
+// ClusterStatus is the type of Cluster's public `status` property.
+declare const cluster: Cluster;
+expectType<ClusterStatus>(cluster.status);
+expectAssignable<ClusterStatus>("ready");


### PR DESCRIPTION
Three types that describe the public API are not exported, so consumers can't name them and end up re-deriving them with `Parameters<...>` / `ReturnType<...>` or widening to something looser.

| type | where it shows up in the public API |
| --- | --- |
| `ScanStreamOptions` | the options parameter of `scanStream()`, `sscanStream()`, `hscanStream()`, `zscanStream()` and their `Buffer` variants — 14 public methods across `Redis` and `Cluster` |
| `RedisStatus` | the type of the public `status` property, and of the event names accepted by the `on()` / `once()` overloads |
| `ClusterStatus` | the type of `Cluster`'s public `status` property |

`ScanStreamOptions` was already exported from `lib/types.ts` and only needed re-exporting from `lib/index.ts`; the other two gain an `export` keyword. No runtime code is touched.

Not included: `FlushQueueOptions` is in the same situation but only appears in `private flushQueue()` and an internal `DataHandledable` method, so it doesn't look like public API.

### Tests

`test/typing/exports.test-d.ts` imports the three names and checks them against the signatures they describe, so the exports can't be dropped or drift from their use sites without `tsd` failing. Verified by mutation:

- removing the three re-export lines from `lib/index.ts` → `tsd` fails with 5 errors (`has no exported member ...` ×3, plus two "Parameter type X is not identical to argument type X");
- removing only the `export` keyword from `type RedisStatus` → build fails with `lib/index.ts(70,15): error TS2614`;
- restored → clean.

### Verification

- `npm run test:tsd` — passes.
- `npm run lint` — rc=0, same 23 warnings as baseline, none in changed lines.
- `prettier --check` — same 13 warnings as baseline; `lib/cluster/index.ts` is flagged on baseline too and the edited region is byte-identical to prettier's output.
- `npm run test:js` against `docker:setup` (single + cluster, both healthy) — **2545 passing, 34 pending, 6 failing**. The six are `georadiusbymember` / `georadiusbymember_ro` ("returns the anchor member within a zero radius", RESP2/legacy + RESP3/legacy + RESP3/resp3). They reproduce identically on unmodified `main` with this change stashed, so they're pre-existing and unrelated to this PR.

Related: #1880 asked for `RedisStatus` to be exported; it was closed automatically as stale, with no maintainer decision on it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only surface area with no runtime changes; risk is limited to accidental export removal or type drift, which tsd guards against.
> 
> **Overview**
> **Exports three public API types** so TypeScript consumers can import them by name instead of using `Parameters<...>` / `ReturnType<...>`.
> 
> `ScanStreamOptions` is re-exported from the package entry (`lib/index.ts`); it already existed in `lib/types.ts`. `RedisStatus` and `ClusterStatus` are now exported from their defining modules (`lib/Redis.ts`, `lib/cluster/index.ts`) and re-exported from `lib/index.ts`. **No runtime behavior changes.**
> 
> Adds `test/typing/exports.test-d.ts` with **tsd** checks that these exports stay aligned with `scanStream` options, `Redis.status`, and `Cluster.status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5416d6f0dc28966850bd95bedd72268a64920dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->