### PR TITLE
feat: himport managed fieldsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ const result = await redis.setBuffer("foo", "new value", "GET");
 HIMPORT provides a faster ingestion mechanism for loading many hashes that
 share the same set of field names.
 
+Explicit pipelines containing a configured `HIMPORT SET` wait for required
+fieldset preparation on their selected connection before the batch is sent.
+Unconfigured fieldsets remain manually managed.
+
 ```javascript
 const redis = new Redis({
   himportFieldsets: [

--- a/README.md
+++ b/README.md
@@ -313,6 +313,40 @@ const result = await redis.setBuffer("foo", "new value", "GET");
 // result is `<Buffer 62 75 66>` as `GET` indicates returning the old value.
 ```
 
+## HIMPORT Fieldsets (experimental)
+
+> [!WARNING]
+> HIMPORT support is experimental and may change in a future release. When a
+> managed `HIMPORT SET` needs fieldset preparation or recovery, later commands
+> may be sent before that SET resumes. Await the SET before issuing commands
+> that depend on its write.
+
+HIMPORT provides a faster ingestion mechanism for loading many hashes that
+share the same set of field names.
+
+```javascript
+const redis = new Redis({
+  himportFieldsets: [
+    {
+      name: "user-profile",
+      fields: ["name", "email", "age"],
+    },
+  ],
+});
+
+await redis.himport(
+  "SET",
+  "user:42",
+  "user-profile",
+  "Ada",
+  "ada@example.com",
+  "37"
+);
+```
+
+See [`examples/himport.js`](examples/himport.js) for managed fieldsets and
+manual batches.
+
 ## Pipelining
 
 If you want to send a batch of commands (e.g. > 5), you can use pipelining to queue

