### PR TITLE
docs: clarify managed HIMPORT fieldset behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,15 +313,16 @@ const result = await redis.setBuffer("foo", "new value", "GET");
 // result is `<Buffer 62 75 66>` as `GET` indicates returning the old value.
 ```
 
-## HIMPORT Fieldsets (experimental)
+## Managed HIMPORT Fieldsets (experimental)
 
 > [!WARNING]
-> HIMPORT support is experimental and may change in a future release. When a
-> managed `HIMPORT SET` needs fieldset preparation or recovery, later commands
-> may be sent before that SET resumes. Await the SET before issuing commands
-> that depend on its write.
+> ioredis managed-fieldset support is experimental and may change in a future
+> release. When a managed `HIMPORT SET` needs fieldset preparation or recovery,
+> later commands may be sent before that SET resumes. Await the SET before
+> issuing commands that depend on its write.
 
-HIMPORT provides a faster ingestion mechanism for loading many hashes that
+[`HIMPORT`](https://redis.io/docs/latest/commands/himport/) requires Redis 8.10
+or newer. It provides a faster ingestion mechanism for loading many hashes that
 share the same set of field names.
 
 Explicit pipelines containing a configured `HIMPORT SET` wait for required
@@ -347,6 +348,31 @@ await redis.himport(
   "37"
 );
 ```
+
+For Cluster clients, pass `himportFieldsets` at the top level of the Cluster
+options, not under `redisOptions`. ioredis prepares managed fieldsets on current
+and future master connections:
+
+```javascript
+const cluster = new Redis.Cluster(nodes, {
+  himportFieldsets: [
+    {
+      name: "user-profile",
+      fields: ["name", "email", "age"],
+    },
+  ],
+});
+```
+
+Direct `HIMPORT PREPARE`, `DISCARD`, and `DISCARDALL` calls on a Cluster client
+fan out to all current masters, wait for every reply, and reject if any master
+fails. Inside an explicit pipeline, these commands remain connection-affine and
+are not managed.
+
+Background preparation failures do not prevent a connection from becoming
+ready. Standalone and Sentinel clients report them through the `error` event;
+Cluster clients report them through `node error`. A dependent managed
+`HIMPORT SET` retries preparation and rejects if recovery fails.
 
 See [`examples/himport.js`](examples/himport.js) for managed fieldsets and
 manual batches.

--- a/examples/himport.js
+++ b/examples/himport.js
@@ -1,5 +1,7 @@
 const Redis = require("..");
 
+// Requires Redis 8.10 or newer.
+
 // -----------------------------------------------------------------------------
 // 1. Managed fieldsets: configure once and use for the client's lifetime
 // -----------------------------------------------------------------------------

--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -237,10 +237,11 @@ export interface ClusterOptions extends CommanderOptions {
     | undefined;
 
   /**
-   * Experimental.
+   * Managed-fieldset support is experimental and requires Redis 8.10 or newer.
    *
    * Long-lived HIMPORT fieldsets managed across all current and future master
    * connections for the lifetime of this Cluster client.
+   * Configure this option at the top level, not under `redisOptions`.
    *
    * When a managed `HIMPORT SET` needs fieldset preparation or recovery,
    * later commands issued on this Cluster client may be sent before that SET
@@ -248,6 +249,15 @@ export interface ClusterOptions extends CommanderOptions {
    *
    * Explicit pipelines containing a managed `HIMPORT SET` wait for required
    * fieldset preparation on the selected master before the batch is sent.
+   *
+   * Background preparation failures do not prevent the connection from
+   * becoming ready and are reported through the `node error` event. A
+   * dependent managed `HIMPORT SET` retries preparation and rejects if
+   * recovery fails.
+   *
+   * Direct `HIMPORT PREPARE`, `DISCARD`, and `DISCARDALL` calls fan out to all
+   * current masters. Within an explicit pipeline, these commands remain
+   * connection-affine and are not managed.
    *
    * Use explicit HIMPORT commands on a separate unconfigured client for
    * bounded, manually managed batches.

--- a/lib/himport/types.ts
+++ b/lib/himport/types.ts
@@ -2,6 +2,8 @@
  * A long-lived HIMPORT fieldset managed by ioredis for the lifetime of a
  * logical Redis or Cluster client.
  *
+ * Requires Redis 8.10 or newer.
+ *
  * @experimental
  */
 export interface HimportFieldset {

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -251,7 +251,7 @@ export interface CommonRedisOptions extends CommanderOptions {
   > | undefined;
 
   /**
-   * Experimental.
+   * Managed-fieldset support is experimental and requires Redis 8.10 or newer.
    *
    * Long-lived HIMPORT fieldsets managed for the lifetime of this client.
    * Definitions are copied during construction and prepared again whenever
@@ -263,6 +263,10 @@ export interface CommonRedisOptions extends CommanderOptions {
    *
    * Explicit pipelines containing a managed `HIMPORT SET` wait for required
    * fieldset preparation before the batch is sent.
+   *
+   * Background preparation failures do not prevent the connection from
+   * becoming ready and are reported through the `error` event. A dependent
+   * managed `HIMPORT SET` retries preparation and rejects if recovery fails.
    *
    * Use explicit `HIMPORT PREPARE` and `DISCARD` commands on a separate
    * client for bounded, manually managed batches.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and type comments only; no application logic or API surface changes.
> 
> **Overview**
> This PR **documents** managed HIMPORT fieldsets only; it does not change runtime behavior.
> 
> The **Managed HIMPORT Fieldsets** section is retitled and expanded to state that **Redis 8.10+** is required, with a link to the `HIMPORT` command docs. **Cluster** usage is spelled out: set `himportFieldsets` on **top-level** `Cluster` options (not `redisOptions`), with a sample constructor snippet.
> 
> New guidance covers **direct** `HIMPORT PREPARE` / `DISCARD` / `DISCARDALL` on Cluster (fan-out to all current masters; pipeline variants stay connection-affine and unmanaged) and **background preparation failures** (connections still become ready; standalone/Sentinel use `error`, Cluster uses `node error`; managed `HIMPORT SET` retries and rejects if recovery fails).
> 
> Matching notes are added to **`examples/himport.js`**, **`HimportFieldset`** in `lib/himport/types.ts`, and the `himportFieldsets` JSDoc on **`RedisOptions`** and **`ClusterOptions`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1577b53c0cf45e9df292f750e1e42f59a96751bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->