### PR TITLE
feat: improve default connection resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,8 +805,9 @@ using the `retryStrategy` option:
 const redis = new Redis({
   // This is the default value of `retryStrategy`
   retryStrategy(times) {
-    const delay = Math.min(times * 50, 2000);
-    return delay;
+    const jitter = Math.floor(Math.random() * 200);
+    const delay = Math.min(Math.pow(2, times - 1) * 50, 5000);
+    return delay + jitter;
   },
 });
 ```
@@ -816,6 +817,8 @@ The argument `times` means this is the nth reconnection being made and
 the return value represents how long (in ms) to wait to reconnect. When the
 return value isn't a number, ioredis will stop trying to reconnect, and the connection
 will be lost forever if the user doesn't call `redis.connect()` manually.
+The default strategy uses exponential backoff capped at 5 seconds and adds up to
+199 milliseconds of random jitter to prevent clients from reconnecting simultaneously.
 
 When reconnected, the client will auto subscribe to channels that the previous connection subscribed to.
 This behavior can be disabled by setting the `autoResubscribe` option to `false`.

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -12,6 +12,12 @@ export type RetryStrategy =
 
 export interface CommonRedisOptions extends CommanderOptions {
   Connector?: ConnectorConstructor | undefined;
+
+  /**
+   * Determines the delay in milliseconds before reconnecting after a connection loss.
+   *
+   * @default Exponential backoff capped at 5000ms, plus 0-199ms of random jitter.
+   */
   retryStrategy?: RetryStrategy;
 
   /**
@@ -43,9 +49,9 @@ export interface CommonRedisOptions extends CommanderOptions {
   socketTimeout?: number | undefined;
 
   /**
-   * Enable/disable keep-alive functionality.
+   * Initial delay in milliseconds before the first TCP keep-alive probe.
    * @link https://nodejs.org/api/net.html#socketsetkeepaliveenable-initialdelay
-   * @default 0
+   * @default 30000
    */
   keepAlive?: number | undefined;
 
@@ -256,9 +262,12 @@ export const DEFAULT_REDIS_OPTIONS: RedisOptions = {
   connectTimeout: 10000,
   disconnectTimeout: 2000,
   retryStrategy: function (times) {
-    return Math.min(times * 50, 2000);
+    const jitter = Math.floor(Math.random() * 200);
+    // `times` is one-based, so the first retry uses an exponent of zero.
+    const delay = Math.min(Math.pow(2, times - 1) * 50, 5000);
+    return delay + jitter;
   },
-  keepAlive: 0,
+  keepAlive: 30000,
   noDelay: true,
   connectionName: null,
   disableClientInfo: false,

--- a/test/unit/redis.ts
+++ b/test/unit/redis.ts
@@ -1,6 +1,7 @@
 import * as sinon from "sinon";
 import { expect } from "chai";
 import Redis from "../../lib/Redis";
+import { DEFAULT_REDIS_OPTIONS } from "../../lib/redis/RedisOptions";
 
 describe("Redis", () => {
   describe("constructor", () => {
@@ -15,6 +16,10 @@ describe("Redis", () => {
         expect(option).to.have.property("port", 6379);
         expect(option).to.have.property("host", "localhost");
         expect(option).to.have.property("family", 0);
+        expect(option).to.have.property("keepAlive", 30000);
+
+        option = getOption({ keepAlive: 1234 });
+        expect(option).to.have.property("keepAlive", 1234);
 
         option = getOption(6380);
         expect(option).to.have.property("port", 6380);
@@ -125,6 +130,43 @@ describe("Redis", () => {
       const redis = Redis.createClient({ name: "pass", lazyConnect: true });
       expect(redis.options).to.have.property("name", "pass");
       expect(redis.options).to.have.property("lazyConnect", true);
+    });
+  });
+
+  describe("default retryStrategy", () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("uses exponential backoff capped at 5000ms", () => {
+      const retryStrategy = DEFAULT_REDIS_OPTIONS.retryStrategy;
+      expect(retryStrategy).to.be.a("function");
+      if (typeof retryStrategy !== "function") {
+        throw new Error("Expected the default retryStrategy to be a function");
+      }
+
+      sinon.stub(Math, "random").returns(0);
+
+      expect(retryStrategy(1)).to.eql(50);
+      expect(retryStrategy(2)).to.eql(100);
+      expect(retryStrategy(3)).to.eql(200);
+      expect(retryStrategy(6)).to.eql(1600);
+      expect(retryStrategy(7)).to.eql(3200);
+      expect(retryStrategy(8)).to.eql(5000);
+      expect(retryStrategy(20)).to.eql(5000);
+    });
+
+    it("adds up to 199ms of random jitter", () => {
+      const retryStrategy = DEFAULT_REDIS_OPTIONS.retryStrategy;
+      expect(retryStrategy).to.be.a("function");
+      if (typeof retryStrategy !== "function") {
+        throw new Error("Expected the default retryStrategy to be a function");
+      }
+
+      sinon.stub(Math, "random").returns(0.999);
+
+      expect(retryStrategy(1)).to.eql(249);
+      expect(retryStrategy(8)).to.eql(5199);
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changing default reconnect delays and enabling 30s TCP keep-alive affects all connections that rely on library defaults, which can alter outage recovery timing and idle connection detection without an explicit opt-in.
> 
> **Overview**
> **Default reconnect and TCP keep-alive behavior** is updated for clients that do not override options.
> 
> The built-in `retryStrategy` switches from linear backoff (50ms per attempt, 2s cap) to **exponential backoff** (`50 × 2^(times−1)`, **5s cap**) plus **0–199ms jitter**, documented in the README and `retryStrategy` JSDoc.
> 
> **TCP `keepAlive`** default changes from `0` to **30000ms** (initial delay before the first keep-alive probe); the option docs now describe that semantics instead of a generic enable/disable note.
> 
> Unit tests lock in the new `retryStrategy` math (with stubbed `Math.random`) and assert `keepAlive` defaults to 30000 while still honoring overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fda6af05c18c70422c9687a1d77b644aef35c32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->