--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -191,6 +191,10 @@ module.exports = {
   hpexpire: "number[]",
   hget: "string | null",
   hgetall: "[field: string, value: string][]",
+  himport: (types) => {
+    if (matchSubcommand(types, ["PREPARE", "SET"])) return "'OK'";
+    if (matchSubcommand(types, ["DISCARD", "DISCARDALL"])) return "number";
+  },
   hgetdel: "(string | null)[]",
   hgetex: "(string | null)[]",
   hincrby: "number",

--- a/examples/himport.js
+++ b/examples/himport.js
@@ -1,0 +1,71 @@
+const Redis = require("..");
+
+// -----------------------------------------------------------------------------
+// 1. Managed fieldsets: configure once and use for the client's lifetime
+// -----------------------------------------------------------------------------
+
+async function managedFieldsetsExample() {
+  const redis = new Redis({
+    himportFieldsets: [
+      {
+        name: "user-profile",
+        fields: ["name", "email", "age"],
+      },
+    ],
+  });
+
+  try {
+    await redis.himport(
+      "SET",
+      "himport:managed:user:1",
+      "user-profile",
+      "Ada",
+      "ada@example.com",
+      "37"
+    );
+
+    console.log("Managed:", await redis.hgetall("himport:managed:user:1"));
+  } finally {
+    await redis.del("himport:managed:user:1");
+    redis.disconnect();
+  }
+}
+
+// -----------------------------------------------------------------------------
+// 2. Manual batches: explicitly prepare, use, and discard a fieldset
+// -----------------------------------------------------------------------------
+
+async function manualBatchExample() {
+  const redis = new Redis();
+
+  try {
+    await redis.himport("PREPARE", "batch-user", "name", "email");
+
+    try {
+      await redis.himport(
+        "SET",
+        "himport:batch:user:1",
+        "batch-user",
+        "Grace",
+        "grace@example.com"
+      );
+
+      console.log("Manual:", await redis.hgetall("himport:batch:user:1"));
+    } finally {
+      await redis.himport("DISCARD", "batch-user");
+    }
+  } finally {
+    await redis.del("himport:batch:user:1");
+    redis.disconnect();
+  }
+}
+
+async function main() {
+  await managedFieldsetsExample();
+  await manualBatchExample();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -237,6 +237,7 @@ export default class Command implements Respondable {
   isTraced = false;
 
   isResolved = false;
+  isSettled = false;
   reject: (err: Error) => void;
   resolve: (result: any) => void;
   promise: Promise<any>;
@@ -417,7 +418,7 @@ export default class Command implements Respondable {
   setTimeout(ms: number) {
     if (!this._commandTimeoutTimer) {
       this._commandTimeoutTimer = setTimeout(() => {
-        if (!this.isResolved) {
+        if (!this.isSettled) {
           this.reject(new Error("Command timed out"));
         }
       }, ms);
@@ -457,7 +458,7 @@ export default class Command implements Respondable {
     }
 
     this._blockingTimeoutTimer = setTimeout(() => {
-      if (this.isResolved) {
+      if (this.isSettled) {
         this._blockingTimeoutTimer = undefined;
         return;
       }
@@ -535,6 +536,7 @@ export default class Command implements Respondable {
       this.resolve = this._convertValue(resolve);
       this.reject = (err: Error) => {
         this._clearTimers();
+        this.isSettled = true;
         if (this.errorStack) {
           reject(optimizeErrorStack(err, this.errorStack.stack, __dirname));
         } else {
@@ -577,6 +579,7 @@ export default class Command implements Respondable {
         this._clearTimers();
         resolve(this.transformReply(value));
         this.isResolved = true;
+        this.isSettled = true;
       } catch (err) {
         this.reject(err);
       }

--- a/lib/Command.ts
+++ b/lib/Command.ts
@@ -523,6 +523,9 @@ export default class Command implements Respondable {
   }
 
   private initPromise() {
+    this.isResolved = false;
+    this.isSettled = false;
+
     const promise = new Promise((resolve, reject) => {
       if (!this.transformed) {
         this.transformed = true;

--- a/lib/Pipeline.ts
+++ b/lib/Pipeline.ts
@@ -9,6 +9,7 @@ import { Callback, PipelineWriteableStream } from "./types";
 import { constants } from "buffer";
 import { noop } from "./utils";
 import Commander from "./utils/Commander";
+import { interceptHimportPipeline } from "./himport/HimportCoordinator";
 
 /*
   This function derives from the cluster-key-slot implementation.
@@ -340,15 +341,33 @@ Pipeline.prototype.exec = function (callback: Callback): Promise<Array<any>> {
   }
 
   const _this = this;
-  execPipeline();
+  let node;
+  const himportIntercepted = interceptHimportPipeline({
+    owner: _this.redis,
+    commands: _this._queue,
+    slot: pipelineSlot,
+    preferredNodeKey: _this.preferKey,
+    setDestination(connection) {
+      node = {
+        slot: pipelineSlot,
+        redis: connection,
+      };
+    },
+    resume: execPipeline,
+    reject(error) {
+      _this.reject(error);
+    },
+  });
+  if (!himportIntercepted) {
+    execPipeline();
+  }
 
   return this.promise;
 
   function execPipeline() {
     let writePending: number = (_this.replyPending = _this._queue.length);
 
-    let node;
-    if (_this.isCluster) {
+    if (_this.isCluster && !node) {
       node = {
         slot: pipelineSlot,
         redis: _this.redis.connectionPool.nodes.all[_this.preferKey],

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -45,6 +45,7 @@ import Commander from "./utils/Commander";
 import { defaults, noop } from "./utils/lodash";
 import HimportCoordinator, {
   bindHimportCoordinator,
+  hasHimportCoordinator,
   interceptHimportCommand,
   isInternalHimportCommand,
 } from "./himport/HimportCoordinator";
@@ -130,6 +131,7 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
   private retryAttempts = 0;
   private manuallyClosing = false;
   private socketTimeoutTimer: NodeJS.Timeout | undefined;
+  private [hasHimportCoordinator] = false;
 
   // Prepare autopipelines structures
   private _autoPipelines = new Map();
@@ -524,6 +526,7 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
 
     if (
       !stream &&
+      this[hasHimportCoordinator] &&
       interceptHimportCommand(
         this,
         command,

--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -43,6 +43,12 @@ import {
 import applyMixin from "./utils/applyMixin";
 import Commander from "./utils/Commander";
 import { defaults, noop } from "./utils/lodash";
+import HimportCoordinator, {
+  bindHimportCoordinator,
+  interceptHimportCommand,
+  isInternalHimportCommand,
+} from "./himport/HimportCoordinator";
+import { cloneHimportFieldsets } from "./himport/HimportCoordinator";
 import Deque = require("denque");
 const debug = Debug("redis");
 
@@ -157,6 +163,17 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
     this.parseOptions(arg1, arg2, arg3);
 
     EventEmitter.call(this);
+
+    this.options.himportFieldsets = cloneHimportFieldsets(
+      this.options.himportFieldsets
+    );
+    if (this.options.himportFieldsets?.length) {
+      bindHimportCoordinator(
+        this,
+        new HimportCoordinator(this.options.himportFieldsets),
+        "standalone"
+      );
+    }
 
     this.resetCommandQueue();
     this.resetOfflineQueue();
@@ -448,6 +465,7 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
     const monitorInstance = this.duplicate({
       monitor: true,
       lazyConnect: false,
+      himportFieldsets: undefined,
     });
 
     return asCallback(
@@ -504,6 +522,20 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
       command.setTimeout(this.options.commandTimeout);
     }
 
+    if (
+      !stream &&
+      interceptHimportCommand(
+        this,
+        command,
+        this.status === "ready",
+        () => {
+          this.sendCommand(command);
+        }
+      )
+    ) {
+      return command.promise;
+    }
+
     const blockingTimeout = this.getBlockingTimeoutInMs(command);
 
     let writable =
@@ -512,7 +544,8 @@ class Redis<ReplyMapping extends ReplyMappingMode = "legacy">
       (!stream &&
         this.status === "connect" &&
         this.condition?.handshake &&
-        Command.checkFlag("HANDSHAKE_COMMANDS", command.name)) ||
+        (Command.checkFlag("HANDSHAKE_COMMANDS", command.name) ||
+          isInternalHimportCommand(command))) ||
       // Before ready, loading-safe commands remain writable after handshake.
       (!stream &&
         this.status === "connect" &&

--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -22,6 +22,7 @@ export const notAllowedAutoPipelineCommands = [
   "client",
   "hello",
   "readonly",
+  "himport",
 ];
 
 function executeAutoPipeline(client, slotKey: string) {

--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -3,6 +3,7 @@ import { RedisOptions, RetryStrategy } from "../redis/RedisOptions";
 import { ReplyMappingMode } from "../types";
 import { CommanderOptions } from "../utils/Commander";
 import { NodeRole } from "./util";
+import type { HimportFieldset } from "../himport/types";
 
 export type DNSResolveSrvFunction = (
   hostname: string,
@@ -170,6 +171,7 @@ export interface ClusterOptions extends CommanderOptions {
         | "retryStrategy"
         | "enableOfflineQueue"
         | "readOnly"
+        | "himportFieldsets"
       >
     | undefined;
 
@@ -233,6 +235,24 @@ export interface ClusterOptions extends CommanderOptions {
   scripts?:
     | Record<string, { lua: string; numberOfKeys?: number; readOnly?: boolean }>
     | undefined;
+
+  /**
+   * Experimental.
+   *
+   * Long-lived HIMPORT fieldsets managed across all current and future master
+   * connections for the lifetime of this Cluster client.
+   *
+   * When a managed `HIMPORT SET` needs fieldset preparation or recovery,
+   * later commands issued on this Cluster client may be sent before that SET
+   * resumes. Await the SET before issuing commands that depend on its write.
+   *
+   * Use explicit HIMPORT commands on a separate unconfigured client for
+   * bounded, manually managed batches.
+   *
+   * @default undefined
+   * @experimental
+   */
+  himportFieldsets?: readonly HimportFieldset[] | undefined;
 }
 
 export type ClusterOptionsWithReplyMapping<Mapping extends ReplyMappingMode> =

--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -246,6 +246,9 @@ export interface ClusterOptions extends CommanderOptions {
    * later commands issued on this Cluster client may be sent before that SET
    * resumes. Await the SET before issuing commands that depend on its write.
    *
+   * Explicit pipelines containing a managed `HIMPORT SET` wait for required
+   * fieldset preparation on the selected master before the batch is sent.
+   *
    * Use explicit HIMPORT commands on a separate unconfigured client for
    * bounded, manually managed batches.
    *

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -8,6 +8,12 @@ const debug = Debug("cluster:connectionPool");
 
 type NODE_TYPE = "all" | "master" | "slave";
 
+export interface ConnectionPoolHooks {
+  onCreate?: (redis: Redis, readOnly: boolean) => void;
+  onRoleChange?: (redis: Redis, key: NodeKey, readOnly: boolean) => void;
+  onRemove?: (redis: Redis) => void;
+}
+
 export default class ConnectionPool extends EventEmitter {
   // master + slave = all
   private nodes: { [key in NODE_TYPE]: { [key: string]: Redis } } = {
@@ -20,7 +26,8 @@ export default class ConnectionPool extends EventEmitter {
 
   constructor(
     private redisOptions: NonNullable<ClusterOptions["redisOptions"]>,
-    private clusterNodeRetryStrategy: ClusterNodeRetryStrategy = null
+    private clusterNodeRetryStrategy: ClusterNodeRetryStrategy = null,
+    private hooks: ConnectionPoolHooks = {}
   ) {
     super();
   }
@@ -90,6 +97,7 @@ export default class ConnectionPool extends EventEmitter {
         )
     );
 
+    this.hooks.onCreate?.(redis, readOnly);
     return redis
   }
 
@@ -121,6 +129,7 @@ export default class ConnectionPool extends EventEmitter {
           delete this.nodes.slave[key];
           this.nodes.master[key] = redis;
         }
+        this.hooks.onRoleChange?.(redis, key, readOnly);
       }
     } else {
       debug("Connecting to %s as %s", key, readOnly ? "slave" : "master");
@@ -211,6 +220,7 @@ export default class ConnectionPool extends EventEmitter {
     const { nodes } = this;
     if (nodes.all[key]) {
       debug("Remove %s from the pool", key);
+      this.hooks.onRemove?.(nodes.all[key]);
       delete nodes.all[key];
     }
     delete nodes.master[key];

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -45,10 +45,19 @@ import {
   NodeRole,
   normalizeNodeOptions,
   RedisOptions,
+  waitForRedisReady,
   weightSrvRecords,
 } from "./util";
 import Deque = require("denque");
 import ClusterSubscriberGroup from "./ClusterSubscriberGroup";
+import HimportCoordinator, {
+  bindHimportCoordinator,
+  cloneHimportFieldsets,
+  getHimportBinding,
+  interceptHimportControlCommand,
+  setHimportRole,
+  unbindHimportCoordinator,
+} from "../himport/HimportCoordinator";
 
 const debug = Debug("cluster");
 
@@ -81,7 +90,9 @@ export type ClusterStatus =
 /**
  * Client for the official Redis Cluster
  */
-class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commander<{
+class Cluster<
+  ReplyMapping extends ReplyMappingMode = "legacy"
+> extends Commander<{
   type: "default";
   mapping: ReplyMapping extends "resp3" ? "resp3" : "resp2";
 }> {
@@ -145,6 +156,12 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
 
     this.startupNodes = startupNodes;
     this.options = defaults({}, options, DEFAULT_CLUSTER_OPTIONS, this.options);
+    this.options.himportFieldsets = cloneHimportFieldsets(
+      this.options.himportFieldsets
+    );
+    const himportCoordinator = this.options.himportFieldsets?.length
+      ? new HimportCoordinator(this.options.himportFieldsets)
+      : undefined;
 
     if (this.options.shardedSubscribers) {
       this.createShardedSubscriberGroup();
@@ -170,9 +187,47 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
       );
     }
 
+    const redisOptions = { ...(this.options.redisOptions ?? {}) };
+    delete (redisOptions as Partial<RedisOptions>).himportFieldsets;
     this.connectionPool = new ConnectionPool(
-      this.options.redisOptions ?? {},
-      this.options.clusterNodeRetryStrategy
+      redisOptions,
+      this.options.clusterNodeRetryStrategy,
+      himportCoordinator
+        ? {
+            onCreate: (redis, readOnly) => {
+              bindHimportCoordinator(
+                redis,
+                himportCoordinator,
+                readOnly ? "replica" : "master"
+              );
+            },
+            onRoleChange: (redis, key, readOnly) => {
+              setHimportRole(redis, readOnly ? "replica" : "master");
+              himportCoordinator.invalidate(redis);
+              if (!readOnly) {
+                waitForRedisReady(redis).then(
+                  () => {
+                    for (const definition of himportCoordinator.getDefinitions()) {
+                      const preparation = himportCoordinator.ensurePrepared(
+                        redis,
+                        definition
+                      );
+                      preparation?.catch((error) => {
+                        this.emit("node error", error, key);
+                      });
+                    }
+                  },
+                  (error: Error) => {
+                    this.emit("node error", error, key);
+                  }
+                );
+              }
+            },
+            onRemove: (redis) => {
+              unbindHimportCoordinator(redis);
+            },
+          }
+        : undefined
     );
 
     this.connectionPool.on("-node", (redis, key) => {
@@ -377,7 +432,6 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
       this.shardedSubscribers.stop();
     }
 
-
     if (status === "wait") {
       const ret = asCallback(Promise.resolve<"OK">("OK"), callback);
 
@@ -492,7 +546,7 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
     if (this.isRefreshing) {
       return;
     }
-    
+
     this.isRefreshing = true;
 
     const _this = this;
@@ -550,6 +604,17 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
     }
     if (this.status === "end") {
       command.reject(new Error(CONNECTION_CLOSED_ERROR_MSG));
+      return command.promise;
+    }
+    if (
+      !stream &&
+      !node &&
+      this.status === "ready" &&
+      interceptHimportControlCommand(
+        this.connectionPool.getNodes("master"),
+        command
+      )
+    ) {
       return command.promise;
     }
     let to = this.options.scaleReads;
@@ -714,7 +779,6 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
             }
             if (asking) {
               redis = _this.connectionPool.getInstanceByKey(asking);
-              redis.asking();
             }
           }
           if (!redis) {
@@ -757,6 +821,43 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
       }
 
       lastRedis = redis;
+      if (asking) {
+        const himportBinding = getHimportBinding(redis);
+        const managedSet =
+          !stream && himportBinding?.role === "master"
+            ? himportBinding.coordinator.classify(command)
+            : undefined;
+        if (managedSet) {
+          waitForRedisReady(redis)
+            .then(() => {
+              if (command.isSettled) {
+                return;
+              }
+              const preparation = himportBinding.coordinator.prepareCommand(
+                redis,
+                command
+              );
+              return preparation ?? Promise.resolve();
+            })
+            .then(
+              () => {
+                if (command.isSettled) {
+                  return;
+                }
+                himportBinding.coordinator.allowNextSend(redis, command);
+                redis.asking();
+                redis.sendCommand(command, stream);
+              },
+              (error: Error) => {
+                if (!command.isSettled) {
+                  command.reject(error);
+                }
+              }
+            );
+          return;
+        }
+        redis.asking();
+      }
       redis.sendCommand(command, stream);
     }
     return command.promise;
@@ -953,9 +1054,7 @@ class Cluster<ReplyMapping extends ReplyMappingMode = "legacy"> extends Commande
 
   private natMapper(nodeKey: NodeKey | RedisOptions): RedisOptions {
     const key =
-      typeof nodeKey === "string"
-        ? nodeKey
-        : `${nodeKey.host}:${nodeKey.port}`;
+      typeof nodeKey === "string" ? nodeKey : `${nodeKey.host}:${nodeKey.port}`;
 
     let mapped = null;
     if (this.options.natMap && typeof this.options.natMap === "function") {

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -55,6 +55,7 @@ import HimportCoordinator, {
   cloneHimportFieldsets,
   getHimportBinding,
   interceptHimportControlCommand,
+  isHimportControlCommand,
   setHimportRole,
   unbindHimportCoordinator,
 } from "../himport/HimportCoordinator";
@@ -613,6 +614,7 @@ class Cluster<
       !stream &&
       !node &&
       this.status === "ready" &&
+      isHimportControlCommand(command) &&
       interceptHimportControlCommand(
         this.connectionPool.getNodes("master"),
         command

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -162,6 +162,9 @@ class Cluster<
     const himportCoordinator = this.options.himportFieldsets?.length
       ? new HimportCoordinator(this.options.himportFieldsets)
       : undefined;
+    if (himportCoordinator) {
+      bindHimportCoordinator(this, himportCoordinator, "cluster");
+    }
 
     if (this.options.shardedSubscribers) {
       this.createShardedSubscriberGroup();

--- a/lib/cluster/util.ts
+++ b/lib/cluster/util.ts
@@ -1,4 +1,9 @@
-import { parseURL, resolveTLSProfile } from "../utils";
+import type Redis from "../Redis";
+import {
+  CONNECTION_CLOSED_ERROR_MSG,
+  parseURL,
+  resolveTLSProfile,
+} from "../utils";
 import { isIP } from "net";
 import { SrvRecord } from "dns";
 
@@ -20,6 +25,32 @@ export interface SrvRecordsGroup {
 
 export interface GroupedSrvRecords {
   [key: number]: SrvRecordsGroup;
+}
+
+export function waitForRedisReady(redis: Redis): Promise<void> {
+  if (redis.status === "ready") {
+    return Promise.resolve();
+  }
+  if (redis.status === "wait") {
+    return redis.connect();
+  }
+  if (redis.status === "end") {
+    return Promise.reject(new Error(CONNECTION_CLOSED_ERROR_MSG));
+  }
+
+  return new Promise((resolve, reject) => {
+    const onReady = () => {
+      redis.removeListener("end", onEnd);
+      resolve();
+    };
+    const onEnd = () => {
+      redis.removeListener("ready", onReady);
+      reject(new Error(CONNECTION_CLOSED_ERROR_MSG));
+    };
+
+    redis.once("ready", onReady);
+    redis.once("end", onEnd);
+  });
 }
 
 export function getNodeKey(node: RedisOptions): NodeKey {

--- a/lib/himport/HimportCoordinator.ts
+++ b/lib/himport/HimportCoordinator.ts
@@ -54,6 +54,12 @@ export interface HimportBinding {
   role: HimportConnectionRole;
 }
 
+export const hasHimportCoordinator = Symbol("hasHimportCoordinator");
+
+type HimportBindingOwner = object & {
+  [hasHimportCoordinator]?: boolean;
+};
+
 const bindings = new WeakMap<object, HimportBinding>();
 const internalCommands = new WeakSet<Command>();
 const debug = Debug("himport");
@@ -447,6 +453,7 @@ export function bindHimportCoordinator(
   role: HimportConnectionRole
 ): void {
   bindings.set(owner, { coordinator, role });
+  (owner as HimportBindingOwner)[hasHimportCoordinator] = true;
 }
 
 export function getHimportBinding(owner: object): HimportBinding | undefined {
@@ -542,6 +549,7 @@ export function unbindHimportCoordinator(owner: object): void {
     binding.coordinator.detach(owner as HimportConnection);
     bindings.delete(owner);
   }
+  (owner as HimportBindingOwner)[hasHimportCoordinator] = false;
 }
 
 export function isInternalHimportCommand(command: Command): boolean {

--- a/lib/himport/HimportCoordinator.ts
+++ b/lib/himport/HimportCoordinator.ts
@@ -434,7 +434,10 @@ export default class HimportCoordinator {
     connection: HimportConnection,
     definition: HimportDefinition
   ): void {
-    this.getSession(connection).fieldsets.delete(definition.canonicalName);
+    const fieldsets = this.getSession(connection).fieldsets;
+    if (fieldsets.get(definition.canonicalName)?.status === "prepared") {
+      fieldsets.delete(definition.canonicalName);
+    }
   }
 }
 

--- a/lib/himport/HimportCoordinator.ts
+++ b/lib/himport/HimportCoordinator.ts
@@ -1,0 +1,510 @@
+import Command from "../Command";
+import { Debug } from "../utils";
+import type { HimportFieldset } from "./types";
+
+type HimportConnectionRole = "standalone" | "master" | "replica";
+
+export interface HimportConnection {
+  sendCommand(command: Command): unknown;
+}
+
+interface HimportDefinition {
+  readonly canonicalName: string;
+  readonly name: string | Buffer;
+  readonly fields: readonly (string | Buffer)[];
+}
+
+type PreparationState =
+  | { status: "preparing"; promise: Promise<void> }
+  | { status: "prepared" };
+
+interface ConnectionSessionState {
+  fieldsets: Map<string, PreparationState>;
+}
+
+interface ManagedSetContext {
+  definition: HimportDefinition;
+  lastConnection?: HimportConnection;
+  resumeSend?: () => void;
+  recoveryAttempts: number;
+  recoveryInstalled: boolean;
+  sendWithoutPreparationOn?: HimportConnection;
+}
+
+export interface HimportBinding {
+  coordinator: HimportCoordinator;
+  role: HimportConnectionRole;
+}
+
+const bindings = new WeakMap<object, HimportBinding>();
+const internalCommands = new WeakSet<Command>();
+const debug = Debug("himport");
+
+function copyValue(value: string | Buffer): string | Buffer {
+  return value instanceof Buffer ? Buffer.from(value) : value;
+}
+
+function canonicalize(value: string | Buffer): string {
+  return Buffer.from(value).toString("base64");
+}
+
+function commandToken(value: unknown): string {
+  if (value === undefined) {
+    return "";
+  }
+  return Buffer.isBuffer(value)
+    ? value.toString("utf8").toUpperCase()
+    : String(value).toUpperCase();
+}
+
+export function cloneHimportFieldsets(
+  fieldsets: readonly HimportFieldset[] | undefined
+): readonly HimportFieldset[] | undefined {
+  if (fieldsets === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(fieldsets)) {
+    throw new TypeError("himportFieldsets must be an array");
+  }
+
+  const names = new Set<string>();
+  const copied = fieldsets.map((fieldset) => {
+    if (!fieldset || typeof fieldset !== "object") {
+      throw new TypeError("Each HIMPORT fieldset must be an object");
+    }
+    if (typeof fieldset.name !== "string" && !Buffer.isBuffer(fieldset.name)) {
+      throw new TypeError(
+        "Each HIMPORT fieldset name must be a string or Buffer"
+      );
+    }
+    if (!Array.isArray(fieldset.fields)) {
+      throw new TypeError(
+        "Each HIMPORT fieldset fields value must be an array"
+      );
+    }
+
+    const name = copyValue(fieldset.name);
+    const canonicalName = canonicalize(name);
+    if (names.has(canonicalName)) {
+      throw new TypeError("Duplicate HIMPORT fieldset name");
+    }
+    names.add(canonicalName);
+
+    const fields = fieldset.fields.map((field) => {
+      if (typeof field !== "string" && !Buffer.isBuffer(field)) {
+        throw new TypeError("Each HIMPORT field must be a string or Buffer");
+      }
+      return copyValue(field);
+    });
+
+    return Object.freeze({
+      name,
+      fields: Object.freeze(fields),
+    });
+  });
+
+  return Object.freeze(copied);
+}
+
+export default class HimportCoordinator {
+  private readonly definitions: readonly HimportDefinition[];
+  private readonly definitionsByName = new Map<string, HimportDefinition>();
+  private readonly sessions = new WeakMap<
+    HimportConnection,
+    ConnectionSessionState
+  >();
+  private readonly managedSets = new WeakMap<Command, ManagedSetContext>();
+
+  constructor(fieldsets: readonly HimportFieldset[]) {
+    this.definitions = fieldsets.map((fieldset) => {
+      const definition = {
+        canonicalName: canonicalize(fieldset.name),
+        name: fieldset.name,
+        fields: fieldset.fields,
+      };
+      this.definitionsByName.set(definition.canonicalName, definition);
+      return definition;
+    });
+  }
+
+  get size(): number {
+    return this.definitions.length;
+  }
+
+  beginSession(connection: HimportConnection): void {
+    this.sessions.set(connection, {
+      fieldsets: new Map(),
+    });
+  }
+
+  detach(connection: HimportConnection): void {
+    this.sessions.delete(connection);
+  }
+
+  invalidate(connection: HimportConnection): void {
+    const session = this.sessions.get(connection);
+    if (session) {
+      session.fieldsets.clear();
+    }
+  }
+
+  getDefinitions(): readonly HimportDefinition[] {
+    return this.definitions;
+  }
+
+  classify(command: Command): ManagedSetContext | undefined {
+    const existing = this.managedSets.get(command);
+    if (existing) {
+      return existing;
+    }
+    if (
+      command.name.toLowerCase() !== "himport" ||
+      commandToken(command.args[0]) !== "SET"
+    ) {
+      return undefined;
+    }
+
+    const fieldsetName = command.args[2];
+    if (typeof fieldsetName !== "string" && !Buffer.isBuffer(fieldsetName)) {
+      return undefined;
+    }
+
+    const definition = this.definitionsByName.get(canonicalize(fieldsetName));
+    if (!definition) {
+      return undefined;
+    }
+
+    const context: ManagedSetContext = {
+      definition,
+      recoveryAttempts: 0,
+      recoveryInstalled: false,
+    };
+    this.managedSets.set(command, context);
+    return context;
+  }
+
+  prepareCommand(
+    connection: HimportConnection,
+    command: Command
+  ): Promise<void> | undefined {
+    const context = this.classify(command);
+    if (!context) {
+      return undefined;
+    }
+    return this.ensurePrepared(connection, context.definition);
+  }
+
+  interceptCommand(
+    connection: HimportConnection,
+    command: Command,
+    ready: boolean,
+    resumeSend: () => void
+  ): boolean {
+    if (command.isSettled) {
+      return true;
+    }
+
+    if (command.name.toLowerCase() === "reset") {
+      this.invalidate(connection);
+    }
+
+    const managedSet = this.classify(command);
+    if (!managedSet) {
+      return false;
+    }
+
+    this.installRecovery(connection, command, resumeSend);
+    const maySend = this.consumeAllowedSend(connection, command);
+    if (!ready || maySend) {
+      return false;
+    }
+
+    const preparation = this.prepareCommand(connection, command);
+    if (!preparation) {
+      return false;
+    }
+
+    preparation.then(
+      () => {
+        if (command.isSettled) {
+          return;
+        }
+        try {
+          this.allowNextSend(connection, command);
+          resumeSend();
+        } catch (error) {
+          command.reject(error as Error);
+        }
+      },
+      (error: Error) => {
+        if (!command.isSettled) {
+          command.reject(error);
+        }
+      }
+    );
+    return true;
+  }
+
+  allowNextSend(connection: HimportConnection, command: Command): void {
+    const context = this.classify(command);
+    if (context) {
+      context.sendWithoutPreparationOn = connection;
+    }
+  }
+
+  consumeAllowedSend(connection: HimportConnection, command: Command): boolean {
+    const context = this.managedSets.get(command);
+    if (context?.sendWithoutPreparationOn !== connection) {
+      return false;
+    }
+    context.sendWithoutPreparationOn = undefined;
+    return true;
+  }
+
+  installRecovery(
+    connection: HimportConnection,
+    command: Command,
+    resumeSend: () => void
+  ): void {
+    const context = this.classify(command);
+    if (!context) {
+      return;
+    }
+
+    context.lastConnection = connection;
+    context.resumeSend = resumeSend;
+    if (context.recoveryInstalled) {
+      return;
+    }
+    context.recoveryInstalled = true;
+
+    const reject = command.reject;
+    command.reject = (error: Error) => {
+      if (command.isSettled) {
+        return;
+      }
+
+      const recoveryConnection = context.lastConnection;
+      const recoverySend = context.resumeSend;
+      if (
+        context.recoveryAttempts > 0 ||
+        !recoveryConnection ||
+        !recoverySend ||
+        !isMissingFieldsetError(error)
+      ) {
+        reject.call(command, error);
+        return;
+      }
+
+      context.recoveryAttempts += 1;
+      this.markUnprepared(recoveryConnection, context.definition);
+      const preparation = this.ensurePrepared(
+        recoveryConnection,
+        context.definition
+      );
+
+      Promise.resolve(preparation).then(
+        () => {
+          if (command.isSettled) {
+            return;
+          }
+          try {
+            this.allowNextSend(recoveryConnection, command);
+            recoverySend();
+          } catch (sendError) {
+            reject.call(command, sendError as Error);
+          }
+        },
+        (preparationError: Error) => {
+          if (!command.isSettled) {
+            reject.call(command, preparationError);
+          }
+        }
+      );
+    };
+  }
+
+  ensurePrepared(
+    connection: HimportConnection,
+    definition: HimportDefinition
+  ): Promise<void> | undefined {
+    const session = this.getSession(connection);
+    const current = session.fieldsets.get(definition.canonicalName);
+
+    if (current?.status === "prepared") {
+      return undefined;
+    }
+    if (current?.status === "preparing") {
+      return current.promise;
+    }
+
+    const command = new Command("himport", [
+      "PREPARE",
+      definition.name,
+      ...definition.fields,
+    ]);
+    internalCommands.add(command);
+
+    const promise = Promise.resolve(connection.sendCommand(command)).then(
+      () => {
+        if (this.sessions.get(connection) !== session) {
+          return (
+            this.ensurePrepared(connection, definition) ?? Promise.resolve()
+          );
+        }
+        const latest = session.fieldsets.get(definition.canonicalName);
+        if (latest?.status === "preparing" && latest.promise === promise) {
+          session.fieldsets.set(definition.canonicalName, {
+            status: "prepared",
+          });
+        }
+      },
+      (error: Error) => {
+        if (this.sessions.get(connection) !== session) {
+          return (
+            this.ensurePrepared(connection, definition) ?? Promise.resolve()
+          );
+        }
+        const latest = session.fieldsets.get(definition.canonicalName);
+        if (latest?.status === "preparing" && latest.promise === promise) {
+          session.fieldsets.delete(definition.canonicalName);
+        }
+        throw error;
+      }
+    );
+
+    session.fieldsets.set(definition.canonicalName, {
+      status: "preparing",
+      promise,
+    });
+    return promise;
+  }
+
+  private getSession(connection: HimportConnection): ConnectionSessionState {
+    let session = this.sessions.get(connection);
+    if (!session) {
+      session = {
+        fieldsets: new Map(),
+      };
+      this.sessions.set(connection, session);
+    }
+    return session;
+  }
+
+  private markUnprepared(
+    connection: HimportConnection,
+    definition: HimportDefinition
+  ): void {
+    this.getSession(connection).fieldsets.delete(definition.canonicalName);
+  }
+}
+
+export function bindHimportCoordinator(
+  owner: object,
+  coordinator: HimportCoordinator,
+  role: HimportConnectionRole
+): void {
+  bindings.set(owner, { coordinator, role });
+}
+
+export function getHimportBinding(owner: object): HimportBinding | undefined {
+  return bindings.get(owner);
+}
+
+export function interceptHimportCommand(
+  connection: HimportConnection,
+  command: Command,
+  ready: boolean,
+  resumeSend: () => void
+): boolean {
+  const binding = bindings.get(connection);
+  if (
+    !binding ||
+    binding.role === "replica" ||
+    isInternalHimportCommand(command)
+  ) {
+    return false;
+  }
+  return binding.coordinator.interceptCommand(
+    connection,
+    command,
+    ready,
+    resumeSend
+  );
+}
+
+export function setHimportRole(
+  owner: object,
+  role: HimportConnectionRole
+): void {
+  const binding = bindings.get(owner);
+  if (binding) {
+    binding.role = role;
+  }
+}
+
+export function unbindHimportCoordinator(owner: object): void {
+  const binding = bindings.get(owner);
+  if (binding) {
+    binding.coordinator.detach(owner as HimportConnection);
+    bindings.delete(owner);
+  }
+}
+
+export function isInternalHimportCommand(command: Command): boolean {
+  return internalCommands.has(command);
+}
+
+export function isHimportControlCommand(command: Command): boolean {
+  if (command.name.toLowerCase() !== "himport") {
+    return false;
+  }
+  return ["PREPARE", "DISCARD", "DISCARDALL"].includes(
+    commandToken(command.args[0])
+  );
+}
+
+export function interceptHimportControlCommand(
+  connections: readonly HimportConnection[],
+  command: Command
+): boolean {
+  if (!isHimportControlCommand(command) || connections.length === 0) {
+    return false;
+  }
+
+  const replies = connections.map((connection) => {
+    const clone = new Command(command.name, command.args);
+    connection.sendCommand(clone);
+    return clone.promise;
+  });
+
+  Promise.allSettled(replies).then((results) => {
+    let firstReply: unknown;
+    let hasFirstReply = false;
+
+    for (const result of results) {
+      if (result.status === "rejected") {
+        command.reject(result.reason);
+        return;
+      }
+      if (!hasFirstReply) {
+        firstReply = result.value;
+        hasFirstReply = true;
+      } else if (String(result.value) !== String(firstReply)) {
+        debug(
+          "divergent HIMPORT reply across masters (%s != %s)",
+          result.value,
+          firstReply
+        );
+      }
+    }
+
+    command.resolve(firstReply);
+  });
+
+  return true;
+}
+
+function isMissingFieldsetError(error: Error): boolean {
+  return error.message.toLowerCase().includes("no such fieldset");
+}

--- a/lib/himport/HimportCoordinator.ts
+++ b/lib/himport/HimportCoordinator.ts
@@ -2,10 +2,28 @@ import Command from "../Command";
 import { Debug } from "../utils";
 import type { HimportFieldset } from "./types";
 
-type HimportConnectionRole = "standalone" | "master" | "replica";
+type HimportConnectionRole = "standalone" | "cluster" | "master" | "replica";
 
 export interface HimportConnection {
   sendCommand(command: Command): unknown;
+}
+
+interface HimportPipelineOwner extends HimportConnection {
+  slots?: readonly (readonly string[])[];
+  connectionPool?: {
+    getInstanceByKey(key: string): HimportConnection | undefined;
+    getSampleInstance(role: "master"): HimportConnection | undefined;
+  };
+}
+
+interface HimportPipelineInterception {
+  owner: HimportPipelineOwner;
+  commands: readonly Command[];
+  slot?: number;
+  preferredNodeKey?: string;
+  setDestination(connection: HimportConnection): void;
+  resume(): void;
+  reject(error: Error): void;
 }
 
 interface HimportDefinition {
@@ -192,6 +210,27 @@ export default class HimportCoordinator {
       return undefined;
     }
     return this.ensurePrepared(connection, context.definition);
+  }
+
+  hasManagedSet(commands: readonly Command[]): boolean {
+    return commands.some((command) => this.classify(command) !== undefined);
+  }
+
+  prepareCommands(
+    connection: HimportConnection,
+    commands: readonly Command[]
+  ): Promise<void> | undefined {
+    const preparations = new Set<Promise<void>>();
+    for (const command of commands) {
+      const preparation = this.prepareCommand(connection, command);
+      if (preparation) {
+        preparations.add(preparation);
+      }
+    }
+    if (preparations.size === 0) {
+      return undefined;
+    }
+    return Promise.all(preparations).then(() => undefined);
   }
 
   interceptCommand(
@@ -431,6 +470,57 @@ export function interceptHimportCommand(
     ready,
     resumeSend
   );
+}
+
+export function interceptHimportPipeline({
+  owner,
+  commands,
+  slot,
+  preferredNodeKey,
+  setDestination,
+  resume,
+  reject,
+}: HimportPipelineInterception): boolean {
+  const binding = bindings.get(owner);
+  if (!binding || !binding.coordinator.hasManagedSet(commands)) {
+    return false;
+  }
+
+  let connection: HimportConnection = owner;
+  if (binding.role === "cluster") {
+    const nodeKey = preferredNodeKey ?? owner.slots?.[slot]?.[0];
+    const connectionPool = owner.connectionPool;
+    const clusterConnection =
+      (nodeKey && connectionPool?.getInstanceByKey(nodeKey)) ||
+      connectionPool?.getSampleInstance("master");
+
+    if (!clusterConnection) {
+      reject(new Error("No master node is available for the pipeline"));
+      return true;
+    }
+
+    connection = clusterConnection;
+    setDestination(connection);
+  }
+
+  const preparation = binding.coordinator.prepareCommands(connection, commands);
+  if (!preparation) {
+    return false;
+  }
+
+  preparation.then(
+    () => {
+      try {
+        resume();
+      } catch (error) {
+        reject(error as Error);
+      }
+    },
+    (error: Error) => {
+      reject(error);
+    }
+  );
+  return true;
 }
 
 export function setHimportRole(

--- a/lib/himport/types.ts
+++ b/lib/himport/types.ts
@@ -1,0 +1,18 @@
+/**
+ * A long-lived HIMPORT fieldset managed by ioredis for the lifetime of a
+ * logical Redis or Cluster client.
+ *
+ * @experimental
+ */
+export interface HimportFieldset {
+  /**
+   * The name referenced by later `HIMPORT SET` commands.
+   */
+  readonly name: string | Buffer;
+
+  /**
+   * Ordered hash field names. Values passed to `HIMPORT SET` are paired with
+   * fields positionally.
+   */
+  readonly fields: readonly (string | Buffer)[];
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -53,6 +53,7 @@ export {
 } from "./connectors/SentinelConnector";
 export { StandaloneConnectionOptions } from "./connectors/StandaloneConnector";
 export { RedisOptions, CommonRedisOptions } from "./redis/RedisOptions";
+export type { HimportFieldset } from "./himport/types";
 export { ClusterNode } from "./cluster";
 export {
   ClusterOptions,

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -255,6 +255,9 @@ export interface CommonRedisOptions extends CommanderOptions {
    * later commands issued on this client may be sent before that SET resumes.
    * Await the SET before issuing commands that depend on its write.
    *
+   * Explicit pipelines containing a managed `HIMPORT SET` wait for required
+   * fieldset preparation before the batch is sent.
+   *
    * Use explicit `HIMPORT PREPARE` and `DISCARD` commands on a separate
    * client for bounded, manually managed batches.
    *

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -3,6 +3,7 @@ import ConnectorConstructor from "../connectors/ConnectorConstructor";
 import { SentinelConnectionOptions } from "../connectors/SentinelConnector";
 import { StandaloneConnectionOptions } from "../connectors/StandaloneConnector";
 import { ProtocolVersion, ReplyMappingMode } from "../types";
+import type { HimportFieldset } from "../himport/types";
 
 export type ReconnectOnError = (err: Error) => boolean | 1 | 2;
 export type RetryStrategy =
@@ -242,6 +243,25 @@ export interface CommonRedisOptions extends CommanderOptions {
     string,
     { lua: string; numberOfKeys?: number | undefined; readOnly?: boolean | undefined }
   > | undefined;
+
+  /**
+   * Experimental.
+   *
+   * Long-lived HIMPORT fieldsets managed for the lifetime of this client.
+   * Definitions are copied during construction and prepared again whenever
+   * the physical Redis connection changes.
+   *
+   * When a managed `HIMPORT SET` needs fieldset preparation or recovery,
+   * later commands issued on this client may be sent before that SET resumes.
+   * Await the SET before issuing commands that depend on its write.
+   *
+   * Use explicit `HIMPORT PREPARE` and `DISCARD` commands on a separate
+   * client for bounded, manually managed batches.
+   *
+   * @default undefined
+   * @experimental
+   */
+  himportFieldsets?: readonly HimportFieldset[] | undefined;
 }
 
 export type RedisOptions = CommonRedisOptions &

--- a/lib/redis/event_handler.ts
+++ b/lib/redis/event_handler.ts
@@ -8,11 +8,12 @@ import { CommandItem, Respondable } from "../types";
 import { Debug, noop, CONNECTION_CLOSED_ERROR_MSG } from "../utils";
 import { PACKAGE_VERSION } from "../utils/version";
 import DataHandler from "../DataHandler";
+import { getHimportBinding } from "../himport/HimportCoordinator";
 
 const debug = Debug("connection");
 
 interface HandshakeCommand {
-  kind: "hello" | "auth" | "select" | "client" | "readonly";
+  kind: "hello" | "auth" | "select" | "client" | "readonly" | "himport";
   send: () => Promise<unknown>;
   errorHandler?: (err: Error) => void;
 }
@@ -94,6 +95,19 @@ function getHandshakeCommands(self: any): HandshakeCommand[] {
     });
   }
 
+  const himportBinding = getHimportBinding(self);
+  if (himportBinding && himportBinding.role !== "replica") {
+    for (const definition of himportBinding.coordinator.getDefinitions()) {
+      commands.push({
+        kind: "himport",
+        send: () =>
+          himportBinding.coordinator.ensurePrepared(self, definition) ??
+          Promise.resolve(),
+        errorHandler: (err) => self.silentEmit("error", err),
+      });
+    }
+  }
+
   return commands;
 }
 
@@ -154,6 +168,8 @@ export function connectHandler(self) {
       });
 
       const { connectionEpoch } = self;
+      const himportBinding = getHimportBinding(self);
+      himportBinding?.coordinator.beginSession(self);
       const isActiveConnect = () =>
         connectionEpoch === self.connectionEpoch && self.status === "connect";
       const finishHandshake = () => {

--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -2019,6 +2019,40 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
   hgetexBuffer(...args: [key: RedisKey, fieldsToken: 'FIELDS', numfields: number | string, ...fields: (string | Buffer)[]]): Result<(Buffer | null)[], Context>;
 
   /**
+   * Removes a single session-local fieldset by name.
+   * - _group_: hash
+   * - _complexity_: O(N) where N is the number of session-local fieldsets.
+   * - _since_: 8.10.0
+   */
+  himport(subcommand: 'DISCARD', fieldsetName: string | Buffer, callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Removes all session-local fieldsets for the connection.
+   * - _group_: hash
+   * - _complexity_: O(N) where N is the number of session-local fieldsets.
+   * - _since_: 8.10.0
+   */
+  himport(subcommand: 'DISCARDALL', callback?: Callback<number>): Result<number, Context>;
+
+  /**
+   * Defines a session-local fieldset that maps a name to a sorted set of field names.
+   * - _group_: hash
+   * - _complexity_: O(N*log(N)) where N is the number of fields.
+   * - _since_: 8.10.0
+   */
+  himport(...args: [subcommand: 'PREPARE', fieldsetName: string | Buffer, ...fields: (string | Buffer)[], callback: Callback<'OK'>]): Result<'OK', Context>;
+  himport(...args: [subcommand: 'PREPARE', fieldsetName: string | Buffer, ...fields: (string | Buffer)[]]): Result<'OK', Context>;
+
+  /**
+   * Creates a fieldset-based hash from values supplied in the order matching a previously prepared fieldset.
+   * - _group_: hash
+   * - _complexity_: O(N) where N is the number of fields in the fieldset.
+   * - _since_: 8.10.0
+   */
+  himport(...args: [subcommand: 'SET', key: RedisKey, fieldsetName: string | Buffer, ...values: (string | Buffer | number)[], callback: Callback<'OK'>]): Result<'OK', Context>;
+  himport(...args: [subcommand: 'SET', key: RedisKey, fieldsetName: string | Buffer, ...values: (string | Buffer | number)[]]): Result<'OK', Context>;
+
+  /**
    * Increments the integer value of a field in a hash by a number. Uses 0 as initial value if the field doesn't exist.
    * - _group_: hash
    * - _complexity_: O(1)

--- a/test/functional/cluster/himport.ts
+++ b/test/functional/cluster/himport.ts
@@ -281,6 +281,66 @@ describe("cluster:himport", () => {
     }
   });
 
+  it("prepares a promoted master before a configured pipeline SET", async () => {
+    let replicaPrepared = false;
+    let replicaPrepareAttempts = 0;
+    const received = setup((argv, port) => {
+      if (port === replica && argv[0] === "himport" && argv[1] === "PREPARE") {
+        replicaPrepareAttempts += 1;
+        if (replicaPrepareAttempts === 1) {
+          return new Error("ERR temporary prepare failure");
+        }
+        replicaPrepared = true;
+      }
+      if (
+        port === replica &&
+        argv[0] === "himport" &&
+        argv[1] === "SET" &&
+        !replicaPrepared
+      ) {
+        return new Error("ERR no such fieldset");
+      }
+    });
+    createCluster({
+      himportFieldsets: [{ name: "configured", fields: ["field"] }],
+    });
+
+    await cluster.set("bar", "value");
+    slotTable[0] = [0, 8191, ["127.0.0.1", replica], ["127.0.0.1", masterOne]];
+
+    try {
+      const preparationFailed = new Promise<void>((resolve) => {
+        cluster.once("node error", (error) => {
+          expect(error.message).to.equal("ERR temporary prepare failure");
+          resolve();
+        });
+      });
+
+      cluster.refreshSlotsCache();
+      await preparationFailed;
+      expect(
+        await cluster
+          .pipeline()
+          .himport("SET", "bar", "configured", "value")
+          .exec()
+      ).to.deep.equal([[null, "OK"]]);
+      expect(
+        commands(received, replica).map(({ argv }) => argv.slice(0, 2))
+      ).to.deep.equal([
+        ["himport", "PREPARE"],
+        ["himport", "PREPARE"],
+        ["himport", "SET"],
+      ]);
+    } finally {
+      slotTable[0] = [
+        0,
+        8191,
+        ["127.0.0.1", masterOne],
+        ["127.0.0.1", replica],
+      ];
+    }
+  });
+
   it("keeps explicit pipelines connection-affine and unmanaged", async () => {
     const received = setup();
     createCluster();

--- a/test/functional/cluster/himport.ts
+++ b/test/functional/cluster/himport.ts
@@ -1,0 +1,303 @@
+import { expect } from "chai";
+import { Socket } from "net";
+import { Cluster } from "../../../lib";
+import MockServer from "../../helpers/mock_server";
+
+interface ReceivedCommand {
+  port: number;
+  argv: string[];
+}
+
+describe("cluster:himport", () => {
+  const masterOne = 30301;
+  const masterTwo = 30302;
+  const replica = 30303;
+  const slotTable = [
+    [0, 8191, ["127.0.0.1", masterOne], ["127.0.0.1", replica]],
+    [8192, 16383, ["127.0.0.1", masterTwo]],
+  ];
+  let cluster: Cluster;
+
+  afterEach(() => {
+    cluster?.disconnect();
+  });
+
+  function setup(
+    handler?: (
+      argv: string[],
+      port: number,
+      socket: Socket,
+      flags: { hang?: boolean },
+      server: MockServer
+    ) => unknown
+  ) {
+    const received: ReceivedCommand[] = [];
+
+    for (const port of [masterOne, masterTwo, replica]) {
+      let server: MockServer;
+      server = new MockServer(port, (argv, socket, flags) => {
+        if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+          return slotTable;
+        }
+        if (argv[0] === "himport" || argv[0] === "asking") {
+          received.push({ port, argv });
+        }
+        return handler?.(argv, port, socket, flags, server);
+      });
+    }
+
+    return received;
+  }
+
+  function createCluster(options = {}) {
+    cluster = new Cluster([{ host: "127.0.0.1", port: masterOne }], {
+      enableReadyCheck: false,
+      redisOptions: {
+        protocol: 2,
+        enableReadyCheck: false,
+      },
+      ...options,
+    });
+  }
+
+  function commands(
+    received: ReceivedCommand[],
+    port: number,
+    subcommand?: string
+  ): ReceivedCommand[] {
+    return received.filter(
+      ({ port: commandPort, argv }) =>
+        commandPort === port &&
+        argv[0] === "himport" &&
+        (!subcommand || argv[1] === subcommand)
+    );
+  }
+
+  it("fans manual control commands out to masters only", async () => {
+    const received = setup();
+    createCluster();
+
+    expect(await cluster.himport("PREPARE", "batch", "a", "b")).to.equal("OK");
+    expect(commands(received, masterOne, "PREPARE")).to.have.lengthOf(1);
+    expect(commands(received, masterTwo, "PREPARE")).to.have.lengthOf(1);
+    expect(commands(received, replica)).to.have.lengthOf(0);
+  });
+
+  it("waits for all manual control replies and returns the first", async () => {
+    const received = setup((argv, port) => {
+      if (argv[0] === "himport" && argv[1] === "DISCARD") {
+        return port === masterOne ? 1 : 0;
+      }
+    });
+    createCluster();
+
+    expect(await cluster.himport("DISCARD", "batch")).to.equal(1);
+    expect(commands(received, masterOne, "DISCARD")).to.have.lengthOf(1);
+    expect(commands(received, masterTwo, "DISCARD")).to.have.lengthOf(1);
+  });
+
+  it("rejects a manual control command when one master fails", async () => {
+    setup((argv, port) => {
+      if (
+        argv[0] === "himport" &&
+        argv[1] === "PREPARE" &&
+        port === masterTwo
+      ) {
+        return new Error("ERR prepare failed");
+      }
+    });
+    createCluster();
+
+    let error: Error | undefined;
+    try {
+      await cluster.himport("PREPARE", "batch", "field");
+    } catch (receivedError) {
+      error = receivedError as Error;
+    }
+
+    expect(error?.message).to.equal("ERR prepare failed");
+  });
+
+  it("prepares configured fieldsets on each connected master", async () => {
+    const received = setup();
+    createCluster({
+      himportFieldsets: [{ name: "configured", fields: ["a", "b"] }],
+    });
+
+    await cluster.set("foo", "value");
+    await cluster.set("bar", "value");
+    expect(
+      await cluster.himport("SET", "foo", "configured", "1", "2")
+    ).to.equal("OK");
+
+    expect(commands(received, masterOne, "PREPARE")).to.have.lengthOf(1);
+    expect(commands(received, masterTwo, "PREPARE")).to.have.lengthOf(1);
+    expect(commands(received, replica)).to.have.lengthOf(0);
+  });
+
+  it("recovers a configured SET on the selected master", async () => {
+    let setAttempts = 0;
+    const received = setup((argv, port) => {
+      if (port === masterTwo && argv[0] === "himport" && argv[1] === "SET") {
+        setAttempts += 1;
+        if (setAttempts === 1) {
+          return new Error("ERR no such fieldset");
+        }
+      }
+    });
+    createCluster({
+      himportFieldsets: [{ name: "configured", fields: ["field"] }],
+    });
+
+    expect(await cluster.himport("SET", "foo", "configured", "value")).to.equal(
+      "OK"
+    );
+
+    expect(setAttempts).to.equal(2);
+    expect(commands(received, masterTwo, "PREPARE")).to.have.lengthOf(2);
+  });
+
+  it("prepares an ASK target before ASKING and SET", async () => {
+    let redirected = false;
+    const received = setup((argv, port) => {
+      if (
+        !redirected &&
+        port === masterOne &&
+        argv[0] === "himport" &&
+        argv[1] === "SET"
+      ) {
+        redirected = true;
+        return new Error(`ASK 5061 127.0.0.1:${masterTwo}`);
+      }
+    });
+    createCluster({
+      himportFieldsets: [{ name: "configured", fields: ["field"] }],
+    });
+
+    expect(await cluster.himport("SET", "bar", "configured", "value")).to.equal(
+      "OK"
+    );
+
+    expect(
+      received
+        .filter(({ port }) => port === masterTwo)
+        .map(({ argv }) => argv.slice(0, 2))
+    ).to.deep.equal([["himport", "PREPARE"], ["asking"], ["himport", "SET"]]);
+  });
+
+  it("does not send to an ASK target after the command times out", async () => {
+    let redirected = false;
+    const received = setup((argv, port, socket, flags, server) => {
+      if (
+        !redirected &&
+        port === masterOne &&
+        argv[0] === "himport" &&
+        argv[1] === "SET"
+      ) {
+        redirected = true;
+        flags.hang = true;
+        setTimeout(
+          () =>
+            server.write(socket, new Error(`ASK 5061 127.0.0.1:${masterTwo}`)),
+          50
+        );
+      }
+      if (
+        port === masterTwo &&
+        argv[0] === "himport" &&
+        argv[1] === "PREPARE"
+      ) {
+        flags.hang = true;
+        setTimeout(() => server.write(socket, "OK"), 60);
+      }
+    });
+    createCluster({
+      himportFieldsets: [{ name: "configured", fields: ["field"] }],
+      redisOptions: {
+        protocol: 2,
+        enableReadyCheck: false,
+        commandTimeout: 80,
+      },
+    });
+
+    let error: Error | undefined;
+    try {
+      await cluster.himport("SET", "bar", "configured", "value");
+    } catch (receivedError) {
+      error = receivedError as Error;
+    }
+
+    expect(error?.message).to.equal("Command timed out");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(commands(received, masterTwo, "SET")).to.have.lengthOf(0);
+    expect(
+      received.filter(
+        ({ port, argv }) => port === masterTwo && argv[0] === "asking"
+      )
+    ).to.have.lengthOf(0);
+  });
+
+  it("prepares a promoted replica before its first configured write", async () => {
+    const received = setup();
+    createCluster({
+      himportFieldsets: [{ name: "configured", fields: ["field"] }],
+    });
+
+    await cluster.set("bar", "value");
+    expect(commands(received, replica)).to.have.lengthOf(0);
+
+    slotTable[0] = [0, 8191, ["127.0.0.1", replica], ["127.0.0.1", masterOne]];
+
+    try {
+      const prepared = new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(
+          () => reject(new Error("Timed out waiting for promoted master")),
+          1_000
+        );
+        const check = setInterval(() => {
+          if (commands(received, replica, "PREPARE").length) {
+            clearInterval(check);
+            clearTimeout(timeout);
+            resolve();
+          }
+        }, 10);
+      });
+
+      cluster.refreshSlotsCache();
+      await prepared;
+      expect(commands(received, replica, "PREPARE")).to.have.lengthOf(1);
+
+      expect(
+        await cluster.himport("SET", "bar", "configured", "value")
+      ).to.equal("OK");
+      expect(commands(received, replica, "PREPARE")).to.have.lengthOf(1);
+    } finally {
+      slotTable[0] = [
+        0,
+        8191,
+        ["127.0.0.1", masterOne],
+        ["127.0.0.1", replica],
+      ];
+    }
+  });
+
+  it("keeps explicit pipelines connection-affine and unmanaged", async () => {
+    const received = setup();
+    createCluster();
+
+    const result = await cluster
+      .pipeline()
+      .himport("PREPARE", "batch", "field")
+      .himport("SET", "foo", "batch", "value")
+      .himport("DISCARD", "batch")
+      .exec();
+
+    expect(result).to.deep.equal([
+      [null, "OK"],
+      [null, "OK"],
+      [null, "OK"],
+    ]);
+    expect(commands(received, masterOne)).to.have.lengthOf(0);
+    expect(commands(received, masterTwo)).to.have.lengthOf(3);
+  });
+});

--- a/test/functional/cluster/pipeline.ts
+++ b/test/functional/cluster/pipeline.ts
@@ -108,6 +108,51 @@ describe("cluster:pipeline", () => {
       });
   });
 
+  it("should time out when a MOVED pipeline retry stops responding", async () => {
+    const slotTable = [
+      [0, 12181, ["127.0.0.1", 30001]],
+      [12182, 16383, ["127.0.0.1", 30002]],
+    ];
+    new MockServer(30001, (argv, _socket, flags) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        flags.hang = true;
+      }
+    });
+    new MockServer(30002, (argv) => {
+      if (argv[0] === "cluster" && argv[1] === "SLOTS") {
+        return slotTable;
+      }
+      if (argv[0] === "get" && argv[1] === "foo") {
+        return new Error("MOVED " + calculateSlot("foo") + " 127.0.0.1:30001");
+      }
+    });
+
+    const cluster = new Cluster([{ host: "127.0.0.1", port: "30001" }], {
+      redisOptions: {
+        commandTimeout: 50,
+      },
+    });
+
+    try {
+      const result = await Promise.race([
+        cluster.pipeline().get("foo").exec(),
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(
+            () => reject(new Error("Pipeline retry did not time out")),
+            500
+          );
+        }),
+      ]);
+
+      expect(result[0][0]?.message).to.equal("Command timed out");
+    } finally {
+      cluster.disconnect();
+    }
+  });
+
   it("should auto redirect commands on ASK", (done) => {
     let asked = false;
     const slotTable = [

--- a/test/functional/commands/himport.ts
+++ b/test/functional/commands/himport.ts
@@ -163,6 +163,43 @@ describe("himport", () => {
     ).to.have.lengthOf(2);
   });
 
+  it("prepares configured fieldsets before pipeline SET after RESET", async () => {
+    let prepared = false;
+    const { received } = createRedis((argv) => {
+      if (argv[0] === "himport" && argv[1] === "PREPARE") {
+        prepared = true;
+      }
+      if (argv[0] === "reset") {
+        prepared = false;
+      }
+      if (argv[0] === "himport" && argv[1] === "SET" && !prepared) {
+        return new Error("ERR no such fieldset");
+      }
+    });
+
+    await redis.connect();
+    expect(await redis.reset()).to.equal("OK");
+
+    expect(
+      await redis.pipeline().himport("SET", "key", "fieldset", "1", "2").exec()
+    ).to.deep.equal([[null, "OK"]]);
+    expect(
+      received
+        .filter(
+          (argv) =>
+            argv[0] === "reset" ||
+            (argv[0] === "himport" &&
+              (argv[1] === "PREPARE" || argv[1] === "SET"))
+        )
+        .map((argv) => argv.slice(0, 2))
+    ).to.deep.equal([
+      ["himport", "PREPARE"],
+      ["reset"],
+      ["himport", "PREPARE"],
+      ["himport", "SET"],
+    ]);
+  });
+
   it("recovers once when a configured SET reports a missing fieldset", async () => {
     let setAttempts = 0;
     const { received } = createRedis((argv) => {
@@ -250,6 +287,11 @@ describe("himport", () => {
     }
 
     expect(error?.message).to.equal("ERR no such fieldset");
+    const pipelineResult = await redis
+      .pipeline()
+      .himport("SET", "pipeline-key", "unknown", "value")
+      .exec();
+    expect(pipelineResult[0][0]?.message).to.equal("ERR no such fieldset");
     expect(
       received.filter(
         (argv) =>

--- a/test/functional/commands/himport.ts
+++ b/test/functional/commands/himport.ts
@@ -1,0 +1,262 @@
+import { expect } from "chai";
+import { Socket } from "net";
+import Redis from "../../../lib/Redis";
+import MockServer from "../../helpers/mock_server";
+
+describe("himport", () => {
+  const port = 17379;
+  let redis: Redis;
+
+  afterEach(() => {
+    redis?.disconnect();
+  });
+
+  function createRedis(
+    handler: (
+      argv: string[],
+      socket: Socket,
+      flags: { hang?: boolean },
+      server: MockServer
+    ) => unknown,
+    fieldsets = [{ name: "fieldset", fields: ["a", "b"] }]
+  ): {
+    received: string[][];
+    errors: Error[];
+    getActiveSocket: () => Socket | undefined;
+  } {
+    const received: string[][] = [];
+    const errors: Error[] = [];
+    let activeSocket: Socket | undefined;
+
+    let server: MockServer;
+    server = new MockServer(port, (argv, socket, flags) => {
+      activeSocket = socket;
+      received.push(argv);
+      return handler(argv, socket, flags, server);
+    });
+
+    redis = new Redis({
+      host: "127.0.0.1",
+      port,
+      protocol: 2,
+      enableReadyCheck: false,
+      lazyConnect: true,
+      himportFieldsets: fieldsets,
+    });
+    redis.on("error", (error) => {
+      errors.push(error);
+    });
+
+    return {
+      received,
+      errors,
+      getActiveSocket: () => activeSocket,
+    };
+  }
+
+  it("prepares configured fieldsets during the handshake", async () => {
+    const { received } = createRedis(() => undefined);
+
+    await redis.connect();
+    expect(
+      received.filter((argv) => argv[0] === "himport" && argv[1] === "PREPARE")
+    ).to.deep.equal([["himport", "PREPARE", "fieldset", "a", "b"]]);
+
+    expect(await redis.himport("SET", "key:1", "fieldset", "1", "2")).to.equal(
+      "OK"
+    );
+    expect(await redis.himport("SET", "key:2", "fieldset", "3", "4")).to.equal(
+      "OK"
+    );
+    expect(
+      received.filter((argv) => argv[0] === "himport" && argv[1] === "PREPARE")
+    ).to.have.lengthOf(1);
+  });
+
+  it("keeps user HIMPORT commands behind the handshake gate", async () => {
+    const { received } = createRedis(() => undefined);
+
+    const connecting = redis.connect();
+    const setting = redis.himport(
+      "SET",
+      "key",
+      "fieldset",
+      "value-a",
+      "value-b"
+    );
+    await connecting;
+    expect(await setting).to.equal("OK");
+
+    expect(
+      received
+        .filter((argv) => argv[0] === "himport")
+        .map((argv) => argv.slice(0, 2))
+    ).to.deep.equal([
+      ["himport", "PREPARE"],
+      ["himport", "SET"],
+    ]);
+  });
+
+  it("replays configured fieldsets after reconnecting", async () => {
+    const { received, getActiveSocket } = createRedis(() => undefined);
+
+    await redis.connect();
+    const readyAgain = new Promise<void>((resolve) => {
+      redis.once("ready", () => resolve());
+    });
+    const activeSocket = getActiveSocket();
+    expect(activeSocket).to.exist;
+    activeSocket?.destroy();
+    await readyAgain;
+
+    expect(await redis.himport("SET", "key", "fieldset", "1", "2")).to.equal(
+      "OK"
+    );
+    expect(
+      received.filter((argv) => argv[0] === "himport" && argv[1] === "PREPARE")
+    ).to.have.lengthOf(2);
+  });
+
+  it("keeps the connection usable and rejects dependent SET with PREPARE errors", async () => {
+    const rootMessage = "ERR duplicate field name in fieldset";
+    const { received, errors } = createRedis((argv) => {
+      if (argv[0] === "himport" && argv[1] === "PREPARE") {
+        return new Error(rootMessage);
+      }
+      if (argv[0] === "ping") {
+        return "PONG";
+      }
+    });
+
+    await redis.connect();
+    expect(errors).to.have.lengthOf(1);
+    expect(errors[0].message).to.equal(rootMessage);
+    expect(await redis.ping()).to.equal("PONG");
+
+    let setError: Error | undefined;
+    try {
+      await redis.himport("SET", "key", "fieldset", "1", "2");
+    } catch (error) {
+      setError = error as Error;
+    }
+
+    expect(setError?.message).to.equal(rootMessage);
+    expect(
+      received.filter((argv) => argv[0] === "himport" && argv[1] === "PREPARE")
+    ).to.have.lengthOf(2);
+    expect(
+      received.filter((argv) => argv[0] === "himport" && argv[1] === "SET")
+    ).to.have.lengthOf(0);
+  });
+
+  it("invalidates configured fieldsets when RESET is sent", async () => {
+    const { received } = createRedis(() => undefined);
+
+    await redis.connect();
+    expect(await redis.reset()).to.equal("OK");
+    expect(await redis.himport("SET", "key", "fieldset", "1", "2")).to.equal(
+      "OK"
+    );
+
+    expect(
+      received.filter((argv) => argv[0] === "himport" && argv[1] === "PREPARE")
+    ).to.have.lengthOf(2);
+  });
+
+  it("recovers once when a configured SET reports a missing fieldset", async () => {
+    let setAttempts = 0;
+    const { received } = createRedis((argv) => {
+      if (argv[0] === "himport" && argv[1] === "SET") {
+        setAttempts += 1;
+        if (setAttempts === 1) {
+          return new Error("ERR no such fieldset");
+        }
+      }
+    });
+
+    await redis.connect();
+    expect(await redis.himport("SET", "key", "fieldset", "1", "2")).to.equal(
+      "OK"
+    );
+
+    expect(setAttempts).to.equal(2);
+    expect(
+      received.filter((argv) => argv[0] === "himport" && argv[1] === "PREPARE")
+    ).to.have.lengthOf(2);
+  });
+
+  it("does not retry a configured SET after its command timeout", async () => {
+    let prepareAttempts = 0;
+    let setAttempts = 0;
+    createRedis((argv, socket, flags, server) => {
+      if (argv[0] === "himport" && argv[1] === "PREPARE") {
+        prepareAttempts += 1;
+        if (prepareAttempts === 2) {
+          flags.hang = true;
+          setTimeout(() => server.write(socket, "OK"), 60);
+        }
+      }
+      if (argv[0] === "himport" && argv[1] === "SET") {
+        setAttempts += 1;
+        if (setAttempts === 1) {
+          flags.hang = true;
+          setTimeout(
+            () => server.write(socket, new Error("ERR no such fieldset")),
+            50
+          );
+        }
+      }
+    });
+
+    await redis.connect();
+    redis.options.commandTimeout = 80;
+
+    let error: Error | undefined;
+    try {
+      await redis.himport("SET", "key", "fieldset", "1", "2");
+    } catch (receivedError) {
+      error = receivedError as Error;
+    }
+
+    expect(error?.message).to.equal("Command timed out");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(setAttempts).to.equal(1);
+  });
+
+  it("leaves explicit commands for unconfigured fieldsets unmanaged", async () => {
+    let unconfiguredPrepareCount = 0;
+    const { received } = createRedis((argv) => {
+      if (
+        argv[0] === "himport" &&
+        argv[1] === "PREPARE" &&
+        argv[2] === "batch"
+      ) {
+        unconfiguredPrepareCount += 1;
+      }
+      if (argv[0] === "himport" && argv[1] === "SET" && argv[3] === "unknown") {
+        return new Error("ERR no such fieldset");
+      }
+    });
+
+    await redis.connect();
+    expect(await redis.himport("PREPARE", "batch", "x")).to.equal("OK");
+    expect(unconfiguredPrepareCount).to.equal(1);
+
+    let error: Error | undefined;
+    try {
+      await redis.himport("SET", "key", "unknown", "value");
+    } catch (receivedError) {
+      error = receivedError as Error;
+    }
+
+    expect(error?.message).to.equal("ERR no such fieldset");
+    expect(
+      received.filter(
+        (argv) =>
+          argv[0] === "himport" &&
+          argv[1] === "PREPARE" &&
+          argv[2] === "unknown"
+      )
+    ).to.have.lengthOf(0);
+  });
+});

--- a/test/typing/commands.test-d.ts
+++ b/test/typing/commands.test-d.ts
@@ -59,6 +59,17 @@ expectType<Promise<(string | null)[]>>(redis.mget(["key", "bar"]));
 expectType<Promise<Record<string, string>>>(redis.hgetall("key"));
 expectType<Promise<Record<string, Buffer>>>(redis.hgetallBuffer("key"));
 
+// HIMPORT
+expectType<Promise<"OK">>(
+  redis.himport("PREPARE", "fieldset", "field1", Buffer.from("field2"))
+);
+expectType<Promise<"OK">>(
+  redis.himport("SET", "key", "fieldset", "value1", 2)
+);
+expectType<Promise<number>>(redis.himport("DISCARD", "fieldset"));
+expectType<Promise<number>>(redis.himport("DISCARDALL"));
+expectError(redis.himport("UNKNOWN", "fieldset"));
+
 // Hash field expiration commands
 expectType<Promise<number[]>>(
   redis.hexpireat("key", 1_700_000_000, "FIELDS", 1, "field")
@@ -327,6 +338,16 @@ redis.argrep("key", 0, 4, "MATCH", "alpha", (err, res) => {
 redis.arop("key", 0, 2, "SUM", (err, res) => {
   expectType<Error | null | undefined>(err);
   expectType<string | null | undefined>(res);
+});
+
+redis.himport("SET", "key", "fieldset", "value", (err, res) => {
+  expectType<Error | null | undefined>(err);
+  expectType<"OK" | undefined>(res);
+});
+
+redis.himport("DISCARD", "fieldset", (err, res) => {
+  expectType<Error | null | undefined>(err);
+  expectType<number | undefined>(res);
 });
 
 // XNACK

--- a/test/typing/options.test-d.ts
+++ b/test/typing/options.test-d.ts
@@ -1,5 +1,11 @@
 import { expectAssignable, expectType } from "tsd";
-import { Redis, Cluster, NatMap, DNSLookupFunction } from "../../built";
+import {
+  Redis,
+  Cluster,
+  NatMap,
+  DNSLookupFunction,
+  HimportFieldset,
+} from "../../built";
 
 expectType<Redis>(new Redis());
 
@@ -12,6 +18,13 @@ expectType<Redis>(new Redis({ host: "localhost", port: 6379 }));
 expectType<Redis>(new Redis({ host: "localhost", port: 6379, family: 4 }));
 expectType<Redis>(new Redis({ host: "localhost", port: 6379, family: 4 }));
 expectType<Redis>(new Redis(6379, "localhost", { password: "password" }));
+const himportFieldsets: readonly HimportFieldset[] = [
+  {
+    name: Buffer.from("fieldset"),
+    fields: ["field1", Buffer.from("field2")],
+  },
+];
+expectType<Redis>(new Redis({ himportFieldsets }));
 
 // Socket
 expectType<Redis>(new Redis("/tmp/redis.sock"));
@@ -37,6 +50,7 @@ expectType<Cluster>(new Redis.Cluster([30001, "localhost", { port: 30002 }]));
 expectType<Cluster>(
   new Redis.Cluster([30001, 30002], {
     enableAutoPipelining: true,
+    himportFieldsets,
   })
 );
 

--- a/test/unit/HimportCoordinator.ts
+++ b/test/unit/HimportCoordinator.ts
@@ -1,0 +1,186 @@
+import { expect } from "chai";
+import Command from "../../lib/Command";
+import HimportCoordinator, {
+  cloneHimportFieldsets,
+  HimportConnection,
+} from "../../lib/himport/HimportCoordinator";
+
+class FakeConnection implements HimportConnection {
+  readonly commands: Command[] = [];
+  prepareErrors: Array<Error | undefined> = [];
+
+  sendCommand(command: Command): unknown {
+    this.commands.push(command);
+
+    if (
+      command.name === "himport" &&
+      String(command.args[0]).toUpperCase() === "PREPARE"
+    ) {
+      const error = this.prepareErrors.shift();
+      if (error) {
+        command.reject(error);
+      } else {
+        command.resolve(Buffer.from("OK"));
+      }
+    } else {
+      command.resolve(Buffer.from("OK"));
+    }
+
+    return command.promise;
+  }
+}
+
+class DeferredConnection implements HimportConnection {
+  readonly commands: Command[] = [];
+
+  sendCommand(command: Command): unknown {
+    this.commands.push(command);
+    return command.promise;
+  }
+}
+
+describe("HimportCoordinator", () => {
+  it("deep-copies and freezes configured fieldsets", () => {
+    const name = Buffer.from("fieldset");
+    const field = Buffer.from("field");
+    const fields = [field];
+    const source = [{ name, fields }];
+
+    const copied = cloneHimportFieldsets(source);
+
+    name.fill(0);
+    field.fill(0);
+    fields.push(Buffer.from("later"));
+    source.push({ name: "other", fields: ["field"] });
+
+    expect(copied).to.have.lengthOf(1);
+    expect(copied[0].name.toString()).to.equal("fieldset");
+    expect(copied[0].fields).to.have.lengthOf(1);
+    expect(copied[0].fields[0].toString()).to.equal("field");
+    expect(Object.isFrozen(copied)).to.equal(true);
+    expect(Object.isFrozen(copied[0])).to.equal(true);
+    expect(Object.isFrozen(copied[0].fields)).to.equal(true);
+  });
+
+  it("rejects duplicate names after binary canonicalization", () => {
+    expect(() =>
+      cloneHimportFieldsets([
+        { name: "same", fields: ["a"] },
+        { name: Buffer.from("same"), fields: ["b"] },
+      ])
+    ).to.throw("Duplicate HIMPORT fieldset name");
+  });
+
+  it("coalesces preparation and prepares once per session", async () => {
+    const fieldsets = cloneHimportFieldsets([
+      { name: "fieldset", fields: ["a", "b"] },
+    ]);
+    const coordinator = new HimportCoordinator(fieldsets);
+    const connection = new FakeConnection();
+    const set = new Command("himport", ["SET", "key", "fieldset", "1", "2"]);
+
+    coordinator.beginSession(connection);
+    const first = coordinator.prepareCommand(connection, set);
+    const second = coordinator.prepareCommand(connection, set);
+
+    expect(first).to.equal(second);
+    await first;
+    expect(connection.commands).to.have.lengthOf(1);
+    expect(connection.commands[0].args).to.deep.equal([
+      "PREPARE",
+      "fieldset",
+      "a",
+      "b",
+    ]);
+    expect(coordinator.prepareCommand(connection, set)).to.equal(undefined);
+
+    coordinator.beginSession(connection);
+    await coordinator.prepareCommand(connection, set);
+    expect(connection.commands).to.have.lengthOf(2);
+  });
+
+  it("retains preparation failures and retries on later use", async () => {
+    const fieldsets = cloneHimportFieldsets([
+      { name: "fieldset", fields: ["field"] },
+    ]);
+    const coordinator = new HimportCoordinator(fieldsets);
+    const connection = new FakeConnection();
+    const set = new Command("himport", ["SET", "key", "fieldset", "value"]);
+    const rootCause = new Error("ERR duplicate field name in fieldset");
+
+    connection.prepareErrors.push(rootCause);
+    coordinator.beginSession(connection);
+
+    let received: Error | undefined;
+    try {
+      await coordinator.prepareCommand(connection, set);
+    } catch (error) {
+      received = error as Error;
+    }
+
+    expect(received).to.equal(rootCause);
+
+    await coordinator.prepareCommand(connection, set);
+    expect(connection.commands).to.have.lengthOf(2);
+    expect(coordinator.prepareCommand(connection, set)).to.equal(undefined);
+  });
+
+  it("does not treat an old-session preparation as current", async () => {
+    const fieldsets = cloneHimportFieldsets([
+      { name: "fieldset", fields: ["field"] },
+    ]);
+    const coordinator = new HimportCoordinator(fieldsets);
+    const connection = new DeferredConnection();
+    const set = new Command("himport", ["SET", "key", "fieldset", "value"]);
+
+    coordinator.beginSession(connection);
+    const oldSessionPreparation = coordinator.prepareCommand(connection, set);
+    coordinator.beginSession(connection);
+    const currentPreparation = coordinator.prepareCommand(connection, set);
+    expect(connection.commands).to.have.lengthOf(2);
+
+    let oldPreparationSettled = false;
+    oldSessionPreparation.then(() => {
+      oldPreparationSettled = true;
+    });
+    connection.commands[0].resolve(Buffer.from("OK"));
+    await Promise.resolve();
+    expect(oldPreparationSettled).to.equal(false);
+
+    connection.commands[1].resolve(Buffer.from("OK"));
+    await Promise.all([oldSessionPreparation, currentPreparation]);
+    expect(oldPreparationSettled).to.equal(true);
+    expect(coordinator.prepareCommand(connection, set)).to.equal(undefined);
+  });
+
+  it("re-prepares and retries once after a missing-fieldset error", async () => {
+    const fieldsets = cloneHimportFieldsets([
+      { name: "fieldset", fields: ["field"] },
+    ]);
+    const coordinator = new HimportCoordinator(fieldsets);
+    const connection = new FakeConnection();
+    const set = new Command("himport", ["SET", "key", "fieldset", "value"], {
+      replyEncoding: "utf8",
+    });
+
+    coordinator.beginSession(connection);
+    await coordinator.prepareCommand(connection, set);
+    coordinator.installRecovery(connection, set, () => {
+      connection.sendCommand(set);
+    });
+
+    set.reject(new Error("ERR no such fieldset"));
+
+    expect(await set.promise).to.equal("OK");
+    expect(
+      connection.commands.filter(
+        (command) => String(command.args[0]).toUpperCase() === "PREPARE"
+      )
+    ).to.have.lengthOf(2);
+    expect(
+      connection.commands.filter(
+        (command) => String(command.args[0]).toUpperCase() === "SET"
+      )
+    ).to.have.lengthOf(1);
+  });
+});

--- a/test/unit/HimportCoordinator.ts
+++ b/test/unit/HimportCoordinator.ts
@@ -183,4 +183,58 @@ describe("HimportCoordinator", () => {
       )
     ).to.have.lengthOf(1);
   });
+
+  it("coalesces concurrent missing-fieldset recoveries", async () => {
+    const fieldsets = cloneHimportFieldsets([
+      { name: "fieldset", fields: ["field"] },
+    ]);
+    const coordinator = new HimportCoordinator(fieldsets);
+    const connection = new DeferredConnection();
+    const firstSet = new Command(
+      "himport",
+      ["SET", "key:1", "fieldset", "value"],
+      { replyEncoding: "utf8" }
+    );
+    const secondSet = new Command(
+      "himport",
+      ["SET", "key:2", "fieldset", "value"],
+      { replyEncoding: "utf8" }
+    );
+
+    coordinator.beginSession(connection);
+    const initialPreparation = coordinator.prepareCommand(connection, firstSet);
+    connection.commands[0].resolve(Buffer.from("OK"));
+    await initialPreparation;
+
+    coordinator.installRecovery(connection, firstSet, () => {
+      connection.sendCommand(firstSet);
+    });
+    coordinator.installRecovery(connection, secondSet, () => {
+      connection.sendCommand(secondSet);
+    });
+
+    firstSet.reject(new Error("ERR no such fieldset"));
+    secondSet.reject(new Error("ERR no such fieldset"));
+
+    const preparations = connection.commands.filter(
+      (command) => String(command.args[0]).toUpperCase() === "PREPARE"
+    );
+    expect(preparations).to.have.lengthOf(2);
+
+    preparations[1].resolve(Buffer.from("OK"));
+    await preparations[1].promise;
+    await Promise.resolve();
+
+    const retriedSets = connection.commands.filter(
+      (command) => String(command.args[0]).toUpperCase() === "SET"
+    );
+    expect(retriedSets).to.have.lengthOf(2);
+    for (const command of retriedSets) {
+      command.resolve(Buffer.from("OK"));
+    }
+    expect(await Promise.all([firstSet.promise, secondSet.promise])).to.eql([
+      "OK",
+      "OK",
+    ]);
+  });
 });

--- a/test/unit/clusters/index.ts
+++ b/test/unit/clusters/index.ts
@@ -1,5 +1,6 @@
 import { nodeKeyToRedisOptions } from "../../../lib/cluster/util";
 import { Cluster } from "../../../lib";
+import Command from "../../../lib/Command";
 import * as sinon from "sinon";
 import { expect } from "chai";
 
@@ -57,6 +58,22 @@ describe("cluster", () => {
     });
   });
 
+  describe("#sendCommand", () => {
+    it("does not enumerate masters for ordinary commands", () => {
+      const cluster = new Cluster([]);
+      const getNodes = sinon.spy(cluster["connectionPool"], "getNodes");
+      const command = new Command("get", ["key"]);
+      cluster.status = "ready";
+
+      try {
+        cluster.sendCommand(command);
+        expect(getNodes.called).to.equal(false);
+      } finally {
+        command.resolve(Buffer.from("value"));
+        getNodes.restore();
+      }
+    });
+  });
 
   describe("natMapper", () => {
     it("returns the original nodeKey if no NAT mapping is provided", () => {
@@ -96,7 +113,6 @@ describe("cluster", () => {
       expect(result).to.eql({ host: "203.0.113.1", port: 6379 });
     });
   });
-
 });
 
 describe("nodeKeyToRedisOptions()", () => {

--- a/test/unit/command.ts
+++ b/test/unit/command.ts
@@ -90,6 +90,30 @@ describe("Command", () => {
       expect(command.isSettled).to.equal(true);
       expect(command.isResolved).to.equal(false);
     });
+
+    it("resets settlement state when reinitialized for a retry", async () => {
+      const command = new Command("get", ["foo"]);
+      const firstRejection = command.promise.catch(() => undefined);
+
+      command.reject(new Error("MOVED 12182 127.0.0.1:30001"));
+      await firstRejection;
+      expect(command.isSettled).to.equal(true);
+
+      (command as any).initPromise();
+      expect(command.isResolved).to.equal(false);
+      expect(command.isSettled).to.equal(false);
+
+      command.setTimeout(10);
+
+      let error: Error | undefined;
+      try {
+        await command.promise;
+      } catch (receivedError) {
+        error = receivedError as Error;
+      }
+      expect(error?.message).to.equal("Command timed out");
+      expect(command.isSettled).to.equal(true);
+    });
   });
 
   describe("#getKeys()", () => {

--- a/test/unit/command.ts
+++ b/test/unit/command.ts
@@ -79,6 +79,19 @@ describe("Command", () => {
     });
   });
 
+  describe("#reject()", () => {
+    it("marks the command as settled", async () => {
+      const command = new Command("get", ["foo"]);
+      const rejection = command.promise.catch(() => undefined);
+
+      command.reject(new Error("ERR failed"));
+      await rejection;
+
+      expect(command.isSettled).to.equal(true);
+      expect(command.isResolved).to.equal(false);
+    });
+  });
+
   describe("#getKeys()", () => {
     it("should return keys", () => {
       expect(getKeys("get", ["foo"])).to.eql(["foo"]);

--- a/test/unit/redis.ts
+++ b/test/unit/redis.ts
@@ -1,5 +1,7 @@
 import * as sinon from "sinon";
 import { expect } from "chai";
+import Command from "../../lib/Command";
+import HimportCoordinator, * as HimportCoordinatorModule from "../../lib/himport/HimportCoordinator";
 import Redis from "../../lib/Redis";
 
 describe("Redis", () => {
@@ -136,6 +138,75 @@ describe("Redis", () => {
         done();
       });
       redis.end();
+    });
+  });
+
+  describe("#sendCommand", () => {
+    it("bypasses HIMPORT interception when no coordinator is attached", () => {
+      const intercept = sinon.spy(
+        HimportCoordinatorModule,
+        "interceptHimportCommand"
+      );
+      const redis = new Redis({ lazyConnect: true });
+      const connect = sinon.stub(redis, "connect").resolves();
+      const command = new Command("get", ["key"]);
+      redis.condition = {
+        select: 0,
+        subscriber: false,
+        protocol: 2,
+        replyMapping: "legacy",
+        handshake: false,
+      };
+
+      try {
+        redis.sendCommand(command);
+        expect(intercept.called).to.equal(false);
+      } finally {
+        command.resolve(Buffer.from("value"));
+        connect.restore();
+        intercept.restore();
+      }
+    });
+
+    it("enables HIMPORT interception when a coordinator is attached externally", () => {
+      const intercept = sinon.spy(
+        HimportCoordinatorModule,
+        "interceptHimportCommand"
+      );
+      const redis = new Redis({ lazyConnect: true });
+      const connect = sinon.stub(redis, "connect").resolves();
+      const coordinator = new HimportCoordinator([
+        { name: "fieldset", fields: ["field"] },
+      ]);
+      const first = new Command("get", ["key"]);
+      const second = new Command("get", ["key"]);
+      redis.condition = {
+        select: 0,
+        subscriber: false,
+        protocol: 2,
+        replyMapping: "legacy",
+        handshake: false,
+      };
+
+      try {
+        HimportCoordinatorModule.bindHimportCoordinator(
+          redis,
+          coordinator,
+          "master"
+        );
+        redis.sendCommand(first);
+        expect(intercept.callCount).to.equal(1);
+
+        HimportCoordinatorModule.unbindHimportCoordinator(redis);
+        redis.sendCommand(second);
+        expect(intercept.callCount).to.equal(1);
+      } finally {
+        first.resolve(Buffer.from("value"));
+        second.resolve(Buffer.from("value"));
+        HimportCoordinatorModule.unbindHimportCoordinator(redis);
+        connect.restore();
+        intercept.restore();
+      }
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the command send path for Redis, Cluster, and pipelines and introduces async gating around managed writes; behavior is experimental and documented ordering caveats apply, but coverage is broad.
> 
> **Overview**
> Adds **experimental HIMPORT** support so clients can declare long-lived fieldsets via **`himportFieldsets`** on standalone **`Redis`** and **`Cluster`**, then issue **`HIMPORT SET`** without manually tracking **`PREPARE`** on every connection.
> 
> A new **`HimportCoordinator`** intercepts managed **`SET`** commands (and matching pipelines), issues internal **`HIMPORT PREPARE`** during connect/handshake and after reconnect or **`RESET`**, coalesces preparation per connection, and retries once when Redis reports a missing fieldset. **Cluster** wiring fans **`PREPARE` / `DISCARD` / `DISCARDALL`** to all masters, re-prepares on role changes and promoted nodes, and delays **ASK** redirects until the target master is ready. Unconfigured fieldsets and non-managed pipelines stay explicit/manual.
> 
> Also adds **`Command.isSettled`** (separate from **`isResolved`**) so timeouts and HIMPORT recovery do not race settled commands, exports **`HIMPORT`** typings and return types, documents the feature in the README with **`examples/himport.js`**, and adds functional/unit coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2b6dc86983c0c1eb04f48c271a067f48ac6bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->